### PR TITLE
Fix crash in stop_after_album_check if next=0

### DIFF
--- a/streamer.c
+++ b/streamer.c
@@ -374,6 +374,7 @@ int stop_after_album_check (playItem_t *cur, playItem_t *next) {
             stop_after_album = 0;
             deadbeef->sendmessage (DB_EV_CONFIGCHANGED, 0, 0, 0);
         }
+        return 1;
     }
 
     const char *cur_artist = pl_find_meta_raw (cur, "artist");


### PR DESCRIPTION
Deadbeef could crash if "stop after current album" was enabled and current track was the last one in the playlist (or the playlist required a reshuffle). This commit fixes the issue.

Sorry for this silly mistake.
