### PR TITLE
Remove expired cache pixbuf, don't just ignore it

### DIFF
--- a/plugins/gtkui/coverart.h
+++ b/plugins/gtkui/coverart.h
@@ -51,8 +51,5 @@ cover_get_default_pixbuf (void);
 int
 gtkui_is_default_pixbuf (GdkPixbuf *pb);
 
-int
-gtkui_cover_message (uint32_t id, uintptr_t ctx, uint32_t p1, uint32_t p2);
-
 #endif
 

--- a/plugins/gtkui/gtkui.c
+++ b/plugins/gtkui/gtkui.c
@@ -772,7 +772,7 @@ gtkui_message (uint32_t id, uintptr_t ctx, uint32_t p1, uint32_t p2) {
     if (rootwidget) {
         send_messages_to_widgets (rootwidget, id, ctx, p1, p2);
     }
-    gtkui_cover_message (id, ctx, p1, p2);
+
     switch (id) {
     case DB_EV_ACTIVATED:
         g_idle_add (activate_cb, NULL);


### PR DESCRIPTION
Previous fix wasn't quite there.  Better to evict expired pixbuf cache entries immediately instead of leaving them cluttering up the cache until they get pushed out by age.  With this change, the whole cache expiry check on reset is no longer necessary.  The artwork plugin will check against the reset time when get_album_art() is called and it will update the disk cache file, then the pixbuf cache will be checked against disk and updated if necessary.
