### PR TITLE
Libvorbisfile bug

### DIFF
--- a/plugins/vorbis/vorbis.c
+++ b/plugins/vorbis/vorbis.c
@@ -204,8 +204,14 @@ cvorbis_seek_sample (DB_fileinfo_t *_info, int sample) {
         trace ("vorbis: file is NULL on seek\n");
         return -1;
     }
-    if (sample == 0)
-        sample = 1; // workaround libvorbis bug #1486 (ddb issue #1116)
+    if (sample == 0) {
+        deadbeef->pl_lock ();
+        const char *filetype = deadbeef->pl_find_meta_raw(info->it, ":FILETYPE");
+        if (filetype && strncmp(filetype, "Ogg Vorbis", 10)) {
+            sample = 1; // workaround libvorbis bug #1486 (ddb issue #1116)
+        }
+        deadbeef->pl_unlock ();
+    }
     sample += info->it->startsample;
     trace ("vorbis: seek to sample %d\n", sample);
     int res = ov_pcm_seek (&info->vorbis_file, sample);


### PR DESCRIPTION
This update includes the full fix for ddb issue #1116.  This is confirmed as being caused by libvorbisfile bug #1486.  This fix prevents seeking to PCM offset 0 since this hangs in some situations.  Seeking to offset 1 is technically incorrect, but not audible.  This real fix in libvorbisfile is trivial but I don't know when it will be released, and we need to support existing versions anyway.

This commit also includes removal of some tagging code that was cloned from Opus but is redundant in Vorbis.
