### PR TITLE
gtkui: make appearence (fonts/colors) more configurable

### DIFF
--- a/plugins/gtkui/callbacks.h
+++ b/plugins/gtkui/callbacks.h
@@ -898,10 +898,6 @@ on_hide_tray_icon_toggled              (GtkToggleButton *togglebutton,
                                         gpointer         user_data);
 
 void
-on_embolden_current_toggled            (GtkToggleButton *togglebutton,
-                                        gpointer         user_data);
-
-void
 on_hide_delete_from_disk_toggled       (GtkToggleButton *togglebutton,
                                         gpointer         user_data);
 
@@ -1304,4 +1300,74 @@ on_mainwin_button_press_event          (GtkWidget       *widget,
 
 void
 on_enable_shift_jis_recoding_toggled   (GtkToggleButton *togglebutton,
+                                        gpointer         user_data);
+
+void
+on_listview_playing_text_color_set     (GtkColorButton  *colorbutton,
+                                        gpointer         user_data);
+
+void
+on_listview_group_text_color_set       (GtkColorButton  *colorbutton,
+                                        gpointer         user_data);
+
+void
+on_listview_group_text_font_set        (GtkFontButton   *fontbutton,
+                                        gpointer         user_data);
+
+void
+on_listview_text_font_set              (GtkFontButton   *fontbutton,
+                                        gpointer         user_data);
+
+void
+on_listview_playing_text_bold_toggled  (GtkToggleButton *togglebutton,
+                                        gpointer         user_data);
+
+void
+on_listview_playing_text_italic_toggled
+                                        (GtkToggleButton *togglebutton,
+                                        gpointer         user_data);
+
+void
+on_listview_selected_text_bold_toggled (GtkToggleButton *togglebutton,
+                                        gpointer         user_data);
+
+void
+on_listview_selected_text_italic_toggled
+                                        (GtkToggleButton *togglebutton,
+                                        gpointer         user_data);
+
+void
+on_tabstrip_selected_text_color_set    (GtkColorButton  *colorbutton,
+                                        gpointer         user_data);
+
+void
+on_tabstrip_playing_bold_toggled       (GtkToggleButton *togglebutton,
+                                        gpointer         user_data);
+
+void
+on_tabstrip_playing_italic_toggled     (GtkToggleButton *togglebutton,
+                                        gpointer         user_data);
+
+void
+on_tabstrip_selected_bold_toggled      (GtkToggleButton *togglebutton,
+                                        gpointer         user_data);
+
+void
+on_tabstrip_selected_italic_toggled    (GtkToggleButton *togglebutton,
+                                        gpointer         user_data);
+
+void
+on_tabstrip_text_font_set              (GtkFontButton   *fontbutton,
+                                        gpointer         user_data);
+
+void
+on_tabstrip_playing_text_color_set     (GtkColorButton  *colorbutton,
+                                        gpointer         user_data);
+
+void
+on_listview_column_text_color_set      (GtkColorButton  *colorbutton,
+                                        gpointer         user_data);
+
+void
+on_listview_column_text_font_set       (GtkFontButton   *fontbutton,
                                         gpointer         user_data);

--- a/plugins/gtkui/ddblistview.h
+++ b/plugins/gtkui/ddblistview.h
@@ -180,6 +180,7 @@ struct _DdbListview {
 
     // drawing contexts
     drawctx_t listctx;
+    drawctx_t grpctx;
     drawctx_t hdrctx;
 
     // cover art size
@@ -300,6 +301,12 @@ ddb_listview_groupcheck (DdbListview *listview);
 
 int
 ddb_listview_is_album_art_column (DdbListview *listview, int x);
+
+void
+ddb_listview_update_fonts (DdbListview *ps);
+
+void
+ddb_listview_header_update_fonts (DdbListview *ps);
 
 G_END_DECLS
 

--- a/plugins/gtkui/deadbeef.glade
+++ b/plugins/gtkui/deadbeef.glade
@@ -3583,26 +3583,6 @@ Album</property>
 		  </child>
 
 		  <child>
-		    <widget class="GtkCheckButton" id="embolden_current">
-		      <property name="visible">True</property>
-		      <property name="can_focus">True</property>
-		      <property name="label" translatable="yes">Draw playing track using bold font</property>
-		      <property name="use_underline">True</property>
-		      <property name="relief">GTK_RELIEF_NORMAL</property>
-		      <property name="focus_on_click">True</property>
-		      <property name="active">False</property>
-		      <property name="inconsistent">False</property>
-		      <property name="draw_indicator">True</property>
-		      <signal name="toggled" handler="on_embolden_current_toggled" last_modification_time="Mon, 09 Aug 2010 19:39:55 GMT"/>
-		    </widget>
-		    <packing>
-		      <property name="padding">0</property>
-		      <property name="expand">False</property>
-		      <property name="fill">False</property>
-		    </packing>
-		  </child>
-
-		  <child>
 		    <widget class="GtkCheckButton" id="hide_delete_from_disk">
 		      <property name="visible">True</property>
 		      <property name="can_focus">True</property>
@@ -3875,7 +3855,7 @@ Album</property>
 	      <child>
 		<widget class="GtkLabel" id="label73">
 		  <property name="visible">True</property>
-		  <property name="label" translatable="yes">Seekbar/Volumebar colors</property>
+		  <property name="label" translatable="yes">Seekbar/Volumebar</property>
 		  <property name="use_underline">False</property>
 		  <property name="use_markup">False</property>
 		  <property name="justify">GTK_JUSTIFY_LEFT</property>
@@ -3925,16 +3905,34 @@ Album</property>
 		  <child>
 		    <widget class="GtkTable" id="tabstrip_colors_group">
 		      <property name="visible">True</property>
-		      <property name="n_rows">2</property>
-		      <property name="n_columns">5</property>
-		      <property name="homogeneous">True</property>
-		      <property name="row_spacing">0</property>
+		      <property name="n_rows">7</property>
+		      <property name="n_columns">3</property>
+		      <property name="homogeneous">False</property>
+		      <property name="row_spacing">4</property>
 		      <property name="column_spacing">8</property>
 
 		      <child>
-			<widget class="GtkLabel" id="label45">
+			<widget class="GtkColorButton" id="tabstrip_base">
 			  <property name="visible">True</property>
-			  <property name="label" translatable="yes">Middle</property>
+			  <property name="can_focus">True</property>
+			  <property name="use_alpha">False</property>
+			  <property name="focus_on_click">True</property>
+			  <signal name="color_set" handler="on_tabstrip_base_color_set" last_modification_time="Sat, 03 Apr 2010 15:33:56 GMT"/>
+			</widget>
+			<packing>
+			  <property name="left_attach">1</property>
+			  <property name="right_attach">2</property>
+			  <property name="top_attach">6</property>
+			  <property name="bottom_attach">7</property>
+			  <property name="x_options">fill</property>
+			  <property name="y_options"></property>
+			</packing>
+		      </child>
+
+		      <child>
+			<widget class="GtkLabel" id="label76">
+			  <property name="visible">True</property>
+			  <property name="label" translatable="yes">Base:</property>
 			  <property name="use_underline">False</property>
 			  <property name="use_markup">False</property>
 			  <property name="justify">GTK_JUSTIFY_LEFT</property>
@@ -3952,37 +3950,27 @@ Album</property>
 			<packing>
 			  <property name="left_attach">0</property>
 			  <property name="right_attach">1</property>
-			  <property name="top_attach">0</property>
-			  <property name="bottom_attach">1</property>
-			  <property name="x_options">expand</property>
+			  <property name="top_attach">6</property>
+			  <property name="bottom_attach">7</property>
+			  <property name="x_options">fill</property>
 			  <property name="y_options"></property>
 			</packing>
 		      </child>
 
 		      <child>
-			<widget class="GtkLabel" id="label46">
+			<widget class="GtkColorButton" id="tabstrip_dark">
 			  <property name="visible">True</property>
-			  <property name="label" translatable="yes">Light</property>
-			  <property name="use_underline">False</property>
-			  <property name="use_markup">False</property>
-			  <property name="justify">GTK_JUSTIFY_LEFT</property>
-			  <property name="wrap">False</property>
-			  <property name="selectable">False</property>
-			  <property name="xalign">0</property>
-			  <property name="yalign">0.5</property>
-			  <property name="xpad">0</property>
-			  <property name="ypad">0</property>
-			  <property name="ellipsize">PANGO_ELLIPSIZE_NONE</property>
-			  <property name="width_chars">-1</property>
-			  <property name="single_line_mode">False</property>
-			  <property name="angle">0</property>
+			  <property name="can_focus">True</property>
+			  <property name="use_alpha">False</property>
+			  <property name="focus_on_click">True</property>
+			  <signal name="color_set" handler="on_tabstrip_dark_color_set" last_modification_time="Sat, 03 Apr 2010 15:33:48 GMT"/>
 			</widget>
 			<packing>
 			  <property name="left_attach">1</property>
 			  <property name="right_attach">2</property>
-			  <property name="top_attach">0</property>
-			  <property name="bottom_attach">1</property>
-			  <property name="x_options">expand</property>
+			  <property name="top_attach">5</property>
+			  <property name="bottom_attach">6</property>
+			  <property name="x_options">fill</property>
 			  <property name="y_options"></property>
 			</packing>
 		      </child>
@@ -3990,7 +3978,7 @@ Album</property>
 		      <child>
 			<widget class="GtkLabel" id="label44">
 			  <property name="visible">True</property>
-			  <property name="label" translatable="yes">Dark</property>
+			  <property name="label" translatable="yes">Dark:</property>
 			  <property name="use_underline">False</property>
 			  <property name="use_markup">False</property>
 			  <property name="justify">GTK_JUSTIFY_LEFT</property>
@@ -4006,29 +3994,11 @@ Album</property>
 			  <property name="angle">0</property>
 			</widget>
 			<packing>
-			  <property name="left_attach">2</property>
-			  <property name="right_attach">3</property>
-			  <property name="top_attach">0</property>
-			  <property name="bottom_attach">1</property>
-			  <property name="x_options">expand</property>
-			  <property name="y_options"></property>
-			</packing>
-		      </child>
-
-		      <child>
-			<widget class="GtkColorButton" id="tabstrip_mid">
-			  <property name="visible">True</property>
-			  <property name="can_focus">True</property>
-			  <property name="use_alpha">False</property>
-			  <property name="focus_on_click">True</property>
-			  <signal name="color_set" handler="on_tabstrip_mid_color_set" last_modification_time="Sat, 03 Apr 2010 15:33:34 GMT"/>
-			</widget>
-			<packing>
 			  <property name="left_attach">0</property>
 			  <property name="right_attach">1</property>
-			  <property name="top_attach">1</property>
-			  <property name="bottom_attach">2</property>
-			  <property name="x_options">expand</property>
+			  <property name="top_attach">5</property>
+			  <property name="bottom_attach">6</property>
+			  <property name="x_options">fill</property>
 			  <property name="y_options"></property>
 			</packing>
 		      </child>
@@ -4044,53 +4014,17 @@ Album</property>
 			<packing>
 			  <property name="left_attach">1</property>
 			  <property name="right_attach">2</property>
-			  <property name="top_attach">1</property>
-			  <property name="bottom_attach">2</property>
-			  <property name="x_options">expand</property>
+			  <property name="top_attach">4</property>
+			  <property name="bottom_attach">5</property>
+			  <property name="x_options">fill</property>
 			  <property name="y_options"></property>
 			</packing>
 		      </child>
 
 		      <child>
-			<widget class="GtkColorButton" id="tabstrip_dark">
+			<widget class="GtkLabel" id="label46">
 			  <property name="visible">True</property>
-			  <property name="can_focus">True</property>
-			  <property name="use_alpha">False</property>
-			  <property name="focus_on_click">True</property>
-			  <signal name="color_set" handler="on_tabstrip_dark_color_set" last_modification_time="Sat, 03 Apr 2010 15:33:48 GMT"/>
-			</widget>
-			<packing>
-			  <property name="left_attach">2</property>
-			  <property name="right_attach">3</property>
-			  <property name="top_attach">1</property>
-			  <property name="bottom_attach">2</property>
-			  <property name="x_options">expand</property>
-			  <property name="y_options"></property>
-			</packing>
-		      </child>
-
-		      <child>
-			<widget class="GtkColorButton" id="tabstrip_base">
-			  <property name="visible">True</property>
-			  <property name="can_focus">True</property>
-			  <property name="use_alpha">False</property>
-			  <property name="focus_on_click">True</property>
-			  <signal name="color_set" handler="on_tabstrip_base_color_set" last_modification_time="Sat, 03 Apr 2010 15:33:56 GMT"/>
-			</widget>
-			<packing>
-			  <property name="left_attach">3</property>
-			  <property name="right_attach">4</property>
-			  <property name="top_attach">1</property>
-			  <property name="bottom_attach">2</property>
-			  <property name="x_options">expand</property>
-			  <property name="y_options"></property>
-			</packing>
-		      </child>
-
-		      <child>
-			<widget class="GtkLabel" id="label76">
-			  <property name="visible">True</property>
-			  <property name="label" translatable="yes">Base</property>
+			  <property name="label" translatable="yes">Light:</property>
 			  <property name="use_underline">False</property>
 			  <property name="use_markup">False</property>
 			  <property name="justify">GTK_JUSTIFY_LEFT</property>
@@ -4106,11 +4040,57 @@ Album</property>
 			  <property name="angle">0</property>
 			</widget>
 			<packing>
-			  <property name="left_attach">3</property>
-			  <property name="right_attach">4</property>
-			  <property name="top_attach">0</property>
-			  <property name="bottom_attach">1</property>
-			  <property name="x_options">expand</property>
+			  <property name="left_attach">0</property>
+			  <property name="right_attach">1</property>
+			  <property name="top_attach">4</property>
+			  <property name="bottom_attach">5</property>
+			  <property name="x_options">fill</property>
+			  <property name="y_options"></property>
+			</packing>
+		      </child>
+
+		      <child>
+			<widget class="GtkColorButton" id="tabstrip_mid">
+			  <property name="visible">True</property>
+			  <property name="can_focus">True</property>
+			  <property name="use_alpha">False</property>
+			  <property name="focus_on_click">True</property>
+			  <signal name="color_set" handler="on_tabstrip_mid_color_set" last_modification_time="Sat, 03 Apr 2010 15:33:34 GMT"/>
+			</widget>
+			<packing>
+			  <property name="left_attach">1</property>
+			  <property name="right_attach">2</property>
+			  <property name="top_attach">3</property>
+			  <property name="bottom_attach">4</property>
+			  <property name="x_options">fill</property>
+			  <property name="y_options"></property>
+			</packing>
+		      </child>
+
+		      <child>
+			<widget class="GtkLabel" id="label45">
+			  <property name="visible">True</property>
+			  <property name="label" translatable="yes">Middle:</property>
+			  <property name="use_underline">False</property>
+			  <property name="use_markup">False</property>
+			  <property name="justify">GTK_JUSTIFY_LEFT</property>
+			  <property name="wrap">False</property>
+			  <property name="selectable">False</property>
+			  <property name="xalign">0</property>
+			  <property name="yalign">0.5</property>
+			  <property name="xpad">0</property>
+			  <property name="ypad">0</property>
+			  <property name="ellipsize">PANGO_ELLIPSIZE_NONE</property>
+			  <property name="width_chars">-1</property>
+			  <property name="single_line_mode">False</property>
+			  <property name="angle">0</property>
+			</widget>
+			<packing>
+			  <property name="left_attach">0</property>
+			  <property name="right_attach">1</property>
+			  <property name="top_attach">3</property>
+			  <property name="bottom_attach">4</property>
+			  <property name="x_options">fill</property>
 			  <property name="y_options"></property>
 			</packing>
 		      </child>
@@ -4118,7 +4098,7 @@ Album</property>
 		      <child>
 			<widget class="GtkLabel" id="label127">
 			  <property name="visible">True</property>
-			  <property name="label" translatable="yes">Text</property>
+			  <property name="label" translatable="yes">Text:</property>
 			  <property name="use_underline">False</property>
 			  <property name="use_markup">False</property>
 			  <property name="justify">GTK_JUSTIFY_LEFT</property>
@@ -4134,11 +4114,11 @@ Album</property>
 			  <property name="angle">0</property>
 			</widget>
 			<packing>
-			  <property name="left_attach">4</property>
-			  <property name="right_attach">5</property>
+			  <property name="left_attach">0</property>
+			  <property name="right_attach">1</property>
 			  <property name="top_attach">0</property>
 			  <property name="bottom_attach">1</property>
-			  <property name="x_options">expand</property>
+			  <property name="x_options">fill</property>
 			  <property name="y_options"></property>
 			</packing>
 		      </child>
@@ -4152,11 +4132,235 @@ Album</property>
 			  <signal name="color_set" handler="on_tabstrip_text_color_set" last_modification_time="Wed, 23 Mar 2011 20:09:34 GMT"/>
 			</widget>
 			<packing>
-			  <property name="left_attach">4</property>
-			  <property name="right_attach">5</property>
+			  <property name="left_attach">1</property>
+			  <property name="right_attach">2</property>
+			  <property name="top_attach">0</property>
+			  <property name="bottom_attach">1</property>
+			  <property name="x_options">fill</property>
+			  <property name="y_options"></property>
+			</packing>
+		      </child>
+
+		      <child>
+			<widget class="GtkColorButton" id="tabstrip_selected_text">
+			  <property name="visible">True</property>
+			  <property name="can_focus">True</property>
+			  <property name="use_alpha">False</property>
+			  <property name="focus_on_click">True</property>
+			  <signal name="color_set" handler="on_tabstrip_selected_text_color_set" last_modification_time="Mon, 18 Aug 2014 20:05:16 GMT"/>
+			</widget>
+			<packing>
+			  <property name="left_attach">1</property>
+			  <property name="right_attach">2</property>
+			  <property name="top_attach">2</property>
+			  <property name="bottom_attach">3</property>
+			  <property name="x_options">fill</property>
+			  <property name="y_options"></property>
+			</packing>
+		      </child>
+
+		      <child>
+			<widget class="GtkHBox" id="hbox136">
+			  <property name="visible">True</property>
+			  <property name="homogeneous">False</property>
+			  <property name="spacing">8</property>
+
+			  <child>
+			    <widget class="GtkCheckButton" id="tabstrip_playing_bold">
+			      <property name="visible">True</property>
+			      <property name="can_focus">True</property>
+			      <property name="label" translatable="yes">Bold</property>
+			      <property name="use_underline">True</property>
+			      <property name="relief">GTK_RELIEF_NORMAL</property>
+			      <property name="focus_on_click">True</property>
+			      <property name="active">False</property>
+			      <property name="inconsistent">False</property>
+			      <property name="draw_indicator">True</property>
+			      <signal name="toggled" handler="on_tabstrip_playing_bold_toggled" last_modification_time="Mon, 18 Aug 2014 20:06:50 GMT"/>
+			    </widget>
+			    <packing>
+			      <property name="padding">0</property>
+			      <property name="expand">False</property>
+			      <property name="fill">False</property>
+			    </packing>
+			  </child>
+
+			  <child>
+			    <widget class="GtkCheckButton" id="tabstrip_playing_italic">
+			      <property name="visible">True</property>
+			      <property name="can_focus">True</property>
+			      <property name="label" translatable="yes">Italic</property>
+			      <property name="use_underline">True</property>
+			      <property name="relief">GTK_RELIEF_NORMAL</property>
+			      <property name="focus_on_click">True</property>
+			      <property name="active">False</property>
+			      <property name="inconsistent">False</property>
+			      <property name="draw_indicator">True</property>
+			      <signal name="toggled" handler="on_tabstrip_playing_italic_toggled" last_modification_time="Mon, 18 Aug 2014 20:06:58 GMT"/>
+			    </widget>
+			    <packing>
+			      <property name="padding">0</property>
+			      <property name="expand">False</property>
+			      <property name="fill">False</property>
+			    </packing>
+			  </child>
+			</widget>
+			<packing>
+			  <property name="left_attach">2</property>
+			  <property name="right_attach">3</property>
 			  <property name="top_attach">1</property>
 			  <property name="bottom_attach">2</property>
-			  <property name="x_options">expand</property>
+			  <property name="x_options">fill</property>
+			  <property name="y_options">fill</property>
+			</packing>
+		      </child>
+
+		      <child>
+			<widget class="GtkHBox" id="hbox137">
+			  <property name="visible">True</property>
+			  <property name="homogeneous">False</property>
+			  <property name="spacing">8</property>
+
+			  <child>
+			    <widget class="GtkCheckButton" id="tabstrip_selected_bold">
+			      <property name="visible">True</property>
+			      <property name="can_focus">True</property>
+			      <property name="label" translatable="yes">Bold</property>
+			      <property name="use_underline">True</property>
+			      <property name="relief">GTK_RELIEF_NORMAL</property>
+			      <property name="focus_on_click">True</property>
+			      <property name="active">False</property>
+			      <property name="inconsistent">False</property>
+			      <property name="draw_indicator">True</property>
+			      <signal name="toggled" handler="on_tabstrip_selected_bold_toggled" last_modification_time="Mon, 18 Aug 2014 20:07:14 GMT"/>
+			    </widget>
+			    <packing>
+			      <property name="padding">0</property>
+			      <property name="expand">False</property>
+			      <property name="fill">False</property>
+			    </packing>
+			  </child>
+
+			  <child>
+			    <widget class="GtkCheckButton" id="tabstrip_selected_italic">
+			      <property name="visible">True</property>
+			      <property name="can_focus">True</property>
+			      <property name="label" translatable="yes">Italic</property>
+			      <property name="use_underline">True</property>
+			      <property name="relief">GTK_RELIEF_NORMAL</property>
+			      <property name="focus_on_click">True</property>
+			      <property name="active">False</property>
+			      <property name="inconsistent">False</property>
+			      <property name="draw_indicator">True</property>
+			      <signal name="toggled" handler="on_tabstrip_selected_italic_toggled" last_modification_time="Mon, 18 Aug 2014 20:07:21 GMT"/>
+			    </widget>
+			    <packing>
+			      <property name="padding">0</property>
+			      <property name="expand">False</property>
+			      <property name="fill">False</property>
+			    </packing>
+			  </child>
+			</widget>
+			<packing>
+			  <property name="left_attach">2</property>
+			  <property name="right_attach">3</property>
+			  <property name="top_attach">2</property>
+			  <property name="bottom_attach">3</property>
+			  <property name="x_options">fill</property>
+			  <property name="y_options">fill</property>
+			</packing>
+		      </child>
+
+		      <child>
+			<widget class="GtkFontButton" id="tabstrip_text_font">
+			  <property name="visible">True</property>
+			  <property name="can_focus">True</property>
+			  <property name="show_style">True</property>
+			  <property name="show_size">True</property>
+			  <property name="use_font">False</property>
+			  <property name="use_size">False</property>
+			  <property name="focus_on_click">True</property>
+			  <signal name="font_set" handler="on_tabstrip_text_font_set" last_modification_time="Mon, 18 Aug 2014 20:08:18 GMT"/>
+			</widget>
+			<packing>
+			  <property name="left_attach">2</property>
+			  <property name="right_attach">3</property>
+			  <property name="top_attach">0</property>
+			  <property name="bottom_attach">1</property>
+			  <property name="y_options">fill</property>
+			</packing>
+		      </child>
+
+		      <child>
+			<widget class="GtkLabel" id="label152">
+			  <property name="visible">True</property>
+			  <property name="label" translatable="yes">Playing text:</property>
+			  <property name="use_underline">False</property>
+			  <property name="use_markup">False</property>
+			  <property name="justify">GTK_JUSTIFY_LEFT</property>
+			  <property name="wrap">False</property>
+			  <property name="selectable">False</property>
+			  <property name="xalign">0</property>
+			  <property name="yalign">0.5</property>
+			  <property name="xpad">0</property>
+			  <property name="ypad">0</property>
+			  <property name="ellipsize">PANGO_ELLIPSIZE_NONE</property>
+			  <property name="width_chars">-1</property>
+			  <property name="single_line_mode">False</property>
+			  <property name="angle">0</property>
+			</widget>
+			<packing>
+			  <property name="left_attach">0</property>
+			  <property name="right_attach">1</property>
+			  <property name="top_attach">1</property>
+			  <property name="bottom_attach">2</property>
+			  <property name="x_options">fill</property>
+			  <property name="y_options"></property>
+			</packing>
+		      </child>
+
+		      <child>
+			<widget class="GtkLabel" id="label153">
+			  <property name="visible">True</property>
+			  <property name="label" translatable="yes">Selected text:</property>
+			  <property name="use_underline">False</property>
+			  <property name="use_markup">False</property>
+			  <property name="justify">GTK_JUSTIFY_LEFT</property>
+			  <property name="wrap">False</property>
+			  <property name="selectable">False</property>
+			  <property name="xalign">0</property>
+			  <property name="yalign">0.5</property>
+			  <property name="xpad">0</property>
+			  <property name="ypad">0</property>
+			  <property name="ellipsize">PANGO_ELLIPSIZE_NONE</property>
+			  <property name="width_chars">-1</property>
+			  <property name="single_line_mode">False</property>
+			  <property name="angle">0</property>
+			</widget>
+			<packing>
+			  <property name="left_attach">0</property>
+			  <property name="right_attach">1</property>
+			  <property name="top_attach">2</property>
+			  <property name="bottom_attach">3</property>
+			  <property name="x_options">fill</property>
+			  <property name="y_options"></property>
+			</packing>
+		      </child>
+
+		      <child>
+			<widget class="GtkColorButton" id="tabstrip_playing_text">
+			  <property name="visible">True</property>
+			  <property name="can_focus">True</property>
+			  <property name="use_alpha">False</property>
+			  <property name="focus_on_click">True</property>
+			  <signal name="color_set" handler="on_tabstrip_playing_text_color_set" last_modification_time="Mon, 18 Aug 2014 20:05:39 GMT"/>
+			</widget>
+			<packing>
+			  <property name="left_attach">1</property>
+			  <property name="right_attach">2</property>
+			  <property name="top_attach">1</property>
+			  <property name="bottom_attach">2</property>
+			  <property name="x_options">fill</property>
 			  <property name="y_options"></property>
 			</packing>
 		      </child>
@@ -4177,7 +4381,7 @@ Album</property>
 	      <child>
 		<widget class="GtkLabel" id="label74">
 		  <property name="visible">True</property>
-		  <property name="label" translatable="yes">Tab strip colors</property>
+		  <property name="label" translatable="yes">Tab strip</property>
 		  <property name="use_underline">False</property>
 		  <property name="use_markup">False</property>
 		  <property name="justify">GTK_JUSTIFY_LEFT</property>
@@ -4208,7 +4412,7 @@ Album</property>
 		    <widget class="GtkCheckButton" id="override_listview_colors">
 		      <property name="visible">True</property>
 		      <property name="can_focus">True</property>
-		      <property name="label" translatable="yes">Override (looses GTK treeview theming, but speeds up rendering)</property>
+		      <property name="label" translatable="yes">Override (loses GTK treeview theming, but speeds up rendering)</property>
 		      <property name="use_underline">True</property>
 		      <property name="relief">GTK_RELIEF_NORMAL</property>
 		      <property name="focus_on_click">True</property>
@@ -4227,16 +4431,16 @@ Album</property>
 		  <child>
 		    <widget class="GtkTable" id="listview_colors_group">
 		      <property name="visible">True</property>
-		      <property name="n_rows">2</property>
-		      <property name="n_columns">6</property>
-		      <property name="homogeneous">True</property>
-		      <property name="row_spacing">0</property>
+		      <property name="n_rows">9</property>
+		      <property name="n_columns">3</property>
+		      <property name="homogeneous">False</property>
+		      <property name="row_spacing">4</property>
 		      <property name="column_spacing">8</property>
 
 		      <child>
-			<widget class="GtkLabel" id="label58">
+			<widget class="GtkLabel" id="label149">
 			  <property name="visible">True</property>
-			  <property name="label" translatable="yes">Even row</property>
+			  <property name="label" translatable="yes">Group text:</property>
 			  <property name="use_underline">False</property>
 			  <property name="use_markup">False</property>
 			  <property name="justify">GTK_JUSTIFY_LEFT</property>
@@ -4254,17 +4458,55 @@ Album</property>
 			<packing>
 			  <property name="left_attach">0</property>
 			  <property name="right_attach">1</property>
-			  <property name="top_attach">0</property>
-			  <property name="bottom_attach">1</property>
-			  <property name="x_options">expand</property>
+			  <property name="top_attach">4</property>
+			  <property name="bottom_attach">5</property>
+			  <property name="x_options">fill</property>
 			  <property name="y_options"></property>
 			</packing>
 		      </child>
 
 		      <child>
-			<widget class="GtkLabel" id="label59">
+			<widget class="GtkColorButton" id="listview_group_text">
 			  <property name="visible">True</property>
-			  <property name="label" translatable="yes">Odd row</property>
+			  <property name="can_focus">True</property>
+			  <property name="use_alpha">False</property>
+			  <property name="focus_on_click">True</property>
+			  <signal name="color_set" handler="on_listview_group_text_color_set" last_modification_time="Mon, 18 Aug 2014 10:58:55 GMT"/>
+			</widget>
+			<packing>
+			  <property name="left_attach">1</property>
+			  <property name="right_attach">2</property>
+			  <property name="top_attach">4</property>
+			  <property name="bottom_attach">5</property>
+			  <property name="x_options">fill</property>
+			  <property name="y_options"></property>
+			</packing>
+		      </child>
+
+		      <child>
+			<widget class="GtkFontButton" id="listview_group_text_font">
+			  <property name="visible">True</property>
+			  <property name="can_focus">True</property>
+			  <property name="show_style">True</property>
+			  <property name="show_size">True</property>
+			  <property name="use_font">False</property>
+			  <property name="use_size">False</property>
+			  <property name="focus_on_click">True</property>
+			  <signal name="font_set" handler="on_listview_group_text_font_set" last_modification_time="Mon, 18 Aug 2014 11:02:57 GMT"/>
+			</widget>
+			<packing>
+			  <property name="left_attach">2</property>
+			  <property name="right_attach">3</property>
+			  <property name="top_attach">4</property>
+			  <property name="bottom_attach">5</property>
+			  <property name="y_options">fill</property>
+			</packing>
+		      </child>
+
+		      <child>
+			<widget class="GtkLabel" id="label58">
+			  <property name="visible">True</property>
+			  <property name="label" translatable="yes">Even row:</property>
 			  <property name="use_underline">False</property>
 			  <property name="use_markup">False</property>
 			  <property name="justify">GTK_JUSTIFY_LEFT</property>
@@ -4280,11 +4522,11 @@ Album</property>
 			  <property name="angle">0</property>
 			</widget>
 			<packing>
-			  <property name="left_attach">1</property>
-			  <property name="right_attach">2</property>
-			  <property name="top_attach">0</property>
-			  <property name="bottom_attach">1</property>
-			  <property name="x_options">expand</property>
+			  <property name="left_attach">0</property>
+			  <property name="right_attach">1</property>
+			  <property name="top_attach">5</property>
+			  <property name="bottom_attach">6</property>
+			  <property name="x_options">fill</property>
 			  <property name="y_options"></property>
 			</packing>
 		      </child>
@@ -4298,11 +4540,39 @@ Album</property>
 			  <signal name="color_set" handler="on_listview_even_row_color_set" last_modification_time="Sat, 03 Apr 2010 18:03:02 GMT"/>
 			</widget>
 			<packing>
+			  <property name="left_attach">1</property>
+			  <property name="right_attach">2</property>
+			  <property name="top_attach">5</property>
+			  <property name="bottom_attach">6</property>
+			  <property name="x_options">fill</property>
+			  <property name="y_options"></property>
+			</packing>
+		      </child>
+
+		      <child>
+			<widget class="GtkLabel" id="label59">
+			  <property name="visible">True</property>
+			  <property name="label" translatable="yes">Odd row:</property>
+			  <property name="use_underline">False</property>
+			  <property name="use_markup">False</property>
+			  <property name="justify">GTK_JUSTIFY_LEFT</property>
+			  <property name="wrap">False</property>
+			  <property name="selectable">False</property>
+			  <property name="xalign">0</property>
+			  <property name="yalign">0.5</property>
+			  <property name="xpad">0</property>
+			  <property name="ypad">0</property>
+			  <property name="ellipsize">PANGO_ELLIPSIZE_NONE</property>
+			  <property name="width_chars">-1</property>
+			  <property name="single_line_mode">False</property>
+			  <property name="angle">0</property>
+			</widget>
+			<packing>
 			  <property name="left_attach">0</property>
 			  <property name="right_attach">1</property>
-			  <property name="top_attach">1</property>
-			  <property name="bottom_attach">2</property>
-			  <property name="x_options">expand</property>
+			  <property name="top_attach">6</property>
+			  <property name="bottom_attach">7</property>
+			  <property name="x_options">fill</property>
 			  <property name="y_options"></property>
 			</packing>
 		      </child>
@@ -4318,37 +4588,9 @@ Album</property>
 			<packing>
 			  <property name="left_attach">1</property>
 			  <property name="right_attach">2</property>
-			  <property name="top_attach">1</property>
-			  <property name="bottom_attach">2</property>
-			  <property name="x_options">expand</property>
-			  <property name="y_options"></property>
-			</packing>
-		      </child>
-
-		      <child>
-			<widget class="GtkLabel" id="label77">
-			  <property name="visible">True</property>
-			  <property name="label" translatable="yes">Text</property>
-			  <property name="use_underline">False</property>
-			  <property name="use_markup">False</property>
-			  <property name="justify">GTK_JUSTIFY_LEFT</property>
-			  <property name="wrap">False</property>
-			  <property name="selectable">False</property>
-			  <property name="xalign">0</property>
-			  <property name="yalign">0.5</property>
-			  <property name="xpad">0</property>
-			  <property name="ypad">0</property>
-			  <property name="ellipsize">PANGO_ELLIPSIZE_NONE</property>
-			  <property name="width_chars">-1</property>
-			  <property name="single_line_mode">False</property>
-			  <property name="angle">0</property>
-			</widget>
-			<packing>
-			  <property name="left_attach">3</property>
-			  <property name="right_attach">4</property>
-			  <property name="top_attach">0</property>
-			  <property name="bottom_attach">1</property>
-			  <property name="x_options">expand</property>
+			  <property name="top_attach">6</property>
+			  <property name="bottom_attach">7</property>
+			  <property name="x_options">fill</property>
 			  <property name="y_options"></property>
 			</packing>
 		      </child>
@@ -4356,7 +4598,7 @@ Album</property>
 		      <child>
 			<widget class="GtkLabel" id="label78">
 			  <property name="visible">True</property>
-			  <property name="label" translatable="yes">Selected row</property>
+			  <property name="label" translatable="yes">Selected row:</property>
 			  <property name="use_underline">False</property>
 			  <property name="use_markup">False</property>
 			  <property name="justify">GTK_JUSTIFY_LEFT</property>
@@ -4372,11 +4614,11 @@ Album</property>
 			  <property name="angle">0</property>
 			</widget>
 			<packing>
-			  <property name="left_attach">2</property>
-			  <property name="right_attach">3</property>
-			  <property name="top_attach">0</property>
-			  <property name="bottom_attach">1</property>
-			  <property name="x_options">expand</property>
+			  <property name="left_attach">0</property>
+			  <property name="right_attach">1</property>
+			  <property name="top_attach">7</property>
+			  <property name="bottom_attach">8</property>
+			  <property name="x_options">fill</property>
 			  <property name="y_options"></property>
 			</packing>
 		      </child>
@@ -4390,11 +4632,39 @@ Album</property>
 			  <signal name="color_set" handler="on_listview_selected_row_color_set" last_modification_time="Sat, 03 Apr 2010 18:03:15 GMT"/>
 			</widget>
 			<packing>
-			  <property name="left_attach">2</property>
-			  <property name="right_attach">3</property>
-			  <property name="top_attach">1</property>
-			  <property name="bottom_attach">2</property>
-			  <property name="x_options">expand</property>
+			  <property name="left_attach">1</property>
+			  <property name="right_attach">2</property>
+			  <property name="top_attach">7</property>
+			  <property name="bottom_attach">8</property>
+			  <property name="x_options">fill</property>
+			  <property name="y_options"></property>
+			</packing>
+		      </child>
+
+		      <child>
+			<widget class="GtkLabel" id="label77">
+			  <property name="visible">True</property>
+			  <property name="label" translatable="yes">Text:</property>
+			  <property name="use_underline">False</property>
+			  <property name="use_markup">False</property>
+			  <property name="justify">GTK_JUSTIFY_LEFT</property>
+			  <property name="wrap">False</property>
+			  <property name="selectable">False</property>
+			  <property name="xalign">0</property>
+			  <property name="yalign">0.5</property>
+			  <property name="xpad">0</property>
+			  <property name="ypad">0</property>
+			  <property name="ellipsize">PANGO_ELLIPSIZE_NONE</property>
+			  <property name="width_chars">-1</property>
+			  <property name="single_line_mode">False</property>
+			  <property name="angle">0</property>
+			</widget>
+			<packing>
+			  <property name="left_attach">0</property>
+			  <property name="right_attach">1</property>
+			  <property name="top_attach">0</property>
+			  <property name="bottom_attach">1</property>
+			  <property name="x_options">fill</property>
 			  <property name="y_options"></property>
 			</packing>
 		      </child>
@@ -4408,19 +4678,19 @@ Album</property>
 			  <signal name="color_set" handler="on_listview_text_color_set" last_modification_time="Sat, 03 Apr 2010 18:03:22 GMT"/>
 			</widget>
 			<packing>
-			  <property name="left_attach">3</property>
-			  <property name="right_attach">4</property>
-			  <property name="top_attach">1</property>
-			  <property name="bottom_attach">2</property>
-			  <property name="x_options">expand</property>
+			  <property name="left_attach">1</property>
+			  <property name="right_attach">2</property>
+			  <property name="top_attach">0</property>
+			  <property name="bottom_attach">1</property>
+			  <property name="x_options">fill</property>
 			  <property name="y_options"></property>
 			</packing>
 		      </child>
 
 		      <child>
-			<widget class="GtkLabel" id="label61">
+			<widget class="GtkLabel" id="label150">
 			  <property name="visible">True</property>
-			  <property name="label" translatable="yes">Selected text</property>
+			  <property name="label" translatable="yes">Playing text:</property>
 			  <property name="use_underline">False</property>
 			  <property name="use_markup">False</property>
 			  <property name="justify">GTK_JUSTIFY_LEFT</property>
@@ -4436,11 +4706,57 @@ Album</property>
 			  <property name="angle">0</property>
 			</widget>
 			<packing>
-			  <property name="left_attach">4</property>
-			  <property name="right_attach">5</property>
-			  <property name="top_attach">0</property>
-			  <property name="bottom_attach">1</property>
-			  <property name="x_options">expand</property>
+			  <property name="left_attach">0</property>
+			  <property name="right_attach">1</property>
+			  <property name="top_attach">1</property>
+			  <property name="bottom_attach">2</property>
+			  <property name="x_options">fill</property>
+			  <property name="y_options"></property>
+			</packing>
+		      </child>
+
+		      <child>
+			<widget class="GtkColorButton" id="listview_playing_text">
+			  <property name="visible">True</property>
+			  <property name="can_focus">True</property>
+			  <property name="use_alpha">False</property>
+			  <property name="focus_on_click">True</property>
+			  <signal name="color_set" handler="on_listview_playing_text_color_set" last_modification_time="Mon, 18 Aug 2014 10:58:40 GMT"/>
+			</widget>
+			<packing>
+			  <property name="left_attach">1</property>
+			  <property name="right_attach">2</property>
+			  <property name="top_attach">1</property>
+			  <property name="bottom_attach">2</property>
+			  <property name="x_options">fill</property>
+			  <property name="y_options"></property>
+			</packing>
+		      </child>
+
+		      <child>
+			<widget class="GtkLabel" id="label61">
+			  <property name="visible">True</property>
+			  <property name="label" translatable="yes">Selected text:</property>
+			  <property name="use_underline">False</property>
+			  <property name="use_markup">False</property>
+			  <property name="justify">GTK_JUSTIFY_LEFT</property>
+			  <property name="wrap">False</property>
+			  <property name="selectable">False</property>
+			  <property name="xalign">0</property>
+			  <property name="yalign">0.5</property>
+			  <property name="xpad">0</property>
+			  <property name="ypad">0</property>
+			  <property name="ellipsize">PANGO_ELLIPSIZE_NONE</property>
+			  <property name="width_chars">-1</property>
+			  <property name="single_line_mode">False</property>
+			  <property name="angle">0</property>
+			</widget>
+			<packing>
+			  <property name="left_attach">0</property>
+			  <property name="right_attach">1</property>
+			  <property name="top_attach">2</property>
+			  <property name="bottom_attach">3</property>
+			  <property name="x_options">fill</property>
 			  <property name="y_options"></property>
 			</packing>
 		      </child>
@@ -4454,19 +4770,149 @@ Album</property>
 			  <signal name="color_set" handler="on_listview_selected_text_color_set" last_modification_time="Sat, 03 Apr 2010 18:03:29 GMT"/>
 			</widget>
 			<packing>
-			  <property name="left_attach">4</property>
-			  <property name="right_attach">5</property>
+			  <property name="left_attach">1</property>
+			  <property name="right_attach">2</property>
+			  <property name="top_attach">2</property>
+			  <property name="bottom_attach">3</property>
+			  <property name="x_options">fill</property>
+			  <property name="y_options"></property>
+			</packing>
+		      </child>
+
+		      <child>
+			<widget class="GtkHBox" id="hbox134">
+			  <property name="visible">True</property>
+			  <property name="homogeneous">False</property>
+			  <property name="spacing">8</property>
+
+			  <child>
+			    <widget class="GtkCheckButton" id="listview_playing_text_bold">
+			      <property name="visible">True</property>
+			      <property name="can_focus">True</property>
+			      <property name="label" translatable="yes">Bold</property>
+			      <property name="use_underline">True</property>
+			      <property name="relief">GTK_RELIEF_NORMAL</property>
+			      <property name="focus_on_click">True</property>
+			      <property name="active">False</property>
+			      <property name="inconsistent">False</property>
+			      <property name="draw_indicator">True</property>
+			      <signal name="toggled" handler="on_listview_playing_text_bold_toggled" last_modification_time="Mon, 18 Aug 2014 11:59:01 GMT"/>
+			    </widget>
+			    <packing>
+			      <property name="padding">0</property>
+			      <property name="expand">False</property>
+			      <property name="fill">False</property>
+			    </packing>
+			  </child>
+
+			  <child>
+			    <widget class="GtkCheckButton" id="listview_playing_text_italic">
+			      <property name="visible">True</property>
+			      <property name="can_focus">True</property>
+			      <property name="label" translatable="yes">Italic</property>
+			      <property name="use_underline">True</property>
+			      <property name="relief">GTK_RELIEF_NORMAL</property>
+			      <property name="focus_on_click">True</property>
+			      <property name="active">False</property>
+			      <property name="inconsistent">False</property>
+			      <property name="draw_indicator">True</property>
+			      <signal name="toggled" handler="on_listview_playing_text_italic_toggled" last_modification_time="Mon, 18 Aug 2014 11:59:07 GMT"/>
+			    </widget>
+			    <packing>
+			      <property name="padding">0</property>
+			      <property name="expand">False</property>
+			      <property name="fill">False</property>
+			    </packing>
+			  </child>
+			</widget>
+			<packing>
+			  <property name="left_attach">2</property>
+			  <property name="right_attach">3</property>
 			  <property name="top_attach">1</property>
 			  <property name="bottom_attach">2</property>
-			  <property name="x_options">expand</property>
-			  <property name="y_options"></property>
+			  <property name="y_options">fill</property>
+			</packing>
+		      </child>
+
+		      <child>
+			<widget class="GtkHBox" id="hbox135">
+			  <property name="visible">True</property>
+			  <property name="homogeneous">False</property>
+			  <property name="spacing">8</property>
+
+			  <child>
+			    <widget class="GtkCheckButton" id="listview_selected_text_bold">
+			      <property name="visible">True</property>
+			      <property name="can_focus">True</property>
+			      <property name="label" translatable="yes">Bold</property>
+			      <property name="use_underline">True</property>
+			      <property name="relief">GTK_RELIEF_NORMAL</property>
+			      <property name="focus_on_click">True</property>
+			      <property name="active">False</property>
+			      <property name="inconsistent">False</property>
+			      <property name="draw_indicator">True</property>
+			      <signal name="toggled" handler="on_listview_selected_text_bold_toggled" last_modification_time="Mon, 18 Aug 2014 11:59:16 GMT"/>
+			    </widget>
+			    <packing>
+			      <property name="padding">0</property>
+			      <property name="expand">False</property>
+			      <property name="fill">False</property>
+			    </packing>
+			  </child>
+
+			  <child>
+			    <widget class="GtkCheckButton" id="listview_selected_text_italic">
+			      <property name="visible">True</property>
+			      <property name="can_focus">True</property>
+			      <property name="label" translatable="yes">Italic</property>
+			      <property name="use_underline">True</property>
+			      <property name="relief">GTK_RELIEF_NORMAL</property>
+			      <property name="focus_on_click">True</property>
+			      <property name="active">False</property>
+			      <property name="inconsistent">False</property>
+			      <property name="draw_indicator">True</property>
+			      <signal name="toggled" handler="on_listview_selected_text_italic_toggled" last_modification_time="Mon, 18 Aug 2014 11:59:23 GMT"/>
+			    </widget>
+			    <packing>
+			      <property name="padding">0</property>
+			      <property name="expand">False</property>
+			      <property name="fill">False</property>
+			    </packing>
+			  </child>
+			</widget>
+			<packing>
+			  <property name="left_attach">2</property>
+			  <property name="right_attach">3</property>
+			  <property name="top_attach">2</property>
+			  <property name="bottom_attach">3</property>
+			  <property name="y_options">fill</property>
+			</packing>
+		      </child>
+
+		      <child>
+			<widget class="GtkFontButton" id="listview_text_font">
+			  <property name="visible">True</property>
+			  <property name="can_focus">True</property>
+			  <property name="show_style">True</property>
+			  <property name="show_size">True</property>
+			  <property name="use_font">False</property>
+			  <property name="use_size">False</property>
+			  <property name="focus_on_click">True</property>
+			  <signal name="font_set" handler="on_listview_text_font_set" last_modification_time="Mon, 18 Aug 2014 11:02:38 GMT"/>
+			</widget>
+			<packing>
+			  <property name="left_attach">2</property>
+			  <property name="right_attach">3</property>
+			  <property name="top_attach">0</property>
+			  <property name="bottom_attach">1</property>
+			  <property name="y_options">fill</property>
 			</packing>
 		      </child>
 
 		      <child>
 			<widget class="GtkLabel" id="label62">
 			  <property name="visible">True</property>
-			  <property name="label" translatable="yes">Cursor</property>
+			  <property name="label" translatable="yes">Cursor:</property>
 			  <property name="use_underline">False</property>
 			  <property name="use_markup">False</property>
 			  <property name="justify">GTK_JUSTIFY_LEFT</property>
@@ -4482,11 +4928,11 @@ Album</property>
 			  <property name="angle">0</property>
 			</widget>
 			<packing>
-			  <property name="left_attach">5</property>
-			  <property name="right_attach">6</property>
-			  <property name="top_attach">0</property>
-			  <property name="bottom_attach">1</property>
-			  <property name="x_options">expand</property>
+			  <property name="left_attach">0</property>
+			  <property name="right_attach">1</property>
+			  <property name="top_attach">8</property>
+			  <property name="bottom_attach">9</property>
+			  <property name="x_options">fill</property>
 			  <property name="y_options"></property>
 			</packing>
 		      </child>
@@ -4500,12 +4946,78 @@ Album</property>
 			  <signal name="color_set" handler="on_listview_cursor_color_set" last_modification_time="Sat, 03 Apr 2010 18:03:33 GMT"/>
 			</widget>
 			<packing>
-			  <property name="left_attach">5</property>
-			  <property name="right_attach">6</property>
-			  <property name="top_attach">1</property>
-			  <property name="bottom_attach">2</property>
-			  <property name="x_options">expand</property>
+			  <property name="left_attach">1</property>
+			  <property name="right_attach">2</property>
+			  <property name="top_attach">8</property>
+			  <property name="bottom_attach">9</property>
+			  <property name="x_options">fill</property>
 			  <property name="y_options"></property>
+			</packing>
+		      </child>
+
+		      <child>
+			<widget class="GtkLabel" id="label154">
+			  <property name="visible">True</property>
+			  <property name="label" translatable="yes">Column text:</property>
+			  <property name="use_underline">False</property>
+			  <property name="use_markup">False</property>
+			  <property name="justify">GTK_JUSTIFY_LEFT</property>
+			  <property name="wrap">False</property>
+			  <property name="selectable">False</property>
+			  <property name="xalign">0</property>
+			  <property name="yalign">0.5</property>
+			  <property name="xpad">0</property>
+			  <property name="ypad">0</property>
+			  <property name="ellipsize">PANGO_ELLIPSIZE_NONE</property>
+			  <property name="width_chars">-1</property>
+			  <property name="single_line_mode">False</property>
+			  <property name="angle">0</property>
+			</widget>
+			<packing>
+			  <property name="left_attach">0</property>
+			  <property name="right_attach">1</property>
+			  <property name="top_attach">3</property>
+			  <property name="bottom_attach">4</property>
+			  <property name="x_options">fill</property>
+			  <property name="y_options"></property>
+			</packing>
+		      </child>
+
+		      <child>
+			<widget class="GtkColorButton" id="listview_column_text">
+			  <property name="visible">True</property>
+			  <property name="can_focus">True</property>
+			  <property name="use_alpha">False</property>
+			  <property name="focus_on_click">True</property>
+			  <signal name="color_set" handler="on_listview_column_text_color_set" last_modification_time="Tue, 19 Aug 2014 10:54:42 GMT"/>
+			</widget>
+			<packing>
+			  <property name="left_attach">1</property>
+			  <property name="right_attach">2</property>
+			  <property name="top_attach">3</property>
+			  <property name="bottom_attach">4</property>
+			  <property name="x_options">fill</property>
+			  <property name="y_options"></property>
+			</packing>
+		      </child>
+
+		      <child>
+			<widget class="GtkFontButton" id="listview_column_text_font">
+			  <property name="visible">True</property>
+			  <property name="can_focus">True</property>
+			  <property name="show_style">True</property>
+			  <property name="show_size">True</property>
+			  <property name="use_font">False</property>
+			  <property name="use_size">False</property>
+			  <property name="focus_on_click">True</property>
+			  <signal name="font_set" handler="on_listview_column_text_font_set" last_modification_time="Tue, 19 Aug 2014 10:54:29 GMT"/>
+			</widget>
+			<packing>
+			  <property name="left_attach">2</property>
+			  <property name="right_attach">3</property>
+			  <property name="top_attach">3</property>
+			  <property name="bottom_attach">4</property>
+			  <property name="y_options">fill</property>
 			</packing>
 		      </child>
 		    </widget>
@@ -4525,7 +5037,7 @@ Album</property>
 	      <child>
 		<widget class="GtkLabel" id="label75">
 		  <property name="visible">True</property>
-		  <property name="label" translatable="yes">Playlist colors</property>
+		  <property name="label" translatable="yes">Playlist</property>
 		  <property name="use_underline">False</property>
 		  <property name="use_markup">False</property>
 		  <property name="justify">GTK_JUSTIFY_LEFT</property>
@@ -4554,7 +5066,7 @@ Album</property>
 	  <child>
 	    <widget class="GtkLabel" id="label100">
 	      <property name="visible">True</property>
-	      <property name="label" translatable="yes">Colors</property>
+	      <property name="label" translatable="yes">Appearance</property>
 	      <property name="use_underline">False</property>
 	      <property name="use_markup">False</property>
 	      <property name="justify">GTK_JUSTIFY_LEFT</property>

--- a/plugins/gtkui/drawing.h
+++ b/plugins/gtkui/drawing.h
@@ -34,6 +34,14 @@ typedef struct {
 
 // abstract api for drawing primitives
 
+enum {
+    DDB_LIST_FONT = 0,
+    DDB_GROUP_FONT = 1,
+    DDB_TABSTRIP_FONT = 2,
+    DDB_COLUMN_FONT = 3,
+};
+
+
 void
 drawctx_init (drawctx_t *ctx);
 
@@ -59,16 +67,19 @@ float
 draw_get_font_size (drawctx_t *ctx);
 
 void
-draw_init_font (drawctx_t *ctx, GtkStyle *style);
+draw_init_font (drawctx_t *ctx, int type, int reset);
 
 void
-draw_init_font_bold (drawctx_t *ctx);
+draw_init_font_style (drawctx_t *ctx, int bold, int italic, int type);
 
 void
 draw_init_font_normal (drawctx_t *ctx);
 
 void
 draw_text (drawctx_t *ctx, float x, float y, int width, int align, const char *text);
+
+void
+draw_text_custom (drawctx_t *ctx, float x, float y, int width, int align, int type, int bold, int italic, const char *text);
 
 void
 draw_text_with_colors (drawctx_t *ctx, float x, float y, int width, int align, const char *text);
@@ -101,6 +112,12 @@ void
 gtkui_get_tabstrip_text_color (GdkColor *clr);
 
 void
+gtkui_get_tabstrip_playing_text_color (GdkColor *clr);
+
+void
+gtkui_get_tabstrip_selected_text_color (GdkColor *clr);
+
+void
 gtkui_get_listview_even_row_color (GdkColor *clr);
 
 void
@@ -116,7 +133,28 @@ void
 gtkui_get_listview_selected_text_color (GdkColor *clr);
 
 void
+gtkui_get_listview_playing_text_color (GdkColor *clr);
+
+void
+gtkui_get_listview_playing_row_color (GdkColor *clr);
+
+void
+gtkui_get_listview_group_text_color (GdkColor *clr);
+
+void
+gtkui_get_listview_column_text_color (GdkColor *clr);
+
+void
 gtkui_get_listview_cursor_color (GdkColor *clr);
+
+const char*
+gtkui_get_listview_text_font ();
+
+const char *
+gtkui_get_listview_group_text_font ();
+
+const char *
+gtkui_get_listview_column_text_font ();
 
 void
 gtkui_init_theme_colors (void);
@@ -129,5 +167,8 @@ gtkui_override_bar_colors (void);
 
 int
 gtkui_override_tabstrip_colors (void);
+
+const char *
+gtkui_get_tabstrip_text_font  ();
 
 #endif // __DRAWING_H

--- a/plugins/gtkui/gdkdrawing.c
+++ b/plugins/gtkui/gdkdrawing.c
@@ -27,6 +27,34 @@
 #include "support.h"
 #include "gtkui.h"
 
+static char gtkui_listview_text_font[1000];
+static char gtkui_listview_group_text_font[1000];
+static char gtkui_listview_column_text_font[1000];
+static char gtkui_tabstrip_text_font[1000];
+
+static PangoFontDescription *
+get_new_font_description_from_type (int type)
+{
+    PangoFontDescription *desc;
+    switch (type) {
+        case DDB_LIST_FONT:
+            desc = pango_font_description_from_string (gtkui_listview_text_font);
+            break;
+        case DDB_GROUP_FONT:
+            desc = pango_font_description_from_string (gtkui_listview_group_text_font);
+            break;
+        case DDB_TABSTRIP_FONT:
+            desc = pango_font_description_from_string (gtkui_tabstrip_text_font);
+            break;
+        case DDB_COLUMN_FONT:
+            desc = pango_font_description_from_string (gtkui_listview_column_text_font);
+            break;
+        default:
+            desc = NULL;
+    }
+    return desc;
+}
+
 void
 draw_begin (drawctx_t *ctx, cairo_t *cr) {
     ctx->drawable = cr;
@@ -66,11 +94,15 @@ draw_free (drawctx_t *ctx) {
         g_object_unref (ctx->pangolayout);
         ctx->pangolayout = NULL;
     }
+    if (ctx->font_style) {
+        g_object_unref (ctx->font_style);
+        ctx->font_style = NULL;
+    }
 }
 
 void
-draw_init_font (drawctx_t *ctx, GtkStyle *new_font_style) {
-    if (!ctx->pango_ready || (new_font_style && ctx->font_style != new_font_style)) {
+draw_init_font (drawctx_t *ctx, int type, int reset) {
+    if (reset || !ctx->pango_ready) {
         if (ctx->pangoctx) {
             g_object_unref (ctx->pangoctx);
             ctx->pangoctx = NULL;
@@ -79,8 +111,16 @@ draw_init_font (drawctx_t *ctx, GtkStyle *new_font_style) {
             g_object_unref (ctx->pangolayout);
             ctx->pangolayout = NULL;
         }
+        if (ctx->font_style) {
+            g_object_unref (ctx->font_style);
+            ctx->font_style = NULL;
+        }
 
-        ctx->font_style = new_font_style ? new_font_style : gtk_widget_get_default_style ();
+        ctx->font_style = gtk_style_new ();
+        if (ctx->font_style->font_desc) {
+            pango_font_description_free (ctx->font_style->font_desc);
+            ctx->font_style->font_desc = get_new_font_description_from_type (type);
+        }
 
         ctx->pangoctx = gdk_pango_context_get ();
         ctx->pangolayout = pango_layout_new (ctx->pangoctx);
@@ -90,18 +130,27 @@ draw_init_font (drawctx_t *ctx, GtkStyle *new_font_style) {
         pango_layout_set_font_description (ctx->pangolayout, desc);
         ctx->pango_ready = 1;
     }
-    else if (new_font_style) {
+    else if (ctx->pango_ready) {
         PangoFontDescription *desc = ctx->font_style->font_desc;
         pango_layout_set_font_description (ctx->pangolayout, desc);
     }
 }
 
 void
-draw_init_font_bold (drawctx_t *ctx) {
-    PangoFontDescription *desc = pango_font_description_copy (ctx->font_style->font_desc);
-    pango_font_description_set_weight (desc, PANGO_WEIGHT_BOLD);
+draw_init_font_style (drawctx_t *ctx, int bold, int italic, int type) {
+    PangoFontDescription *desc_default = ctx->font_style->font_desc;
+    if (desc_default != NULL) {
+        pango_layout_set_font_description (ctx->pangolayout, desc_default);
+    }
+    PangoFontDescription *desc = pango_font_description_copy (pango_layout_get_font_description (ctx->pangolayout));
+    if (bold) {
+        pango_font_description_set_weight (desc, PANGO_WEIGHT_BOLD);
+    }
+    if (italic) {
+        pango_font_description_set_style (desc, PANGO_STYLE_ITALIC);
+    }
     pango_layout_set_font_description (ctx->pangolayout, desc);
-    pango_font_description_free(desc);
+    pango_font_description_free (desc);
 }
 
 void
@@ -110,10 +159,9 @@ draw_init_font_normal (drawctx_t *ctx) {
     pango_layout_set_font_description (ctx->pangolayout, ctx->font_style->font_desc);
 }
 
-
 float
 draw_get_font_size (drawctx_t *ctx) {
-    draw_init_font (ctx, NULL);
+    draw_init_font (ctx, 0, 0);
     GdkScreen *screen = gdk_screen_get_default ();
     float dpi = gdk_screen_get_resolution (screen);
     PangoFontDescription *desc = ctx->font_style->font_desc;
@@ -122,7 +170,20 @@ draw_get_font_size (drawctx_t *ctx) {
 
 void
 draw_text (drawctx_t *ctx, float x, float y, int width, int align, const char *text) {
-    draw_init_font (ctx, NULL);
+    draw_init_font (ctx, 0, 0);
+    pango_layout_set_width (ctx->pangolayout, width*PANGO_SCALE);
+    pango_layout_set_alignment (ctx->pangolayout, align ? PANGO_ALIGN_RIGHT : PANGO_ALIGN_LEFT);
+    pango_layout_set_text (ctx->pangolayout, text, -1);
+    cairo_move_to (ctx->drawable, x, y);
+    pango_cairo_show_layout (ctx->drawable, ctx->pangolayout);
+}
+
+void
+draw_text_custom (drawctx_t *ctx, float x, float y, int width, int align, int type, int bold, int italic, const char *text) {
+    draw_init_font (ctx, type, 0);
+    if (bold || italic) {
+        draw_init_font_style (ctx, bold, italic, type);
+    }
     pango_layout_set_width (ctx->pangolayout, width*PANGO_SCALE);
     pango_layout_set_alignment (ctx->pangolayout, align ? PANGO_ALIGN_RIGHT : PANGO_ALIGN_LEFT);
     pango_layout_set_text (ctx->pangolayout, text, -1);
@@ -132,19 +193,18 @@ draw_text (drawctx_t *ctx, float x, float y, int width, int align, const char *t
 
 void
 draw_text_with_colors (drawctx_t *ctx, float x, float y, int width, int align, const char *text) {
-    draw_init_font (ctx, NULL);
+    draw_init_font (ctx, 0, 0);
     pango_layout_set_width (ctx->pangolayout, width*PANGO_SCALE);
     pango_layout_set_alignment (ctx->pangolayout, align ? PANGO_ALIGN_RIGHT : PANGO_ALIGN_LEFT);
     pango_layout_set_text (ctx->pangolayout, text, -1);
 //    gdk_draw_layout_with_colors (ctx->drawable, gc, x, y, ctx->pangolayout, &clrfg, &clrbg);
     cairo_move_to (ctx->drawable, x, y);
     pango_cairo_show_layout (ctx->drawable, ctx->pangolayout);
-    
 }
 
 void
 draw_get_text_extents (drawctx_t *ctx, const char *text, int len, int *w, int *h) {
-    draw_init_font (ctx, NULL);
+    draw_init_font (ctx, 0, 0);
     pango_layout_set_width (ctx->pangolayout, 1000 * PANGO_SCALE);
     pango_layout_set_alignment (ctx->pangolayout, PANGO_ALIGN_LEFT);
     pango_layout_set_text (ctx->pangolayout, text, len);
@@ -157,13 +217,14 @@ draw_get_text_extents (drawctx_t *ctx, const char *text, int len, int *w, int *h
 
 int
 draw_get_listview_rowheight (drawctx_t *ctx) {
-    PangoFontDescription *font_desc = ctx->font_style->font_desc;
+    PangoFontDescription *font_desc = pango_font_description_copy (pango_layout_get_font_description (ctx->pangolayout));
     PangoFontMetrics *metrics = pango_context_get_metrics (ctx->pangoctx,
             font_desc,
             pango_context_get_language (ctx->pangoctx));
     int row_height = (pango_font_metrics_get_ascent (metrics) +
             pango_font_metrics_get_descent (metrics));
     pango_font_metrics_unref (metrics);
+    pango_font_description_free (font_desc);
     return PANGO_PIXELS(row_height)+6;
 }
 
@@ -181,12 +242,17 @@ static GdkColor gtkui_tabstrip_mid_color;
 static GdkColor gtkui_tabstrip_light_color;
 static GdkColor gtkui_tabstrip_base_color;
 static GdkColor gtkui_tabstrip_text_color;
+static GdkColor gtkui_tabstrip_playing_text_color;
+static GdkColor gtkui_tabstrip_selected_text_color;
 
 static GdkColor gtkui_listview_even_row_color;
 static GdkColor gtkui_listview_odd_row_color;
 static GdkColor gtkui_listview_selection_color;
 static GdkColor gtkui_listview_text_color;
 static GdkColor gtkui_listview_selected_text_color;
+static GdkColor gtkui_listview_playing_text_color;
+static GdkColor gtkui_listview_group_text_color;
+static GdkColor gtkui_listview_column_text_color;
 static GdkColor gtkui_listview_cursor_color;
 
 static int override_listview_colors = 0;
@@ -219,6 +285,7 @@ gtkui_init_theme_colors (void) {
     GtkStyle *style = gtk_widget_get_style (mainwin);
     char color_text[100];
     const char *clr;
+    const char *font_name = pango_font_description_to_string (style->font_desc);
 
     if (!override_bar_colors) {
         memcpy (&gtkui_bar_foreground_color, &style->base[GTK_STATE_SELECTED], sizeof (GdkColor));
@@ -241,6 +308,9 @@ gtkui_init_theme_colors (void) {
         memcpy (&gtkui_tabstrip_light_color, &style->light[GTK_STATE_NORMAL], sizeof (GdkColor));
         memcpy (&gtkui_tabstrip_base_color, &style->bg[GTK_STATE_NORMAL], sizeof (GdkColor));
         memcpy (&gtkui_tabstrip_text_color, &style->text[GTK_STATE_NORMAL], sizeof (GdkColor));
+        memcpy (&gtkui_tabstrip_playing_text_color, &style->text[GTK_STATE_NORMAL], sizeof (GdkColor));
+        memcpy (&gtkui_tabstrip_selected_text_color, &style->text[GTK_STATE_NORMAL], sizeof (GdkColor));
+        strncpy (gtkui_tabstrip_text_font, font_name, sizeof (gtkui_tabstrip_text_font));
     }
     else {
         snprintf (color_text, sizeof (color_text), "%hd %hd %hd", style->dark[GTK_STATE_NORMAL].red, style->dark[GTK_STATE_NORMAL].green, style->dark[GTK_STATE_NORMAL].blue);
@@ -262,6 +332,16 @@ gtkui_init_theme_colors (void) {
         snprintf (color_text, sizeof (color_text), "%hd %hd %hd", style->text[GTK_STATE_NORMAL].red, style->text[GTK_STATE_NORMAL].green, style->text[GTK_STATE_NORMAL].blue);
         clr = deadbeef->conf_get_str_fast ("gtkui.color.tabstrip_text", color_text);
         sscanf (clr, "%hd %hd %hd", &gtkui_tabstrip_text_color.red, &gtkui_tabstrip_text_color.green, &gtkui_tabstrip_text_color.blue);
+
+        snprintf (color_text, sizeof (color_text), "%hd %hd %hd", style->text[GTK_STATE_NORMAL].red, style->text[GTK_STATE_NORMAL].green, style->text[GTK_STATE_NORMAL].blue);
+        clr = deadbeef->conf_get_str_fast ("gtkui.color.tabstrip_playing_text", color_text);
+        sscanf (clr, "%hd %hd %hd", &gtkui_tabstrip_playing_text_color.red, &gtkui_tabstrip_playing_text_color.green, &gtkui_tabstrip_playing_text_color.blue);
+
+        snprintf (color_text, sizeof (color_text), "%hd %hd %hd", style->text[GTK_STATE_NORMAL].red, style->text[GTK_STATE_NORMAL].green, style->text[GTK_STATE_NORMAL].blue);
+        clr = deadbeef->conf_get_str_fast ("gtkui.color.tabstrip_selected_text", color_text);
+        sscanf (clr, "%hd %hd %hd", &gtkui_tabstrip_selected_text_color.red, &gtkui_tabstrip_selected_text_color.green, &gtkui_tabstrip_selected_text_color.blue);
+
+        strncpy (gtkui_tabstrip_text_font, deadbeef->conf_get_str_fast ("gtkui.font.tabstrip_text", font_name), sizeof (gtkui_tabstrip_text_font));
     }
 
     if (!override_listview_colors) {
@@ -270,7 +350,13 @@ gtkui_init_theme_colors (void) {
         memcpy (&gtkui_listview_selection_color, &style->bg[GTK_STATE_SELECTED], sizeof (GdkColor));
         memcpy (&gtkui_listview_text_color, &style->fg[GTK_STATE_NORMAL], sizeof (GdkColor));
         memcpy (&gtkui_listview_selected_text_color, &style->fg[GTK_STATE_SELECTED], sizeof (GdkColor));
+        memcpy (&gtkui_listview_playing_text_color, &style->fg[GTK_STATE_NORMAL], sizeof (GdkColor));
+        memcpy (&gtkui_listview_group_text_color, &style->fg[GTK_STATE_NORMAL], sizeof (GdkColor));
+        memcpy (&gtkui_listview_column_text_color, &style->fg[GTK_STATE_NORMAL], sizeof (GdkColor));
         memcpy (&gtkui_listview_cursor_color, &style->fg[GTK_STATE_NORMAL], sizeof (GdkColor));
+        strncpy (gtkui_listview_text_font, font_name, sizeof (gtkui_listview_text_font));
+        strncpy (gtkui_listview_group_text_font, font_name, sizeof (gtkui_listview_group_text_font));
+        strncpy (gtkui_listview_column_text_font, font_name, sizeof (gtkui_listview_column_text_font));
     }
     else {
         snprintf (color_text, sizeof (color_text), "%hd %hd %hd", style->light[GTK_STATE_NORMAL].red, style->light[GTK_STATE_NORMAL].green, style->light[GTK_STATE_NORMAL].blue);
@@ -281,7 +367,7 @@ gtkui_init_theme_colors (void) {
         clr = deadbeef->conf_get_str_fast ("gtkui.color.listview_odd_row", color_text);
         sscanf (clr, "%hd %hd %hd", &gtkui_listview_odd_row_color.red, &gtkui_listview_odd_row_color.green, &gtkui_listview_odd_row_color.blue);
 
-        snprintf (color_text, sizeof (color_text), "%hd %hd %hd", style->mid[GTK_STATE_NORMAL].red, style->mid[GTK_STATE_NORMAL].green, style->mid[GTK_STATE_NORMAL].blue);
+        snprintf (color_text, sizeof (color_text), "%hd %hd %hd", style->bg[GTK_STATE_SELECTED].red, style->bg[GTK_STATE_SELECTED].green, style->bg[GTK_STATE_SELECTED].blue);
         clr = deadbeef->conf_get_str_fast ("gtkui.color.listview_selection", color_text);
         sscanf (clr, "%hd %hd %hd", &gtkui_listview_selection_color.red, &gtkui_listview_selection_color.green, &gtkui_listview_selection_color.blue);
 
@@ -293,9 +379,25 @@ gtkui_init_theme_colors (void) {
         clr = deadbeef->conf_get_str_fast ("gtkui.color.listview_selected_text", color_text);
         sscanf (clr, "%hd %hd %hd", &gtkui_listview_selected_text_color.red, &gtkui_listview_selected_text_color.green, &gtkui_listview_selected_text_color.blue);
 
+        snprintf (color_text, sizeof (color_text), "%hd %hd %hd", style->fg[GTK_STATE_NORMAL].red, style->fg[GTK_STATE_NORMAL].green, style->fg[GTK_STATE_NORMAL].blue);
+        clr = deadbeef->conf_get_str_fast ("gtkui.color.listview_playing_text", color_text);
+        sscanf (clr, "%hd %hd %hd", &gtkui_listview_playing_text_color.red, &gtkui_listview_playing_text_color.green, &gtkui_listview_playing_text_color.blue);
+
+        snprintf (color_text, sizeof (color_text), "%hd %hd %hd", style->fg[GTK_STATE_NORMAL].red, style->fg[GTK_STATE_NORMAL].green, style->fg[GTK_STATE_NORMAL].blue);
+        clr = deadbeef->conf_get_str_fast ("gtkui.color.listview_group_text", color_text);
+        sscanf (clr, "%hd %hd %hd", &gtkui_listview_group_text_color.red, &gtkui_listview_group_text_color.green, &gtkui_listview_group_text_color.blue);
+
+        snprintf (color_text, sizeof (color_text), "%hd %hd %hd", style->fg[GTK_STATE_NORMAL].red, style->fg[GTK_STATE_NORMAL].green, style->fg[GTK_STATE_NORMAL].blue);
+        clr = deadbeef->conf_get_str_fast ("gtkui.color.listview_column_text", color_text);
+        sscanf (clr, "%hd %hd %hd", &gtkui_listview_column_text_color.red, &gtkui_listview_column_text_color.green, &gtkui_listview_column_text_color.blue);
+
         snprintf (color_text, sizeof (color_text), "%hd %hd %hd", style->fg[GTK_STATE_SELECTED].red, style->fg[GTK_STATE_SELECTED].green, style->fg[GTK_STATE_SELECTED].blue);
         clr = deadbeef->conf_get_str_fast ("gtkui.color.listview_cursor", color_text);
         sscanf (clr, "%hd %hd %hd", &gtkui_listview_cursor_color.red, &gtkui_listview_cursor_color.green, &gtkui_listview_cursor_color.blue);
+
+        strncpy (gtkui_listview_text_font, deadbeef->conf_get_str_fast ("gtkui.font.listview_text", font_name), sizeof (gtkui_listview_text_font));
+        strncpy (gtkui_listview_group_text_font, deadbeef->conf_get_str_fast ("gtkui.font.listview_group_text", font_name), sizeof (gtkui_listview_group_text_font));
+        strncpy (gtkui_listview_column_text_font, deadbeef->conf_get_str_fast ("gtkui.font.listview_column_text", font_name), sizeof (gtkui_listview_column_text_font));
     }
     deadbeef->conf_unlock ();
 }
@@ -336,6 +438,16 @@ gtkui_get_tabstrip_text_color (GdkColor *clr) {
 }
 
 void
+gtkui_get_tabstrip_playing_text_color (GdkColor *clr) {
+    memcpy (clr, &gtkui_tabstrip_playing_text_color, sizeof (GdkColor));
+}
+
+void
+gtkui_get_tabstrip_selected_text_color (GdkColor *clr) {
+    memcpy (clr, &gtkui_tabstrip_selected_text_color, sizeof (GdkColor));
+}
+
+void
 gtkui_get_listview_even_row_color (GdkColor *clr) {
     memcpy (clr, &gtkui_listview_even_row_color, sizeof (GdkColor));
 }
@@ -361,7 +473,41 @@ gtkui_get_listview_selected_text_color (GdkColor *clr) {
 }
 
 void
+gtkui_get_listview_playing_text_color (GdkColor *clr) {
+    memcpy (clr, &gtkui_listview_playing_text_color, sizeof (GdkColor));
+}
+
+void
+gtkui_get_listview_group_text_color (GdkColor *clr) {
+    memcpy (clr, &gtkui_listview_group_text_color, sizeof (GdkColor));
+}
+
+void
+gtkui_get_listview_column_text_color (GdkColor *clr) {
+    memcpy (clr, &gtkui_listview_column_text_color, sizeof (GdkColor));
+}
+
+void
 gtkui_get_listview_cursor_color (GdkColor *clr) {
     memcpy (clr, &gtkui_listview_cursor_color, sizeof (GdkColor));
 }
 
+const char *
+gtkui_get_listview_text_font () {
+    return gtkui_listview_text_font;
+}
+
+const char *
+gtkui_get_listview_group_text_font () {
+    return gtkui_listview_group_text_font;
+}
+
+const char *
+gtkui_get_listview_column_text_font () {
+    return gtkui_listview_column_text_font;
+}
+
+const char *
+gtkui_get_tabstrip_text_font () {
+    return gtkui_tabstrip_text_font;
+}

--- a/plugins/gtkui/gtkui.c
+++ b/plugins/gtkui/gtkui.c
@@ -95,6 +95,17 @@ void (*gtkui_original_pl_add_files_end) (void);
 
 // cached config variables
 int gtkui_embolden_current_track;
+int gtkui_embolden_tracks;
+int gtkui_embolden_selected_tracks;
+int gtkui_italic_selected_tracks;
+int gtkui_italic_tracks;
+int gtkui_italic_current_track;
+
+int gtkui_tabstrip_embolden_playing;
+int gtkui_tabstrip_italic_playing;
+int gtkui_tabstrip_embolden_selected;
+int gtkui_tabstrip_italic_selected;
+
 int gtkui_groups_pinned;
 
 #ifdef __APPLE__
@@ -600,8 +611,16 @@ gtkui_on_configchanged (void *data) {
     int stop_after_album = deadbeef->conf_get_int ("playlist.stop_after_album", 0);
     gtk_check_menu_item_set_active (GTK_CHECK_MENU_ITEM (lookup_widget (mainwin, "stop_after_album")), stop_after_album ? TRUE : FALSE);
 
-    // embolden current track
     gtkui_embolden_current_track = deadbeef->conf_get_int ("gtkui.embolden_current_track", 0);
+    gtkui_embolden_tracks = deadbeef->conf_get_int ("gtkui.embolden_tracks", 0);
+    gtkui_embolden_selected_tracks = deadbeef->conf_get_int ("gtkui.embolden_selected_tracks", 0);
+    gtkui_italic_current_track = deadbeef->conf_get_int ("gtkui.italic_current_track", 0);
+    gtkui_italic_tracks = deadbeef->conf_get_int ("gtkui.italic_tracks", 0);
+    gtkui_italic_selected_tracks = deadbeef->conf_get_int ("gtkui.italic_selected_tracks", 0);
+    gtkui_tabstrip_embolden_playing = deadbeef->conf_get_int ("gtkui.tabstrip_embolden_playing", 0);
+    gtkui_tabstrip_italic_playing = deadbeef->conf_get_int ("gtkui.tabstrip_italic_playing", 0);
+    gtkui_tabstrip_embolden_selected = deadbeef->conf_get_int ("gtkui.tabstrip_embolden_selected", 0);
+    gtkui_tabstrip_italic_selected = deadbeef->conf_get_int ("gtkui.tabstrip_italic_selected", 0);
 
     // pin groups
     gtkui_groups_pinned = deadbeef->conf_get_int ("playlist.pin.groups", 0);

--- a/plugins/gtkui/gtkui.h
+++ b/plugins/gtkui/gtkui.h
@@ -34,10 +34,22 @@
 extern DB_functions_t *deadbeef;
 extern GtkWidget *mainwin;
 extern GtkWidget *searchwin;
+
+extern int gtkui_embolden_selected_tracks;
+extern int gtkui_embolden_tracks;
 extern int gtkui_embolden_current_track;
+extern int gtkui_italic_selected_tracks;
+extern int gtkui_italic_tracks;
+extern int gtkui_italic_current_track;
+
 extern int gtkui_is_retina;
 extern int gtkui_unicode_playstate;
 extern int gtkui_disable_seekbar_overlay;
+
+extern int gtkui_tabstrip_embolden_selected;
+extern int gtkui_tabstrip_embolden_playing;
+extern int gtkui_tabstrip_italic_selected;
+extern int gtkui_tabstrip_italic_playing;
 
 struct _GSList;
 

--- a/plugins/gtkui/interface.c
+++ b/plugins/gtkui/interface.c
@@ -1557,7 +1557,6 @@ create_prefwin (void)
   GtkWidget *label147;
   GtkWidget *vbox44;
   GtkWidget *mmb_delete_playlist;
-  GtkWidget *embolden_current;
   GtkWidget *hide_delete_from_disk;
   GtkWidget *auto_name_playlist_from_folder;
   GtkWidget *auto_size_columns;
@@ -1575,32 +1574,58 @@ create_prefwin (void)
   GtkWidget *vbox22;
   GtkWidget *override_tabstrip_colors;
   GtkWidget *tabstrip_colors_group;
-  GtkWidget *label45;
-  GtkWidget *label46;
-  GtkWidget *label44;
-  GtkWidget *tabstrip_mid;
-  GtkWidget *tabstrip_light;
-  GtkWidget *tabstrip_dark;
   GtkWidget *tabstrip_base;
   GtkWidget *label76;
+  GtkWidget *tabstrip_dark;
+  GtkWidget *label44;
+  GtkWidget *tabstrip_light;
+  GtkWidget *label46;
+  GtkWidget *tabstrip_mid;
+  GtkWidget *label45;
   GtkWidget *label127;
   GtkWidget *tabstrip_text;
+  GtkWidget *tabstrip_selected_text;
+  GtkWidget *hbox136;
+  GtkWidget *tabstrip_playing_bold;
+  GtkWidget *tabstrip_playing_italic;
+  GtkWidget *hbox137;
+  GtkWidget *tabstrip_selected_bold;
+  GtkWidget *tabstrip_selected_italic;
+  GtkWidget *tabstrip_text_font;
+  GtkWidget *label152;
+  GtkWidget *label153;
+  GtkWidget *tabstrip_playing_text;
   GtkWidget *label74;
   GtkWidget *vbox23;
   GtkWidget *override_listview_colors;
   GtkWidget *listview_colors_group;
+  GtkWidget *label149;
+  GtkWidget *listview_group_text;
+  GtkWidget *listview_group_text_font;
   GtkWidget *label58;
-  GtkWidget *label59;
   GtkWidget *listview_even_row;
+  GtkWidget *label59;
   GtkWidget *listview_odd_row;
-  GtkWidget *label77;
   GtkWidget *label78;
   GtkWidget *listview_selected_row;
+  GtkWidget *label77;
   GtkWidget *listview_text;
+  GtkWidget *label150;
+  GtkWidget *listview_playing_text;
   GtkWidget *label61;
   GtkWidget *listview_selected_text;
+  GtkWidget *hbox134;
+  GtkWidget *listview_playing_text_bold;
+  GtkWidget *listview_playing_text_italic;
+  GtkWidget *hbox135;
+  GtkWidget *listview_selected_text_bold;
+  GtkWidget *listview_selected_text_italic;
+  GtkWidget *listview_text_font;
   GtkWidget *label62;
   GtkWidget *listview_cursor;
+  GtkWidget *label154;
+  GtkWidget *listview_column_text;
+  GtkWidget *listview_column_text_font;
   GtkWidget *label75;
   GtkWidget *label100;
   GtkWidget *vbox11;
@@ -2023,10 +2048,6 @@ create_prefwin (void)
   gtk_widget_show (mmb_delete_playlist);
   gtk_box_pack_start (GTK_BOX (vbox44), mmb_delete_playlist, FALSE, FALSE, 0);
 
-  embolden_current = gtk_check_button_new_with_mnemonic (_("Draw playing track using bold font"));
-  gtk_widget_show (embolden_current);
-  gtk_box_pack_start (GTK_BOX (vbox44), embolden_current, FALSE, FALSE, 0);
-
   hide_delete_from_disk = gtk_check_button_new_with_mnemonic (_("Hide \"Remove From Disk\" context menu item"));
   gtk_widget_show (hide_delete_from_disk);
   gtk_box_pack_start (GTK_BOX (vbox44), hide_delete_from_disk, FALSE, FALSE, 0);
@@ -2093,7 +2114,7 @@ create_prefwin (void)
                     (GtkAttachOptions) (GTK_EXPAND),
                     (GtkAttachOptions) (0), 0, 0);
 
-  label73 = gtk_label_new (_("Seekbar/Volumebar colors"));
+  label73 = gtk_label_new (_("Seekbar/Volumebar"));
   gtk_widget_show (label73);
   gtk_notebook_set_tab_label (GTK_NOTEBOOK (notebook4), gtk_notebook_get_nth_page (GTK_NOTEBOOK (notebook4), 0), label73);
 
@@ -2106,77 +2127,138 @@ create_prefwin (void)
   gtk_widget_show (override_tabstrip_colors);
   gtk_box_pack_start (GTK_BOX (vbox22), override_tabstrip_colors, FALSE, FALSE, 0);
 
-  tabstrip_colors_group = gtk_table_new (2, 5, TRUE);
+  tabstrip_colors_group = gtk_table_new (7, 3, FALSE);
   gtk_widget_show (tabstrip_colors_group);
   gtk_box_pack_start (GTK_BOX (vbox22), tabstrip_colors_group, TRUE, TRUE, 0);
+  gtk_table_set_row_spacings (GTK_TABLE (tabstrip_colors_group), 4);
   gtk_table_set_col_spacings (GTK_TABLE (tabstrip_colors_group), 8);
-
-  label45 = gtk_label_new (_("Middle"));
-  gtk_widget_show (label45);
-  gtk_table_attach (GTK_TABLE (tabstrip_colors_group), label45, 0, 1, 0, 1,
-                    (GtkAttachOptions) (GTK_EXPAND),
-                    (GtkAttachOptions) (0), 0, 0);
-  gtk_misc_set_alignment (GTK_MISC (label45), 0, 0.5);
-
-  label46 = gtk_label_new (_("Light"));
-  gtk_widget_show (label46);
-  gtk_table_attach (GTK_TABLE (tabstrip_colors_group), label46, 1, 2, 0, 1,
-                    (GtkAttachOptions) (GTK_EXPAND),
-                    (GtkAttachOptions) (0), 0, 0);
-  gtk_misc_set_alignment (GTK_MISC (label46), 0, 0.5);
-
-  label44 = gtk_label_new (_("Dark"));
-  gtk_widget_show (label44);
-  gtk_table_attach (GTK_TABLE (tabstrip_colors_group), label44, 2, 3, 0, 1,
-                    (GtkAttachOptions) (GTK_EXPAND),
-                    (GtkAttachOptions) (0), 0, 0);
-  gtk_misc_set_alignment (GTK_MISC (label44), 0, 0.5);
-
-  tabstrip_mid = gtk_color_button_new ();
-  gtk_widget_show (tabstrip_mid);
-  gtk_table_attach (GTK_TABLE (tabstrip_colors_group), tabstrip_mid, 0, 1, 1, 2,
-                    (GtkAttachOptions) (GTK_EXPAND),
-                    (GtkAttachOptions) (0), 0, 0);
-
-  tabstrip_light = gtk_color_button_new ();
-  gtk_widget_show (tabstrip_light);
-  gtk_table_attach (GTK_TABLE (tabstrip_colors_group), tabstrip_light, 1, 2, 1, 2,
-                    (GtkAttachOptions) (GTK_EXPAND),
-                    (GtkAttachOptions) (0), 0, 0);
-
-  tabstrip_dark = gtk_color_button_new ();
-  gtk_widget_show (tabstrip_dark);
-  gtk_table_attach (GTK_TABLE (tabstrip_colors_group), tabstrip_dark, 2, 3, 1, 2,
-                    (GtkAttachOptions) (GTK_EXPAND),
-                    (GtkAttachOptions) (0), 0, 0);
 
   tabstrip_base = gtk_color_button_new ();
   gtk_widget_show (tabstrip_base);
-  gtk_table_attach (GTK_TABLE (tabstrip_colors_group), tabstrip_base, 3, 4, 1, 2,
-                    (GtkAttachOptions) (GTK_EXPAND),
+  gtk_table_attach (GTK_TABLE (tabstrip_colors_group), tabstrip_base, 1, 2, 6, 7,
+                    (GtkAttachOptions) (GTK_FILL),
                     (GtkAttachOptions) (0), 0, 0);
 
-  label76 = gtk_label_new (_("Base"));
+  label76 = gtk_label_new (_("Base:"));
   gtk_widget_show (label76);
-  gtk_table_attach (GTK_TABLE (tabstrip_colors_group), label76, 3, 4, 0, 1,
-                    (GtkAttachOptions) (GTK_EXPAND),
+  gtk_table_attach (GTK_TABLE (tabstrip_colors_group), label76, 0, 1, 6, 7,
+                    (GtkAttachOptions) (GTK_FILL),
                     (GtkAttachOptions) (0), 0, 0);
   gtk_misc_set_alignment (GTK_MISC (label76), 0, 0.5);
 
-  label127 = gtk_label_new (_("Text"));
+  tabstrip_dark = gtk_color_button_new ();
+  gtk_widget_show (tabstrip_dark);
+  gtk_table_attach (GTK_TABLE (tabstrip_colors_group), tabstrip_dark, 1, 2, 5, 6,
+                    (GtkAttachOptions) (GTK_FILL),
+                    (GtkAttachOptions) (0), 0, 0);
+
+  label44 = gtk_label_new (_("Dark:"));
+  gtk_widget_show (label44);
+  gtk_table_attach (GTK_TABLE (tabstrip_colors_group), label44, 0, 1, 5, 6,
+                    (GtkAttachOptions) (GTK_FILL),
+                    (GtkAttachOptions) (0), 0, 0);
+  gtk_misc_set_alignment (GTK_MISC (label44), 0, 0.5);
+
+  tabstrip_light = gtk_color_button_new ();
+  gtk_widget_show (tabstrip_light);
+  gtk_table_attach (GTK_TABLE (tabstrip_colors_group), tabstrip_light, 1, 2, 4, 5,
+                    (GtkAttachOptions) (GTK_FILL),
+                    (GtkAttachOptions) (0), 0, 0);
+
+  label46 = gtk_label_new (_("Light:"));
+  gtk_widget_show (label46);
+  gtk_table_attach (GTK_TABLE (tabstrip_colors_group), label46, 0, 1, 4, 5,
+                    (GtkAttachOptions) (GTK_FILL),
+                    (GtkAttachOptions) (0), 0, 0);
+  gtk_misc_set_alignment (GTK_MISC (label46), 0, 0.5);
+
+  tabstrip_mid = gtk_color_button_new ();
+  gtk_widget_show (tabstrip_mid);
+  gtk_table_attach (GTK_TABLE (tabstrip_colors_group), tabstrip_mid, 1, 2, 3, 4,
+                    (GtkAttachOptions) (GTK_FILL),
+                    (GtkAttachOptions) (0), 0, 0);
+
+  label45 = gtk_label_new (_("Middle:"));
+  gtk_widget_show (label45);
+  gtk_table_attach (GTK_TABLE (tabstrip_colors_group), label45, 0, 1, 3, 4,
+                    (GtkAttachOptions) (GTK_FILL),
+                    (GtkAttachOptions) (0), 0, 0);
+  gtk_misc_set_alignment (GTK_MISC (label45), 0, 0.5);
+
+  label127 = gtk_label_new (_("Text:"));
   gtk_widget_show (label127);
-  gtk_table_attach (GTK_TABLE (tabstrip_colors_group), label127, 4, 5, 0, 1,
-                    (GtkAttachOptions) (GTK_EXPAND),
+  gtk_table_attach (GTK_TABLE (tabstrip_colors_group), label127, 0, 1, 0, 1,
+                    (GtkAttachOptions) (GTK_FILL),
                     (GtkAttachOptions) (0), 0, 0);
   gtk_misc_set_alignment (GTK_MISC (label127), 0, 0.5);
 
   tabstrip_text = gtk_color_button_new ();
   gtk_widget_show (tabstrip_text);
-  gtk_table_attach (GTK_TABLE (tabstrip_colors_group), tabstrip_text, 4, 5, 1, 2,
-                    (GtkAttachOptions) (GTK_EXPAND),
+  gtk_table_attach (GTK_TABLE (tabstrip_colors_group), tabstrip_text, 1, 2, 0, 1,
+                    (GtkAttachOptions) (GTK_FILL),
                     (GtkAttachOptions) (0), 0, 0);
 
-  label74 = gtk_label_new (_("Tab strip colors"));
+  tabstrip_selected_text = gtk_color_button_new ();
+  gtk_widget_show (tabstrip_selected_text);
+  gtk_table_attach (GTK_TABLE (tabstrip_colors_group), tabstrip_selected_text, 1, 2, 2, 3,
+                    (GtkAttachOptions) (GTK_FILL),
+                    (GtkAttachOptions) (0), 0, 0);
+
+  hbox136 = gtk_hbox_new (FALSE, 8);
+  gtk_widget_show (hbox136);
+  gtk_table_attach (GTK_TABLE (tabstrip_colors_group), hbox136, 2, 3, 1, 2,
+                    (GtkAttachOptions) (GTK_FILL),
+                    (GtkAttachOptions) (GTK_FILL), 0, 0);
+
+  tabstrip_playing_bold = gtk_check_button_new_with_mnemonic (_("Bold"));
+  gtk_widget_show (tabstrip_playing_bold);
+  gtk_box_pack_start (GTK_BOX (hbox136), tabstrip_playing_bold, FALSE, FALSE, 0);
+
+  tabstrip_playing_italic = gtk_check_button_new_with_mnemonic (_("Italic"));
+  gtk_widget_show (tabstrip_playing_italic);
+  gtk_box_pack_start (GTK_BOX (hbox136), tabstrip_playing_italic, FALSE, FALSE, 0);
+
+  hbox137 = gtk_hbox_new (FALSE, 8);
+  gtk_widget_show (hbox137);
+  gtk_table_attach (GTK_TABLE (tabstrip_colors_group), hbox137, 2, 3, 2, 3,
+                    (GtkAttachOptions) (GTK_FILL),
+                    (GtkAttachOptions) (GTK_FILL), 0, 0);
+
+  tabstrip_selected_bold = gtk_check_button_new_with_mnemonic (_("Bold"));
+  gtk_widget_show (tabstrip_selected_bold);
+  gtk_box_pack_start (GTK_BOX (hbox137), tabstrip_selected_bold, FALSE, FALSE, 0);
+
+  tabstrip_selected_italic = gtk_check_button_new_with_mnemonic (_("Italic"));
+  gtk_widget_show (tabstrip_selected_italic);
+  gtk_box_pack_start (GTK_BOX (hbox137), tabstrip_selected_italic, FALSE, FALSE, 0);
+
+  tabstrip_text_font = gtk_font_button_new ();
+  gtk_widget_show (tabstrip_text_font);
+  gtk_table_attach (GTK_TABLE (tabstrip_colors_group), tabstrip_text_font, 2, 3, 0, 1,
+                    (GtkAttachOptions) (GTK_EXPAND | GTK_FILL),
+                    (GtkAttachOptions) (GTK_FILL), 0, 0);
+
+  label152 = gtk_label_new (_("Playing text:"));
+  gtk_widget_show (label152);
+  gtk_table_attach (GTK_TABLE (tabstrip_colors_group), label152, 0, 1, 1, 2,
+                    (GtkAttachOptions) (GTK_FILL),
+                    (GtkAttachOptions) (0), 0, 0);
+  gtk_misc_set_alignment (GTK_MISC (label152), 0, 0.5);
+
+  label153 = gtk_label_new (_("Selected text:"));
+  gtk_widget_show (label153);
+  gtk_table_attach (GTK_TABLE (tabstrip_colors_group), label153, 0, 1, 2, 3,
+                    (GtkAttachOptions) (GTK_FILL),
+                    (GtkAttachOptions) (0), 0, 0);
+  gtk_misc_set_alignment (GTK_MISC (label153), 0, 0.5);
+
+  tabstrip_playing_text = gtk_color_button_new ();
+  gtk_widget_show (tabstrip_playing_text);
+  gtk_table_attach (GTK_TABLE (tabstrip_colors_group), tabstrip_playing_text, 1, 2, 1, 2,
+                    (GtkAttachOptions) (GTK_FILL),
+                    (GtkAttachOptions) (0), 0, 0);
+
+  label74 = gtk_label_new (_("Tab strip"));
   gtk_widget_show (label74);
   gtk_notebook_set_tab_label (GTK_NOTEBOOK (notebook4), gtk_notebook_get_nth_page (GTK_NOTEBOOK (notebook4), 1), label74);
 
@@ -2185,98 +2267,184 @@ create_prefwin (void)
   gtk_container_add (GTK_CONTAINER (notebook4), vbox23);
   gtk_container_set_border_width (GTK_CONTAINER (vbox23), 12);
 
-  override_listview_colors = gtk_check_button_new_with_mnemonic (_("Override (looses GTK treeview theming, but speeds up rendering)"));
+  override_listview_colors = gtk_check_button_new_with_mnemonic (_("Override (loses GTK treeview theming, but speeds up rendering)"));
   gtk_widget_show (override_listview_colors);
   gtk_box_pack_start (GTK_BOX (vbox23), override_listview_colors, FALSE, FALSE, 0);
 
-  listview_colors_group = gtk_table_new (2, 6, TRUE);
+  listview_colors_group = gtk_table_new (9, 3, FALSE);
   gtk_widget_show (listview_colors_group);
   gtk_box_pack_start (GTK_BOX (vbox23), listview_colors_group, TRUE, TRUE, 0);
+  gtk_table_set_row_spacings (GTK_TABLE (listview_colors_group), 4);
   gtk_table_set_col_spacings (GTK_TABLE (listview_colors_group), 8);
 
-  label58 = gtk_label_new (_("Even row"));
+  label149 = gtk_label_new (_("Group text:"));
+  gtk_widget_show (label149);
+  gtk_table_attach (GTK_TABLE (listview_colors_group), label149, 0, 1, 4, 5,
+                    (GtkAttachOptions) (GTK_FILL),
+                    (GtkAttachOptions) (0), 0, 0);
+  gtk_misc_set_alignment (GTK_MISC (label149), 0, 0.5);
+
+  listview_group_text = gtk_color_button_new ();
+  gtk_widget_show (listview_group_text);
+  gtk_table_attach (GTK_TABLE (listview_colors_group), listview_group_text, 1, 2, 4, 5,
+                    (GtkAttachOptions) (GTK_FILL),
+                    (GtkAttachOptions) (0), 0, 0);
+
+  listview_group_text_font = gtk_font_button_new ();
+  gtk_widget_show (listview_group_text_font);
+  gtk_table_attach (GTK_TABLE (listview_colors_group), listview_group_text_font, 2, 3, 4, 5,
+                    (GtkAttachOptions) (GTK_EXPAND | GTK_FILL),
+                    (GtkAttachOptions) (GTK_FILL), 0, 0);
+
+  label58 = gtk_label_new (_("Even row:"));
   gtk_widget_show (label58);
-  gtk_table_attach (GTK_TABLE (listview_colors_group), label58, 0, 1, 0, 1,
-                    (GtkAttachOptions) (GTK_EXPAND),
+  gtk_table_attach (GTK_TABLE (listview_colors_group), label58, 0, 1, 5, 6,
+                    (GtkAttachOptions) (GTK_FILL),
                     (GtkAttachOptions) (0), 0, 0);
   gtk_misc_set_alignment (GTK_MISC (label58), 0, 0.5);
 
-  label59 = gtk_label_new (_("Odd row"));
+  listview_even_row = gtk_color_button_new ();
+  gtk_widget_show (listview_even_row);
+  gtk_table_attach (GTK_TABLE (listview_colors_group), listview_even_row, 1, 2, 5, 6,
+                    (GtkAttachOptions) (GTK_FILL),
+                    (GtkAttachOptions) (0), 0, 0);
+
+  label59 = gtk_label_new (_("Odd row:"));
   gtk_widget_show (label59);
-  gtk_table_attach (GTK_TABLE (listview_colors_group), label59, 1, 2, 0, 1,
-                    (GtkAttachOptions) (GTK_EXPAND),
+  gtk_table_attach (GTK_TABLE (listview_colors_group), label59, 0, 1, 6, 7,
+                    (GtkAttachOptions) (GTK_FILL),
                     (GtkAttachOptions) (0), 0, 0);
   gtk_misc_set_alignment (GTK_MISC (label59), 0, 0.5);
 
-  listview_even_row = gtk_color_button_new ();
-  gtk_widget_show (listview_even_row);
-  gtk_table_attach (GTK_TABLE (listview_colors_group), listview_even_row, 0, 1, 1, 2,
-                    (GtkAttachOptions) (GTK_EXPAND),
-                    (GtkAttachOptions) (0), 0, 0);
-
   listview_odd_row = gtk_color_button_new ();
   gtk_widget_show (listview_odd_row);
-  gtk_table_attach (GTK_TABLE (listview_colors_group), listview_odd_row, 1, 2, 1, 2,
-                    (GtkAttachOptions) (GTK_EXPAND),
+  gtk_table_attach (GTK_TABLE (listview_colors_group), listview_odd_row, 1, 2, 6, 7,
+                    (GtkAttachOptions) (GTK_FILL),
                     (GtkAttachOptions) (0), 0, 0);
 
-  label77 = gtk_label_new (_("Text"));
-  gtk_widget_show (label77);
-  gtk_table_attach (GTK_TABLE (listview_colors_group), label77, 3, 4, 0, 1,
-                    (GtkAttachOptions) (GTK_EXPAND),
-                    (GtkAttachOptions) (0), 0, 0);
-  gtk_misc_set_alignment (GTK_MISC (label77), 0, 0.5);
-
-  label78 = gtk_label_new (_("Selected row"));
+  label78 = gtk_label_new (_("Selected row:"));
   gtk_widget_show (label78);
-  gtk_table_attach (GTK_TABLE (listview_colors_group), label78, 2, 3, 0, 1,
-                    (GtkAttachOptions) (GTK_EXPAND),
+  gtk_table_attach (GTK_TABLE (listview_colors_group), label78, 0, 1, 7, 8,
+                    (GtkAttachOptions) (GTK_FILL),
                     (GtkAttachOptions) (0), 0, 0);
   gtk_misc_set_alignment (GTK_MISC (label78), 0, 0.5);
 
   listview_selected_row = gtk_color_button_new ();
   gtk_widget_show (listview_selected_row);
-  gtk_table_attach (GTK_TABLE (listview_colors_group), listview_selected_row, 2, 3, 1, 2,
-                    (GtkAttachOptions) (GTK_EXPAND),
+  gtk_table_attach (GTK_TABLE (listview_colors_group), listview_selected_row, 1, 2, 7, 8,
+                    (GtkAttachOptions) (GTK_FILL),
                     (GtkAttachOptions) (0), 0, 0);
+
+  label77 = gtk_label_new (_("Text:"));
+  gtk_widget_show (label77);
+  gtk_table_attach (GTK_TABLE (listview_colors_group), label77, 0, 1, 0, 1,
+                    (GtkAttachOptions) (GTK_FILL),
+                    (GtkAttachOptions) (0), 0, 0);
+  gtk_misc_set_alignment (GTK_MISC (label77), 0, 0.5);
 
   listview_text = gtk_color_button_new ();
   gtk_widget_show (listview_text);
-  gtk_table_attach (GTK_TABLE (listview_colors_group), listview_text, 3, 4, 1, 2,
-                    (GtkAttachOptions) (GTK_EXPAND),
+  gtk_table_attach (GTK_TABLE (listview_colors_group), listview_text, 1, 2, 0, 1,
+                    (GtkAttachOptions) (GTK_FILL),
                     (GtkAttachOptions) (0), 0, 0);
 
-  label61 = gtk_label_new (_("Selected text"));
+  label150 = gtk_label_new (_("Playing text:"));
+  gtk_widget_show (label150);
+  gtk_table_attach (GTK_TABLE (listview_colors_group), label150, 0, 1, 1, 2,
+                    (GtkAttachOptions) (GTK_FILL),
+                    (GtkAttachOptions) (0), 0, 0);
+  gtk_misc_set_alignment (GTK_MISC (label150), 0, 0.5);
+
+  listview_playing_text = gtk_color_button_new ();
+  gtk_widget_show (listview_playing_text);
+  gtk_table_attach (GTK_TABLE (listview_colors_group), listview_playing_text, 1, 2, 1, 2,
+                    (GtkAttachOptions) (GTK_FILL),
+                    (GtkAttachOptions) (0), 0, 0);
+
+  label61 = gtk_label_new (_("Selected text:"));
   gtk_widget_show (label61);
-  gtk_table_attach (GTK_TABLE (listview_colors_group), label61, 4, 5, 0, 1,
-                    (GtkAttachOptions) (GTK_EXPAND),
+  gtk_table_attach (GTK_TABLE (listview_colors_group), label61, 0, 1, 2, 3,
+                    (GtkAttachOptions) (GTK_FILL),
                     (GtkAttachOptions) (0), 0, 0);
   gtk_misc_set_alignment (GTK_MISC (label61), 0, 0.5);
 
   listview_selected_text = gtk_color_button_new ();
   gtk_widget_show (listview_selected_text);
-  gtk_table_attach (GTK_TABLE (listview_colors_group), listview_selected_text, 4, 5, 1, 2,
-                    (GtkAttachOptions) (GTK_EXPAND),
+  gtk_table_attach (GTK_TABLE (listview_colors_group), listview_selected_text, 1, 2, 2, 3,
+                    (GtkAttachOptions) (GTK_FILL),
                     (GtkAttachOptions) (0), 0, 0);
 
-  label62 = gtk_label_new (_("Cursor"));
+  hbox134 = gtk_hbox_new (FALSE, 8);
+  gtk_widget_show (hbox134);
+  gtk_table_attach (GTK_TABLE (listview_colors_group), hbox134, 2, 3, 1, 2,
+                    (GtkAttachOptions) (GTK_EXPAND | GTK_FILL),
+                    (GtkAttachOptions) (GTK_FILL), 0, 0);
+
+  listview_playing_text_bold = gtk_check_button_new_with_mnemonic (_("Bold"));
+  gtk_widget_show (listview_playing_text_bold);
+  gtk_box_pack_start (GTK_BOX (hbox134), listview_playing_text_bold, FALSE, FALSE, 0);
+
+  listview_playing_text_italic = gtk_check_button_new_with_mnemonic (_("Italic"));
+  gtk_widget_show (listview_playing_text_italic);
+  gtk_box_pack_start (GTK_BOX (hbox134), listview_playing_text_italic, FALSE, FALSE, 0);
+
+  hbox135 = gtk_hbox_new (FALSE, 8);
+  gtk_widget_show (hbox135);
+  gtk_table_attach (GTK_TABLE (listview_colors_group), hbox135, 2, 3, 2, 3,
+                    (GtkAttachOptions) (GTK_EXPAND | GTK_FILL),
+                    (GtkAttachOptions) (GTK_FILL), 0, 0);
+
+  listview_selected_text_bold = gtk_check_button_new_with_mnemonic (_("Bold"));
+  gtk_widget_show (listview_selected_text_bold);
+  gtk_box_pack_start (GTK_BOX (hbox135), listview_selected_text_bold, FALSE, FALSE, 0);
+
+  listview_selected_text_italic = gtk_check_button_new_with_mnemonic (_("Italic"));
+  gtk_widget_show (listview_selected_text_italic);
+  gtk_box_pack_start (GTK_BOX (hbox135), listview_selected_text_italic, FALSE, FALSE, 0);
+
+  listview_text_font = gtk_font_button_new ();
+  gtk_widget_show (listview_text_font);
+  gtk_table_attach (GTK_TABLE (listview_colors_group), listview_text_font, 2, 3, 0, 1,
+                    (GtkAttachOptions) (GTK_EXPAND | GTK_FILL),
+                    (GtkAttachOptions) (GTK_FILL), 0, 0);
+
+  label62 = gtk_label_new (_("Cursor:"));
   gtk_widget_show (label62);
-  gtk_table_attach (GTK_TABLE (listview_colors_group), label62, 5, 6, 0, 1,
-                    (GtkAttachOptions) (GTK_EXPAND),
+  gtk_table_attach (GTK_TABLE (listview_colors_group), label62, 0, 1, 8, 9,
+                    (GtkAttachOptions) (GTK_FILL),
                     (GtkAttachOptions) (0), 0, 0);
   gtk_misc_set_alignment (GTK_MISC (label62), 0, 0.5);
 
   listview_cursor = gtk_color_button_new ();
   gtk_widget_show (listview_cursor);
-  gtk_table_attach (GTK_TABLE (listview_colors_group), listview_cursor, 5, 6, 1, 2,
-                    (GtkAttachOptions) (GTK_EXPAND),
+  gtk_table_attach (GTK_TABLE (listview_colors_group), listview_cursor, 1, 2, 8, 9,
+                    (GtkAttachOptions) (GTK_FILL),
                     (GtkAttachOptions) (0), 0, 0);
 
-  label75 = gtk_label_new (_("Playlist colors"));
+  label154 = gtk_label_new (_("Column text:"));
+  gtk_widget_show (label154);
+  gtk_table_attach (GTK_TABLE (listview_colors_group), label154, 0, 1, 3, 4,
+                    (GtkAttachOptions) (GTK_FILL),
+                    (GtkAttachOptions) (0), 0, 0);
+  gtk_misc_set_alignment (GTK_MISC (label154), 0, 0.5);
+
+  listview_column_text = gtk_color_button_new ();
+  gtk_widget_show (listview_column_text);
+  gtk_table_attach (GTK_TABLE (listview_colors_group), listview_column_text, 1, 2, 3, 4,
+                    (GtkAttachOptions) (GTK_FILL),
+                    (GtkAttachOptions) (0), 0, 0);
+
+  listview_column_text_font = gtk_font_button_new ();
+  gtk_widget_show (listview_column_text_font);
+  gtk_table_attach (GTK_TABLE (listview_colors_group), listview_column_text_font, 2, 3, 3, 4,
+                    (GtkAttachOptions) (GTK_EXPAND | GTK_FILL),
+                    (GtkAttachOptions) (GTK_FILL), 0, 0);
+
+  label75 = gtk_label_new (_("Playlist"));
   gtk_widget_show (label75);
   gtk_notebook_set_tab_label (GTK_NOTEBOOK (notebook4), gtk_notebook_get_nth_page (GTK_NOTEBOOK (notebook4), 2), label75);
 
-  label100 = gtk_label_new (_("Colors"));
+  label100 = gtk_label_new (_("Appearance"));
   gtk_widget_show (label100);
   gtk_notebook_set_tab_label (GTK_NOTEBOOK (notebook), gtk_notebook_get_nth_page (GTK_NOTEBOOK (notebook), 4), label100);
 
@@ -2729,9 +2897,6 @@ create_prefwin (void)
   g_signal_connect ((gpointer) mmb_delete_playlist, "toggled",
                     G_CALLBACK (on_mmb_delete_playlist_toggled),
                     NULL);
-  g_signal_connect ((gpointer) embolden_current, "toggled",
-                    G_CALLBACK (on_embolden_current_toggled),
-                    NULL);
   g_signal_connect ((gpointer) hide_delete_from_disk, "toggled",
                     G_CALLBACK (on_hide_delete_from_disk_toggled),
                     NULL);
@@ -2753,23 +2918,50 @@ create_prefwin (void)
   g_signal_connect ((gpointer) override_tabstrip_colors, "toggled",
                     G_CALLBACK (on_override_tabstrip_colors_toggled),
                     NULL);
-  g_signal_connect ((gpointer) tabstrip_mid, "color_set",
-                    G_CALLBACK (on_tabstrip_mid_color_set),
-                    NULL);
-  g_signal_connect ((gpointer) tabstrip_light, "color_set",
-                    G_CALLBACK (on_tabstrip_light_color_set),
+  g_signal_connect ((gpointer) tabstrip_base, "color_set",
+                    G_CALLBACK (on_tabstrip_base_color_set),
                     NULL);
   g_signal_connect ((gpointer) tabstrip_dark, "color_set",
                     G_CALLBACK (on_tabstrip_dark_color_set),
                     NULL);
-  g_signal_connect ((gpointer) tabstrip_base, "color_set",
-                    G_CALLBACK (on_tabstrip_base_color_set),
+  g_signal_connect ((gpointer) tabstrip_light, "color_set",
+                    G_CALLBACK (on_tabstrip_light_color_set),
+                    NULL);
+  g_signal_connect ((gpointer) tabstrip_mid, "color_set",
+                    G_CALLBACK (on_tabstrip_mid_color_set),
                     NULL);
   g_signal_connect ((gpointer) tabstrip_text, "color_set",
                     G_CALLBACK (on_tabstrip_text_color_set),
                     NULL);
+  g_signal_connect ((gpointer) tabstrip_selected_text, "color_set",
+                    G_CALLBACK (on_tabstrip_selected_text_color_set),
+                    NULL);
+  g_signal_connect ((gpointer) tabstrip_playing_bold, "toggled",
+                    G_CALLBACK (on_tabstrip_playing_bold_toggled),
+                    NULL);
+  g_signal_connect ((gpointer) tabstrip_playing_italic, "toggled",
+                    G_CALLBACK (on_tabstrip_playing_italic_toggled),
+                    NULL);
+  g_signal_connect ((gpointer) tabstrip_selected_bold, "toggled",
+                    G_CALLBACK (on_tabstrip_selected_bold_toggled),
+                    NULL);
+  g_signal_connect ((gpointer) tabstrip_selected_italic, "toggled",
+                    G_CALLBACK (on_tabstrip_selected_italic_toggled),
+                    NULL);
+  g_signal_connect ((gpointer) tabstrip_text_font, "font_set",
+                    G_CALLBACK (on_tabstrip_text_font_set),
+                    NULL);
+  g_signal_connect ((gpointer) tabstrip_playing_text, "color_set",
+                    G_CALLBACK (on_tabstrip_playing_text_color_set),
+                    NULL);
   g_signal_connect ((gpointer) override_listview_colors, "toggled",
                     G_CALLBACK (on_override_listview_colors_toggled),
+                    NULL);
+  g_signal_connect ((gpointer) listview_group_text, "color_set",
+                    G_CALLBACK (on_listview_group_text_color_set),
+                    NULL);
+  g_signal_connect ((gpointer) listview_group_text_font, "font_set",
+                    G_CALLBACK (on_listview_group_text_font_set),
                     NULL);
   g_signal_connect ((gpointer) listview_even_row, "color_set",
                     G_CALLBACK (on_listview_even_row_color_set),
@@ -2783,11 +2975,35 @@ create_prefwin (void)
   g_signal_connect ((gpointer) listview_text, "color_set",
                     G_CALLBACK (on_listview_text_color_set),
                     NULL);
+  g_signal_connect ((gpointer) listview_playing_text, "color_set",
+                    G_CALLBACK (on_listview_playing_text_color_set),
+                    NULL);
   g_signal_connect ((gpointer) listview_selected_text, "color_set",
                     G_CALLBACK (on_listview_selected_text_color_set),
                     NULL);
+  g_signal_connect ((gpointer) listview_playing_text_bold, "toggled",
+                    G_CALLBACK (on_listview_playing_text_bold_toggled),
+                    NULL);
+  g_signal_connect ((gpointer) listview_playing_text_italic, "toggled",
+                    G_CALLBACK (on_listview_playing_text_italic_toggled),
+                    NULL);
+  g_signal_connect ((gpointer) listview_selected_text_bold, "toggled",
+                    G_CALLBACK (on_listview_selected_text_bold_toggled),
+                    NULL);
+  g_signal_connect ((gpointer) listview_selected_text_italic, "toggled",
+                    G_CALLBACK (on_listview_selected_text_italic_toggled),
+                    NULL);
+  g_signal_connect ((gpointer) listview_text_font, "font_set",
+                    G_CALLBACK (on_listview_text_font_set),
+                    NULL);
   g_signal_connect ((gpointer) listview_cursor, "color_set",
                     G_CALLBACK (on_listview_cursor_color_set),
+                    NULL);
+  g_signal_connect ((gpointer) listview_column_text, "color_set",
+                    G_CALLBACK (on_listview_column_text_color_set),
+                    NULL);
+  g_signal_connect ((gpointer) listview_column_text_font, "font_set",
+                    G_CALLBACK (on_listview_column_text_font_set),
                     NULL);
   g_signal_connect ((gpointer) pref_network_enableproxy, "clicked",
                     G_CALLBACK (on_pref_network_enableproxy_clicked),
@@ -2930,7 +3146,6 @@ create_prefwin (void)
   GLADE_HOOKUP_OBJECT (prefwin, label147, "label147");
   GLADE_HOOKUP_OBJECT (prefwin, vbox44, "vbox44");
   GLADE_HOOKUP_OBJECT (prefwin, mmb_delete_playlist, "mmb_delete_playlist");
-  GLADE_HOOKUP_OBJECT (prefwin, embolden_current, "embolden_current");
   GLADE_HOOKUP_OBJECT (prefwin, hide_delete_from_disk, "hide_delete_from_disk");
   GLADE_HOOKUP_OBJECT (prefwin, auto_name_playlist_from_folder, "auto_name_playlist_from_folder");
   GLADE_HOOKUP_OBJECT (prefwin, auto_size_columns, "auto_size_columns");
@@ -2948,32 +3163,58 @@ create_prefwin (void)
   GLADE_HOOKUP_OBJECT (prefwin, vbox22, "vbox22");
   GLADE_HOOKUP_OBJECT (prefwin, override_tabstrip_colors, "override_tabstrip_colors");
   GLADE_HOOKUP_OBJECT (prefwin, tabstrip_colors_group, "tabstrip_colors_group");
-  GLADE_HOOKUP_OBJECT (prefwin, label45, "label45");
-  GLADE_HOOKUP_OBJECT (prefwin, label46, "label46");
-  GLADE_HOOKUP_OBJECT (prefwin, label44, "label44");
-  GLADE_HOOKUP_OBJECT (prefwin, tabstrip_mid, "tabstrip_mid");
-  GLADE_HOOKUP_OBJECT (prefwin, tabstrip_light, "tabstrip_light");
-  GLADE_HOOKUP_OBJECT (prefwin, tabstrip_dark, "tabstrip_dark");
   GLADE_HOOKUP_OBJECT (prefwin, tabstrip_base, "tabstrip_base");
   GLADE_HOOKUP_OBJECT (prefwin, label76, "label76");
+  GLADE_HOOKUP_OBJECT (prefwin, tabstrip_dark, "tabstrip_dark");
+  GLADE_HOOKUP_OBJECT (prefwin, label44, "label44");
+  GLADE_HOOKUP_OBJECT (prefwin, tabstrip_light, "tabstrip_light");
+  GLADE_HOOKUP_OBJECT (prefwin, label46, "label46");
+  GLADE_HOOKUP_OBJECT (prefwin, tabstrip_mid, "tabstrip_mid");
+  GLADE_HOOKUP_OBJECT (prefwin, label45, "label45");
   GLADE_HOOKUP_OBJECT (prefwin, label127, "label127");
   GLADE_HOOKUP_OBJECT (prefwin, tabstrip_text, "tabstrip_text");
+  GLADE_HOOKUP_OBJECT (prefwin, tabstrip_selected_text, "tabstrip_selected_text");
+  GLADE_HOOKUP_OBJECT (prefwin, hbox136, "hbox136");
+  GLADE_HOOKUP_OBJECT (prefwin, tabstrip_playing_bold, "tabstrip_playing_bold");
+  GLADE_HOOKUP_OBJECT (prefwin, tabstrip_playing_italic, "tabstrip_playing_italic");
+  GLADE_HOOKUP_OBJECT (prefwin, hbox137, "hbox137");
+  GLADE_HOOKUP_OBJECT (prefwin, tabstrip_selected_bold, "tabstrip_selected_bold");
+  GLADE_HOOKUP_OBJECT (prefwin, tabstrip_selected_italic, "tabstrip_selected_italic");
+  GLADE_HOOKUP_OBJECT (prefwin, tabstrip_text_font, "tabstrip_text_font");
+  GLADE_HOOKUP_OBJECT (prefwin, label152, "label152");
+  GLADE_HOOKUP_OBJECT (prefwin, label153, "label153");
+  GLADE_HOOKUP_OBJECT (prefwin, tabstrip_playing_text, "tabstrip_playing_text");
   GLADE_HOOKUP_OBJECT (prefwin, label74, "label74");
   GLADE_HOOKUP_OBJECT (prefwin, vbox23, "vbox23");
   GLADE_HOOKUP_OBJECT (prefwin, override_listview_colors, "override_listview_colors");
   GLADE_HOOKUP_OBJECT (prefwin, listview_colors_group, "listview_colors_group");
+  GLADE_HOOKUP_OBJECT (prefwin, label149, "label149");
+  GLADE_HOOKUP_OBJECT (prefwin, listview_group_text, "listview_group_text");
+  GLADE_HOOKUP_OBJECT (prefwin, listview_group_text_font, "listview_group_text_font");
   GLADE_HOOKUP_OBJECT (prefwin, label58, "label58");
-  GLADE_HOOKUP_OBJECT (prefwin, label59, "label59");
   GLADE_HOOKUP_OBJECT (prefwin, listview_even_row, "listview_even_row");
+  GLADE_HOOKUP_OBJECT (prefwin, label59, "label59");
   GLADE_HOOKUP_OBJECT (prefwin, listview_odd_row, "listview_odd_row");
-  GLADE_HOOKUP_OBJECT (prefwin, label77, "label77");
   GLADE_HOOKUP_OBJECT (prefwin, label78, "label78");
   GLADE_HOOKUP_OBJECT (prefwin, listview_selected_row, "listview_selected_row");
+  GLADE_HOOKUP_OBJECT (prefwin, label77, "label77");
   GLADE_HOOKUP_OBJECT (prefwin, listview_text, "listview_text");
+  GLADE_HOOKUP_OBJECT (prefwin, label150, "label150");
+  GLADE_HOOKUP_OBJECT (prefwin, listview_playing_text, "listview_playing_text");
   GLADE_HOOKUP_OBJECT (prefwin, label61, "label61");
   GLADE_HOOKUP_OBJECT (prefwin, listview_selected_text, "listview_selected_text");
+  GLADE_HOOKUP_OBJECT (prefwin, hbox134, "hbox134");
+  GLADE_HOOKUP_OBJECT (prefwin, listview_playing_text_bold, "listview_playing_text_bold");
+  GLADE_HOOKUP_OBJECT (prefwin, listview_playing_text_italic, "listview_playing_text_italic");
+  GLADE_HOOKUP_OBJECT (prefwin, hbox135, "hbox135");
+  GLADE_HOOKUP_OBJECT (prefwin, listview_selected_text_bold, "listview_selected_text_bold");
+  GLADE_HOOKUP_OBJECT (prefwin, listview_selected_text_italic, "listview_selected_text_italic");
+  GLADE_HOOKUP_OBJECT (prefwin, listview_text_font, "listview_text_font");
   GLADE_HOOKUP_OBJECT (prefwin, label62, "label62");
   GLADE_HOOKUP_OBJECT (prefwin, listview_cursor, "listview_cursor");
+  GLADE_HOOKUP_OBJECT (prefwin, label154, "label154");
+  GLADE_HOOKUP_OBJECT (prefwin, listview_column_text, "listview_column_text");
+  GLADE_HOOKUP_OBJECT (prefwin, listview_column_text_font, "listview_column_text_font");
   GLADE_HOOKUP_OBJECT (prefwin, label75, "label75");
   GLADE_HOOKUP_OBJECT (prefwin, label100, "label100");
   GLADE_HOOKUP_OBJECT (prefwin, vbox11, "vbox11");

--- a/plugins/gtkui/mainplaylist.c
+++ b/plugins/gtkui/mainplaylist.c
@@ -180,20 +180,21 @@ void main_draw_group_title (DdbListview *listview, cairo_t *drawable, DdbListvie
         if (theming) {
             GdkColor *clr = &gtk_widget_get_style(theme_treeview)->fg[GTK_STATE_NORMAL];
             float rgb[] = {clr->red/65535.f, clr->green/65535.f, clr->blue/65535.f};
-            draw_set_fg_color (&listview->listctx, rgb);
+            draw_set_fg_color (&listview->grpctx, rgb);
         }
         else {
             GdkColor clr;
-            gtkui_get_listview_text_color (&clr);
+            gtkui_get_listview_group_text_color (&clr);
             float rgb[] = {clr.red/65535.f, clr.green/65535.f, clr.blue/65535.f};
-            draw_set_fg_color (&listview->listctx, rgb);
+            draw_set_fg_color (&listview->grpctx, rgb);
         }
         int ew, eh;
-        draw_get_text_extents (&listview->listctx, str, -1, &ew, &eh);
-        draw_text (&listview->listctx, x + 5, y + height/2 - draw_get_listview_rowheight (&listview->listctx)/2 + 3, ew+5, 0, str);
-        draw_line (&listview->listctx, x + 5 + ew + 3, y+height/2, x + width, y+height/2);
+        draw_get_text_extents (&listview->grpctx, str, -1, &ew, &eh);
+        draw_text_custom (&listview->grpctx, x + 5, y + height/2 - draw_get_listview_rowheight (&listview->grpctx)/2 + 3, ew+5, 0, DDB_GROUP_FONT, 0, 0, str);
+        draw_line (&listview->grpctx, x + 5 + ew + 3, y+height/2, x + width, y+height/2);
     }
 }
+
 void
 main_delete_selected (void) {
     deadbeef->pl_delete_selected ();

--- a/plugins/gtkui/plcommon.c
+++ b/plugins/gtkui/plcommon.c
@@ -168,7 +168,7 @@ void draw_column_data (DdbListview *listview, cairo_t *cr, DdbListviewIter it, D
     }
 
     DB_playItem_t *playing_track = deadbeef->streamer_get_playing_track ();
-	int theming = !gtkui_override_listview_colors ();
+    int theming = !gtkui_override_listview_colors ();
 
     if (cinf->id == DB_COLUMN_ALBUM_ART) {
         if (theming) {
@@ -332,6 +332,9 @@ void draw_column_data (DdbListview *listview, cairo_t *cr, DdbListviewIter it, D
             if (deadbeef->pl_is_selected (it)) {
                 color = (gtkui_get_listview_selected_text_color (&clr), &clr);
             }
+            else if (it && it == playing_track) {
+                color = (gtkui_get_listview_playing_text_color (&clr), &clr);
+            }
             else {
                 color = (gtkui_get_listview_text_color (&clr), &clr);
             }
@@ -339,18 +342,24 @@ void draw_column_data (DdbListview *listview, cairo_t *cr, DdbListviewIter it, D
         float fg[3] = {(float)color->red/0xffff, (float)color->green/0xffff, (float)color->blue/0xffff};
         draw_set_fg_color (&listview->listctx, fg);
 
-        draw_init_font (&listview->listctx, gtk_widget_get_style (GTK_WIDGET (listview)));
-        if (gtkui_embolden_current_track && it && it == playing_track) {
-            draw_init_font_bold (&listview->listctx);
+        draw_init_font (&listview->listctx, DDB_LIST_FONT, 0);
+        int bold = 0;
+        int italic = 0;
+        if (!theming) {
+            if (deadbeef->pl_is_selected (it)) {
+                bold = gtkui_embolden_selected_tracks;
+                italic = gtkui_italic_selected_tracks;
+            }
+            if (it == playing_track) {
+                bold = gtkui_embolden_current_track;
+                italic = gtkui_italic_current_track;
+            }
         }
         if (calign_right) {
-            draw_text (&listview->listctx, x + 5, y + 3, cwidth-10, 1, text);
+            draw_text_custom (&listview->listctx, x + 5, y + 3, cwidth-10, 1, DDB_LIST_FONT, bold, italic, text);
         }
         else {
-            draw_text (&listview->listctx, x + 5, y + 3, cwidth-10, 0, text);
-        }
-        if (gtkui_embolden_current_track && it && it == playing_track) {
-            draw_init_font_normal (&listview->listctx);
+            draw_text_custom (&listview->listctx, x + 5, y + 3, cwidth-10, 0, DDB_LIST_FONT, bold, italic, text);
         }
     }
     if (playing_track) {

--- a/plugins/gtkui/prefwin.c
+++ b/plugins/gtkui/prefwin.c
@@ -108,11 +108,16 @@ prefwin_init_theme_colors (void) {
     gtk_color_button_set_color (GTK_COLOR_BUTTON (lookup_widget (prefwin, "tabstrip_light")), (gtkui_get_tabstrip_light_color (&clr), &clr));
     gtk_color_button_set_color (GTK_COLOR_BUTTON (lookup_widget (prefwin, "tabstrip_base")), (gtkui_get_tabstrip_base_color (&clr), &clr));
     gtk_color_button_set_color (GTK_COLOR_BUTTON (lookup_widget (prefwin, "tabstrip_text")), (gtkui_get_tabstrip_text_color (&clr), &clr));
+    gtk_color_button_set_color (GTK_COLOR_BUTTON (lookup_widget (prefwin, "tabstrip_playing_text")), (gtkui_get_tabstrip_playing_text_color (&clr), &clr));
+    gtk_color_button_set_color (GTK_COLOR_BUTTON (lookup_widget (prefwin, "tabstrip_selected_text")), (gtkui_get_tabstrip_selected_text_color (&clr), &clr));
     gtk_color_button_set_color (GTK_COLOR_BUTTON (lookup_widget (prefwin, "listview_even_row")), (gtkui_get_listview_even_row_color (&clr), &clr));
     gtk_color_button_set_color (GTK_COLOR_BUTTON (lookup_widget (prefwin, "listview_odd_row")), (gtkui_get_listview_odd_row_color (&clr), &clr));
     gtk_color_button_set_color (GTK_COLOR_BUTTON (lookup_widget (prefwin, "listview_selected_row")), (gtkui_get_listview_selection_color (&clr), &clr));
     gtk_color_button_set_color (GTK_COLOR_BUTTON (lookup_widget (prefwin, "listview_text")), (gtkui_get_listview_text_color (&clr), &clr));
     gtk_color_button_set_color (GTK_COLOR_BUTTON (lookup_widget (prefwin, "listview_selected_text")), (gtkui_get_listview_selected_text_color (&clr), &clr));
+    gtk_color_button_set_color (GTK_COLOR_BUTTON (lookup_widget (prefwin, "listview_playing_text")), (gtkui_get_listview_playing_text_color (&clr), &clr));
+    gtk_color_button_set_color (GTK_COLOR_BUTTON (lookup_widget (prefwin, "listview_group_text")), (gtkui_get_listview_group_text_color (&clr), &clr));
+    gtk_color_button_set_color (GTK_COLOR_BUTTON (lookup_widget (prefwin, "listview_column_text")), (gtkui_get_listview_column_text_color (&clr), &clr));
     gtk_color_button_set_color (GTK_COLOR_BUTTON (lookup_widget (prefwin, "listview_cursor")), (gtkui_get_listview_cursor_color (&clr), &clr));
 }
 
@@ -196,9 +201,6 @@ gtkui_run_preferences_dlg (void) {
     // mmb_delete_playlist
     gtk_toggle_button_set_active (GTK_TOGGLE_BUTTON (lookup_widget (w, "mmb_delete_playlist")), deadbeef->conf_get_int ("gtkui.mmb_delete_playlist", 1));
 
-    // embolden current track
-    gtk_toggle_button_set_active (GTK_TOGGLE_BUTTON (lookup_widget (w, "embolden_current")), deadbeef->conf_get_int ("gtkui.embolden_current_track", 0));
-
     // hide_delete_from_disk
     gtk_toggle_button_set_active (GTK_TOGGLE_BUTTON (lookup_widget (w, "hide_delete_from_disk")), deadbeef->conf_get_int ("gtkui.hide_remove_from_disk", 0));
 
@@ -263,10 +265,27 @@ gtkui_run_preferences_dlg (void) {
     gtk_toggle_button_set_active (GTK_TOGGLE_BUTTON (lookup_widget (prefwin, "override_tabstrip_colors")), override);
     gtk_widget_set_sensitive (lookup_widget (prefwin, "tabstrip_colors_group"), override);
 
+    gtk_toggle_button_set_active (GTK_TOGGLE_BUTTON (lookup_widget (w, "tabstrip_playing_bold")), deadbeef->conf_get_int ("gtkui.tabstrip_embolden_playing", 0));
+    gtk_toggle_button_set_active (GTK_TOGGLE_BUTTON (lookup_widget (w, "tabstrip_playing_italic")), deadbeef->conf_get_int ("gtkui.tabstrip_italic_playing", 0));
+    gtk_toggle_button_set_active (GTK_TOGGLE_BUTTON (lookup_widget (w, "tabstrip_selected_bold")), deadbeef->conf_get_int ("gtkui.tabstrip_embolden_selected", 0));
+    gtk_toggle_button_set_active (GTK_TOGGLE_BUTTON (lookup_widget (w, "tabstrip_selected_italic")), deadbeef->conf_get_int ("gtkui.tabstrip_italic_selected", 0));
+
+    gtk_font_button_set_font_name (GTK_FONT_BUTTON (lookup_widget (w, "tabstrip_text_font")), gtkui_get_tabstrip_text_font ());
+
     // override listview colors
     override = deadbeef->conf_get_int ("gtkui.override_listview_colors", 0);
     gtk_toggle_button_set_active (GTK_TOGGLE_BUTTON (lookup_widget (prefwin, "override_listview_colors")), override);
     gtk_widget_set_sensitive (lookup_widget (prefwin, "listview_colors_group"), override);
+
+    // embolden/italic listview text
+    gtk_toggle_button_set_active (GTK_TOGGLE_BUTTON (lookup_widget (w, "listview_selected_text_bold")), deadbeef->conf_get_int ("gtkui.embolden_selected_tracks", 0));
+    gtk_toggle_button_set_active (GTK_TOGGLE_BUTTON (lookup_widget (w, "listview_selected_text_italic")), deadbeef->conf_get_int ("gtkui.italic_selected_tracks", 0));
+    gtk_toggle_button_set_active (GTK_TOGGLE_BUTTON (lookup_widget (w, "listview_playing_text_bold")), deadbeef->conf_get_int ("gtkui.embolden_current_track", 0));
+    gtk_toggle_button_set_active (GTK_TOGGLE_BUTTON (lookup_widget (w, "listview_playing_text_italic")), deadbeef->conf_get_int ("gtkui.italic_current_track", 0));
+
+    gtk_font_button_set_font_name (GTK_FONT_BUTTON (lookup_widget (w, "listview_text_font")), gtkui_get_listview_text_font ());
+    gtk_font_button_set_font_name (GTK_FONT_BUTTON (lookup_widget (w, "listview_group_text_font")), gtkui_get_listview_group_text_font ());
+    gtk_font_button_set_font_name (GTK_FONT_BUTTON (lookup_widget (w, "listview_column_text_font")), gtkui_get_listview_column_text_font ());
 
     // colors
     prefwin_init_theme_colors ();
@@ -561,18 +580,26 @@ on_configure_plugin_clicked            (GtkButton       *button,
     }
 }
 
-void
-on_tabstrip_light_color_set            (GtkColorButton  *colorbutton,
-                                        gpointer         user_data)
+static void
+color_set_helper (GtkColorButton  *colorbutton, gpointer user_data, const char* conf_str)
 {
+    if (conf_str == NULL) {
+        return;
+    }
     GdkColor clr;
     gtk_color_button_get_color (colorbutton, &clr);
     char str[100];
     snprintf (str, sizeof (str), "%d %d %d", clr.red, clr.green, clr.blue);
-    deadbeef->conf_set_str ("gtkui.color.tabstrip_light", str);
+    deadbeef->conf_set_str (conf_str, str);
     deadbeef->sendmessage (DB_EV_CONFIGCHANGED, 0, 0, 0);
     gtkui_init_theme_colors ();
     gtk_widget_queue_draw (mainwin);
+}
+void
+on_tabstrip_light_color_set            (GtkColorButton  *colorbutton,
+                                        gpointer         user_data)
+{
+    color_set_helper (colorbutton, user_data, "gtkui.color.tabstrip_light");
 }
 
 
@@ -580,14 +607,7 @@ void
 on_tabstrip_mid_color_set              (GtkColorButton  *colorbutton,
                                         gpointer         user_data)
 {
-    GdkColor clr;
-    gtk_color_button_get_color (colorbutton, &clr);
-    char str[100];
-    snprintf (str, sizeof (str), "%d %d %d", clr.red, clr.green, clr.blue);
-    deadbeef->conf_set_str ("gtkui.color.tabstrip_mid", str);
-    deadbeef->sendmessage (DB_EV_CONFIGCHANGED, 0, 0, 0);
-    gtkui_init_theme_colors ();
-    gtk_widget_queue_draw (mainwin);
+    color_set_helper (colorbutton, user_data, "gtkui.color.tabstrip_mid");
 }
 
 
@@ -595,56 +615,98 @@ void
 on_tabstrip_dark_color_set             (GtkColorButton  *colorbutton,
                                         gpointer         user_data)
 {
-    GdkColor clr;
-    gtk_color_button_get_color (colorbutton, &clr);
-    char str[100];
-    snprintf (str, sizeof (str), "%d %d %d", clr.red, clr.green, clr.blue);
-    deadbeef->conf_set_str ("gtkui.color.tabstrip_dark", str);
-    deadbeef->sendmessage (DB_EV_CONFIGCHANGED, 0, 0, 0);
-    gtkui_init_theme_colors ();
-    gtk_widget_queue_draw (mainwin);
+    color_set_helper (colorbutton, user_data, "gtkui.color.tabstrip_dark");
 }
 
 void
 on_tabstrip_base_color_set             (GtkColorButton  *colorbutton,
                                         gpointer         user_data)
 {
-    GdkColor clr;
-    gtk_color_button_get_color (colorbutton, &clr);
-    char str[100];
-    snprintf (str, sizeof (str), "%d %d %d", clr.red, clr.green, clr.blue);
-    deadbeef->conf_set_str ("gtkui.color.tabstrip_base", str);
-    deadbeef->sendmessage (DB_EV_CONFIGCHANGED, 0, 0, 0);
-    gtkui_init_theme_colors ();
-    gtk_widget_queue_draw (mainwin);
+    color_set_helper (colorbutton, user_data, "gtkui.color.tabstrip_base");
 }
 
 void
 on_tabstrip_text_color_set             (GtkColorButton  *colorbutton,
                                         gpointer         user_data)
 {
-    GdkColor clr;
-    gtk_color_button_get_color (colorbutton, &clr);
-    char str[100];
-    snprintf (str, sizeof (str), "%d %d %d", clr.red, clr.green, clr.blue);
-    deadbeef->conf_set_str ("gtkui.color.tabstrip_text", str);
-    deadbeef->sendmessage (DB_EV_CONFIGCHANGED, 0, 0, 0);
-    gtkui_init_theme_colors ();
+    color_set_helper (colorbutton, user_data, "gtkui.color.tabstrip_text");
+}
+
+void
+on_tabstrip_selected_text_color_set    (GtkColorButton  *colorbutton,
+                                        gpointer         user_data)
+{
+    color_set_helper (colorbutton, user_data, "gtkui.color.tabstrip_selected_text");
+}
+
+void
+on_tabstrip_playing_bold_toggled       (GtkToggleButton *togglebutton,
+                                        gpointer         user_data)
+{
+    int active = gtk_toggle_button_get_active (GTK_TOGGLE_BUTTON (togglebutton));
+    deadbeef->conf_set_int ("gtkui.tabstrip_embolden_playing", active);
+    gtkui_tabstrip_embolden_playing = active;
+    playlist_refresh ();
     gtk_widget_queue_draw (mainwin);
+}
+
+void
+on_tabstrip_playing_italic_toggled     (GtkToggleButton *togglebutton,
+                                        gpointer         user_data)
+{
+    int active = gtk_toggle_button_get_active (GTK_TOGGLE_BUTTON (togglebutton));
+    deadbeef->conf_set_int ("gtkui.tabstrip_italic_playing", active);
+    gtkui_tabstrip_italic_playing = active;
+    playlist_refresh ();
+    gtk_widget_queue_draw (mainwin);
+}
+
+void
+on_tabstrip_selected_bold_toggled      (GtkToggleButton *togglebutton,
+                                        gpointer         user_data)
+{
+    int active = gtk_toggle_button_get_active (GTK_TOGGLE_BUTTON (togglebutton));
+    deadbeef->conf_set_int ("gtkui.tabstrip_embolden_selected", active);
+    gtkui_tabstrip_embolden_selected = active;
+    playlist_refresh ();
+    gtk_widget_queue_draw (mainwin);
+}
+
+void
+on_tabstrip_selected_italic_toggled    (GtkToggleButton *togglebutton,
+                                        gpointer         user_data)
+{
+    int active = gtk_toggle_button_get_active (GTK_TOGGLE_BUTTON (togglebutton));
+    deadbeef->conf_set_int ("gtkui.tabstrip_italic_selected", active);
+    gtkui_tabstrip_italic_selected = active;
+    playlist_refresh ();
+    gtk_widget_queue_draw (mainwin);
+}
+
+void
+on_tabstrip_text_font_set              (GtkFontButton   *fontbutton,
+                                        gpointer         user_data)
+{
+    deadbeef->conf_set_str ("gtkui.font.tabstrip_text", gtk_font_button_get_font_name (fontbutton));
+    gtkui_init_theme_colors ();
+    playlist_refresh ();
+    deadbeef->sendmessage (DB_EV_CONFIGCHANGED, 0, 0, 0);
+    deadbeef->sendmessage (DB_EV_PLAYLISTCHANGED, 0, 0, 0);
+    gtk_widget_queue_draw (mainwin);
+}
+
+void
+on_tabstrip_playing_text_color_set     (GtkColorButton  *colorbutton,
+                                        gpointer         user_data)
+{
+    color_set_helper (colorbutton, user_data, "gtkui.color.tabstrip_playing_text");
 }
 
 void
 on_bar_foreground_color_set            (GtkColorButton  *colorbutton,
                                         gpointer         user_data)
 {
-    GdkColor clr;
-    gtk_color_button_get_color (colorbutton, &clr);
-    char str[100];
-    snprintf (str, sizeof (str), "%d %d %d", clr.red, clr.green, clr.blue);
-    deadbeef->conf_set_str ("gtkui.color.bar_foreground", str);
-    deadbeef->sendmessage (DB_EV_CONFIGCHANGED, 0, 0, 0);
-    gtkui_init_theme_colors ();
-    gtk_widget_queue_draw (mainwin);
+    color_set_helper (colorbutton, user_data, "gtkui.color.bar_foreground");
 }
 
 
@@ -652,14 +714,7 @@ void
 on_bar_background_color_set            (GtkColorButton  *colorbutton,
                                         gpointer         user_data)
 {
-    GdkColor clr;
-    gtk_color_button_get_color (colorbutton, &clr);
-    char str[100];
-    snprintf (str, sizeof (str), "%d %d %d", clr.red, clr.green, clr.blue);
-    deadbeef->conf_set_str ("gtkui.color.bar_background", str);
-    deadbeef->sendmessage (DB_EV_CONFIGCHANGED, 0, 0, 0);
-    gtkui_init_theme_colors ();
-    gtk_widget_queue_draw (mainwin);
+    color_set_helper (colorbutton, user_data, "gtkui.color.bar_background");
 }
 
 void
@@ -674,6 +729,7 @@ on_override_listview_colors_toggled    (GtkToggleButton *togglebutton,
     prefwin_init_theme_colors ();
     playlist_refresh ();
     deadbeef->sendmessage (DB_EV_PLAYLISTCHANGED, 0, 0, 0);
+    gtk_widget_queue_draw (mainwin);
 }
 
 
@@ -681,13 +737,7 @@ void
 on_listview_even_row_color_set         (GtkColorButton  *colorbutton,
                                         gpointer         user_data)
 {
-    GdkColor clr;
-    gtk_color_button_get_color (colorbutton, &clr);
-    char str[100];
-    snprintf (str, sizeof (str), "%d %d %d", clr.red, clr.green, clr.blue);
-    deadbeef->conf_set_str ("gtkui.color.listview_even_row", str);
-    deadbeef->sendmessage (DB_EV_CONFIGCHANGED, 0, 0, 0);
-    gtkui_init_theme_colors ();
+    color_set_helper (colorbutton, user_data, "gtkui.color.listview_even_row");
     playlist_refresh ();
     deadbeef->sendmessage (DB_EV_PLAYLISTCHANGED, 0, 0, 0);
 }
@@ -696,13 +746,7 @@ void
 on_listview_odd_row_color_set          (GtkColorButton  *colorbutton,
                                         gpointer         user_data)
 {
-    GdkColor clr;
-    gtk_color_button_get_color (colorbutton, &clr);
-    char str[100];
-    snprintf (str, sizeof (str), "%d %d %d", clr.red, clr.green, clr.blue);
-    deadbeef->conf_set_str ("gtkui.color.listview_odd_row", str);
-    deadbeef->sendmessage (DB_EV_CONFIGCHANGED, 0, 0, 0);
-    gtkui_init_theme_colors ();
+    color_set_helper (colorbutton, user_data, "gtkui.color.listview_odd_row");
     playlist_refresh ();
     deadbeef->sendmessage (DB_EV_PLAYLISTCHANGED, 0, 0, 0);
 }
@@ -711,13 +755,7 @@ void
 on_listview_selected_row_color_set     (GtkColorButton  *colorbutton,
                                         gpointer         user_data)
 {
-    GdkColor clr;
-    gtk_color_button_get_color (colorbutton, &clr);
-    char str[100];
-    snprintf (str, sizeof (str), "%d %d %d", clr.red, clr.green, clr.blue);
-    deadbeef->conf_set_str ("gtkui.color.listview_selection", str);
-    deadbeef->sendmessage (DB_EV_CONFIGCHANGED, 0, 0, 0);
-    gtkui_init_theme_colors ();
+    color_set_helper (colorbutton, user_data, "gtkui.color.listview_selection");
     playlist_refresh ();
     deadbeef->sendmessage (DB_EV_PLAYLISTCHANGED, 0, 0, 0);
 }
@@ -726,13 +764,7 @@ void
 on_listview_text_color_set             (GtkColorButton  *colorbutton,
                                         gpointer         user_data)
 {
-    GdkColor clr;
-    gtk_color_button_get_color (colorbutton, &clr);
-    char str[100];
-    snprintf (str, sizeof (str), "%d %d %d", clr.red, clr.green, clr.blue);
-    deadbeef->conf_set_str ("gtkui.color.listview_text", str);
-    deadbeef->sendmessage (DB_EV_CONFIGCHANGED, 0, 0, 0);
-    gtkui_init_theme_colors ();
+    color_set_helper (colorbutton, user_data, "gtkui.color.listview_text");
     playlist_refresh ();
     deadbeef->sendmessage (DB_EV_PLAYLISTCHANGED, 0, 0, 0);
 }
@@ -742,13 +774,7 @@ void
 on_listview_selected_text_color_set    (GtkColorButton  *colorbutton,
                                         gpointer         user_data)
 {
-    GdkColor clr;
-    gtk_color_button_get_color (colorbutton, &clr);
-    char str[100];
-    snprintf (str, sizeof (str), "%d %d %d", clr.red, clr.green, clr.blue);
-    deadbeef->conf_set_str ("gtkui.color.listview_selected_text", str);
-    deadbeef->sendmessage (DB_EV_CONFIGCHANGED, 0, 0, 0);
-    gtkui_init_theme_colors ();
+    color_set_helper (colorbutton, user_data, "gtkui.color.listview_selected_text");
     playlist_refresh ();
     deadbeef->sendmessage (DB_EV_PLAYLISTCHANGED, 0, 0, 0);
 }
@@ -757,17 +783,117 @@ void
 on_listview_cursor_color_set           (GtkColorButton  *colorbutton,
                                         gpointer         user_data)
 {
-    GdkColor clr;
-    gtk_color_button_get_color (colorbutton, &clr);
-    char str[100];
-    snprintf (str, sizeof (str), "%d %d %d", clr.red, clr.green, clr.blue);
-    deadbeef->conf_set_str ("gtkui.color.listview_cursor", str);
+    color_set_helper (colorbutton, user_data, "gtkui.color.listview_cursor");
+    playlist_refresh ();
+    deadbeef->sendmessage (DB_EV_PLAYLISTCHANGED, 0, 0, 0);
+}
+
+void
+on_listview_playing_text_color_set     (GtkColorButton  *colorbutton,
+                                        gpointer         user_data)
+{
+    color_set_helper (colorbutton, user_data, "gtkui.color.listview_playing_text");
+    playlist_refresh ();
+    deadbeef->sendmessage (DB_EV_PLAYLISTCHANGED, 0, 0, 0);
+}
+
+void
+on_listview_group_text_color_set       (GtkColorButton  *colorbutton,
+                                        gpointer         user_data)
+{
+    color_set_helper (colorbutton, user_data, "gtkui.color.listview_group_text");
+    playlist_refresh ();
+    deadbeef->sendmessage (DB_EV_PLAYLISTCHANGED, 0, 0, 0);
+    gtk_widget_queue_draw (mainwin);
+}
+
+void
+on_listview_group_text_font_set        (GtkFontButton   *fontbutton,
+                                        gpointer         user_data)
+{
+    deadbeef->conf_set_str ("gtkui.font.listview_group_text", gtk_font_button_get_font_name (fontbutton));
+    deadbeef->sendmessage (DB_EV_CONFIGCHANGED, 0, 0, 0);
+    gtkui_init_theme_colors ();
+    playlist_refresh ();
+    deadbeef->sendmessage (DB_EV_PLAYLISTCHANGED, 0, 0, 0);
+    gtk_widget_queue_draw (mainwin);
+}
+
+void
+on_listview_text_font_set              (GtkFontButton   *fontbutton,
+                                        gpointer         user_data)
+{
+    deadbeef->conf_set_str ("gtkui.font.listview_text", gtk_font_button_get_font_name (fontbutton));
+    deadbeef->sendmessage (DB_EV_CONFIGCHANGED, 0, 0, 0);
+    gtkui_init_theme_colors ();
+    playlist_refresh ();
+    deadbeef->sendmessage (DB_EV_PLAYLISTCHANGED, 0, 0, 0);
+    gtk_widget_queue_draw (mainwin);
+}
+
+void
+on_listview_playing_text_bold_toggled  (GtkToggleButton *togglebutton,
+                                        gpointer         user_data)
+{
+    int active = gtk_toggle_button_get_active (GTK_TOGGLE_BUTTON (togglebutton));
+    deadbeef->conf_set_int ("gtkui.embolden_current_track", active);
+    gtkui_embolden_current_track = active;
+    playlist_refresh ();
+    gtk_widget_queue_draw (mainwin);
+}
+
+void
+on_listview_playing_text_italic_toggled (GtkToggleButton *togglebutton,
+                                        gpointer         user_data)
+{
+    int active = gtk_toggle_button_get_active (GTK_TOGGLE_BUTTON (togglebutton));
+    deadbeef->conf_set_int ("gtkui.italic_current_track", active);
+    gtkui_italic_current_track = active;
+    playlist_refresh ();
+    gtk_widget_queue_draw (mainwin);
+}
+
+void
+on_listview_selected_text_bold_toggled (GtkToggleButton *togglebutton,
+                                        gpointer         user_data)
+{
+    int active = gtk_toggle_button_get_active (GTK_TOGGLE_BUTTON (togglebutton));
+    deadbeef->conf_set_int ("gtkui.embolden_selected_tracks", active);
+    gtkui_embolden_selected_tracks = active;
+    playlist_refresh ();
+    gtk_widget_queue_draw (mainwin);
+}
+
+void
+on_listview_selected_text_italic_toggled (GtkToggleButton *togglebutton,
+                                        gpointer         user_data)
+{
+    int active = gtk_toggle_button_get_active (GTK_TOGGLE_BUTTON (togglebutton));
+    deadbeef->conf_set_int ("gtkui.italic_selected_tracks", active);
+    gtkui_italic_selected_tracks = active;
+    playlist_refresh ();
+    gtk_widget_queue_draw (mainwin);
+}
+
+void
+on_listview_column_text_color_set      (GtkColorButton  *colorbutton,
+                                        gpointer         user_data)
+{
+    color_set_helper (colorbutton, user_data, "gtkui.color.listview_column_text");
+    playlist_refresh ();
+    deadbeef->sendmessage (DB_EV_PLAYLISTCHANGED, 0, 0, 0);
+}
+
+void
+on_listview_column_text_font_set       (GtkFontButton   *fontbutton,
+                                        gpointer         user_data)
+{
+    deadbeef->conf_set_str ("gtkui.font.listview_column_text", gtk_font_button_get_font_name (fontbutton));
     deadbeef->sendmessage (DB_EV_CONFIGCHANGED, 0, 0, 0);
     gtkui_init_theme_colors ();
     playlist_refresh ();
     deadbeef->sendmessage (DB_EV_PLAYLISTCHANGED, 0, 0, 0);
 }
-
 
 void
 on_override_bar_colors_toggled         (GtkToggleButton *togglebutton,
@@ -863,17 +989,6 @@ on_proxypassword_changed               (GtkEditable     *editable,
                                         gpointer         user_data)
 {
     deadbeef->conf_set_str ("network.proxy.password", gtk_entry_get_text (GTK_ENTRY (editable)));
-}
-
-
-void
-on_embolden_current_toggled            (GtkToggleButton *togglebutton,
-                                        gpointer         user_data)
-{
-    int active = gtk_toggle_button_get_active (GTK_TOGGLE_BUTTON (togglebutton));
-    deadbeef->conf_set_int ("gtkui.embolden_current_track", active);
-    gtkui_embolden_current_track = active;
-    playlist_refresh ();
 }
 
 void


### PR DESCRIPTION
This is quite a huge patch for the gtkui plugin and I'm not sure if I did everything as you'd expected, so I am happy about any feedback/critisism. 

Short summary about what this patch is supposed to do:
- allow font customization for listview, listview header and tabstrip widget
- restyle and rename listview and tabstrip color preferences
- add further color customizations (tabstrip: selected, playing, listview: group title)
- remove embolden current track checkbox from current location since this can now be configured in Preferences -> Appearance -> Playlist
