### PR TITLE
oggedit: fix data type issues from libogg

### DIFF
--- a/plugins/liboggedit/oggedit_internal.c
+++ b/plugins/liboggedit/oggedit_internal.c
@@ -173,7 +173,7 @@ void cleanup(DB_FILE *in, FILE *out, ogg_sync_state *oy, void *buffer)
         free(buffer);
 }
 
-static int get_page(DB_FILE *in, ogg_sync_state *oy, ogg_page *og)
+static int64_t get_page(DB_FILE *in, ogg_sync_state *oy, ogg_page *og)
 {
     uint16_t chunks_left = MAXPAGE / CHUNKSIZE;
     while (ogg_sync_pageout(oy, og) != 1) {
@@ -188,10 +188,10 @@ static int get_page(DB_FILE *in, ogg_sync_state *oy, ogg_page *og)
         ogg_sync_wrote(oy, bytes);
     }
 
-    return ogg_page_serialno(og);
+    return ogg_page_serialno(og) + UINT32_MAX + 1;
 }
 
-static int skip_to_bos(DB_FILE *in, ogg_sync_state *oy, ogg_page *og, const off_t offset)
+static int64_t skip_to_bos(DB_FILE *in, ogg_sync_state *oy, ogg_page *og, const off_t offset)
 {
     if (!in)
         return OGGEDIT_FILE_NOT_OPEN;
@@ -200,7 +200,7 @@ static int skip_to_bos(DB_FILE *in, ogg_sync_state *oy, ogg_page *og, const off_
         return OGGEDIT_SEEK_FAILED;
 
     ogg_sync_reset(oy);
-    int serial;
+    int64_t serial;
     do
         serial = get_page(in, oy, og);
     while (serial > OGGEDIT_EOF && !ogg_page_bos(og));
@@ -208,16 +208,16 @@ static int skip_to_bos(DB_FILE *in, ogg_sync_state *oy, ogg_page *og, const off_
     return serial;
 }
 
-static int skip_to_codec(DB_FILE *in, ogg_sync_state *oy, ogg_page *og, const off_t offset, const char *codec)
+static int64_t skip_to_codec(DB_FILE *in, ogg_sync_state *oy, ogg_page *og, const off_t offset, const char *codec)
 {
-    int serial = skip_to_bos(in, oy, og, offset);
+    int64_t serial = skip_to_bos(in, oy, og, offset);
     while (serial > OGGEDIT_EOF && strcmp(codec_name(og), codec))
         serial = get_page(in, oy, og);
 
     return serial;
 }
 
-static int skip_to_header(DB_FILE *in, ogg_sync_state *oy, ogg_page *og, int serial, const int codec_serial)
+static int64_t skip_to_header(DB_FILE *in, ogg_sync_state *oy, ogg_page *og, int64_t serial, const int64_t codec_serial)
 {
     while (serial > OGGEDIT_EOF && (ogg_page_bos(og) || serial != codec_serial))
         serial = get_page(in, oy, og);
@@ -241,7 +241,7 @@ static bool write_page(FILE *out, ogg_page *og)
     return true;
 }
 
-static int write_page_and_get_next(DB_FILE *in, FILE *out, ogg_sync_state *oy, ogg_page *og)
+static int64_t write_page_and_get_next(DB_FILE *in, FILE *out, ogg_sync_state *oy, ogg_page *og)
 {
     if (!write_page(out, og))
         return OGGEDIT_WRITE_ERROR;
@@ -249,9 +249,9 @@ static int write_page_and_get_next(DB_FILE *in, FILE *out, ogg_sync_state *oy, o
     return get_page(in, oy, og);
 }
 
-int copy_up_to_codec(DB_FILE *in, FILE *out, ogg_sync_state *oy, ogg_page *og, const off_t start_offset, const off_t link_offset, const char *codec)
+int64_t copy_up_to_codec(DB_FILE *in, FILE *out, ogg_sync_state *oy, ogg_page *og, const off_t start_offset, const off_t link_offset, const char *codec)
 {
-    int serial = skip_to_bos(in, oy, og, start_offset);
+    int64_t serial = skip_to_bos(in, oy, og, start_offset);
 
     if (fseek(out, sync_tell(in, oy, og), SEEK_SET))
         return OGGEDIT_SEEK_FAILED;
@@ -262,9 +262,9 @@ int copy_up_to_codec(DB_FILE *in, FILE *out, ogg_sync_state *oy, ogg_page *og, c
     return serial;
 }
 
-int copy_up_to_header(DB_FILE *in, FILE *out, ogg_sync_state *oy, ogg_page *og, const int codec_serial)
+int64_t copy_up_to_header(DB_FILE *in, FILE *out, ogg_sync_state *oy, ogg_page *og, const int64_t codec_serial)
 {
-    int serial;
+    int64_t serial;
     do
         serial = write_page_and_get_next(in, out, oy, og);
     while (serial > OGGEDIT_EOF && serial != codec_serial);
@@ -290,7 +290,7 @@ long flush_stream(FILE *out, ogg_stream_state *os)
 char *codec_names(DB_FILE *in, ogg_sync_state *oy, const off_t link_offset)
 {
     ogg_page og;
-    int serial = skip_to_bos(in, oy, &og, link_offset);
+    int64_t serial = skip_to_bos(in, oy, &og, link_offset);
     char *codecs = strdup("Ogg");
     while (codecs && serial > OGGEDIT_EOF && ogg_page_bos(&og)) {
         codecs = cat_string(codecs, codec_name(&og), strcmp(codecs, "Ogg") ? "/" : " ");
@@ -310,8 +310,8 @@ off_t codec_stream_size(DB_FILE *in, ogg_sync_state *oy, const off_t start_offse
     /* Find codec serial and any other codecs */
     bool multiplex = false;
     ogg_page og;
-    int codec_serial = -1;
-    int serial = skip_to_bos(in, oy, &og, start_offset);
+    int64_t codec_serial = -1;
+    int64_t serial = skip_to_bos(in, oy, &og, start_offset);
     while (serial > OGGEDIT_EOF && ogg_page_bos(&og)) {
         if (strcmp(codec_name(&og), codec))
             multiplex = true;
@@ -367,9 +367,9 @@ char *parse_vendor(const ogg_packet *op, const size_t magic_length)
     return vendor;
 }
 
-int init_read_stream(DB_FILE *in, ogg_sync_state *oy, ogg_stream_state *os, ogg_page *og, const off_t offset, const char *codec)
+int64_t init_read_stream(DB_FILE *in, ogg_sync_state *oy, ogg_stream_state *os, ogg_page *og, const off_t offset, const char *codec)
 {
-    int serial = skip_to_codec(in, oy, og, offset, codec);
+    int64_t serial = skip_to_codec(in, oy, og, offset, codec);
     serial = skip_to_header(in, oy, og, serial, serial);
     if (serial <= OGGEDIT_EOF)
         return serial;
@@ -383,12 +383,12 @@ int init_read_stream(DB_FILE *in, ogg_sync_state *oy, ogg_stream_state *os, ogg_
     return OGGEDIT_OK;
 }
 
-int read_packet(DB_FILE *in, ogg_sync_state *oy, ogg_stream_state *os, ogg_page *og, ogg_packet *header, int pages)
+int64_t read_packet(DB_FILE *in, ogg_sync_state *oy, ogg_stream_state *os, ogg_page *og, ogg_packet *header, int pages)
 {
     ogg_packet op;
     do {
         while (ogg_stream_packetpeek(os, NULL) == 0) {
-            const int serial = get_page(in, oy, og);
+            const int64_t serial = get_page(in, oy, og);
             if (serial <= OGGEDIT_EOF) {
                 return serial;
             }
@@ -456,11 +456,11 @@ size_t vc_size(const char *vendor, size_t num_tags, char **tags)
     return metadata_size;
 }
 
-int copy_remaining_pages(DB_FILE *in, FILE *out, ogg_sync_state *oy, const int codec_serial, uint32_t pageno)
+int64_t copy_remaining_pages(DB_FILE *in, FILE *out, ogg_sync_state *oy, const int64_t codec_serial, uint32_t pageno)
 {
     /* Skip past the codec header packets */
     ogg_page og;
-    int serial;
+    int64_t serial;
     do
         serial = get_page(in, oy, &og);
     while (serial > OGGEDIT_EOF && serial == codec_serial && ogg_page_granulepos(&og) <= 0);
@@ -488,11 +488,11 @@ int copy_remaining_pages(DB_FILE *in, FILE *out, ogg_sync_state *oy, const int c
     return OGGEDIT_OK;
 }
 
-int write_all_streams(DB_FILE *in, FILE *out, ogg_sync_state *oy, const off_t offset)
+int64_t write_all_streams(DB_FILE *in, FILE *out, ogg_sync_state *oy, const off_t offset)
 {
     /* Copy BOS page(s) */
     ogg_page og;
-    int serial = skip_to_bos(in, oy, &og, offset);
+    int64_t serial = skip_to_bos(in, oy, &og, offset);
     while (serial > OGGEDIT_EOF && ogg_page_bos(&og))
         serial = write_page_and_get_next(in, out, oy, &og);
     if (serial <= OGGEDIT_EOF)
@@ -507,16 +507,16 @@ int write_all_streams(DB_FILE *in, FILE *out, ogg_sync_state *oy, const off_t of
     return OGGEDIT_OK;
 }
 
-int write_one_stream(DB_FILE *in, FILE *out, ogg_sync_state *oy, const off_t offset, const char *codec)
+int64_t write_one_stream(DB_FILE *in, FILE *out, ogg_sync_state *oy, const off_t offset, const char *codec)
 {
     /* Find codec BOS page */
     ogg_page og;
-    const int codec_serial = skip_to_codec(in, oy, &og, offset, codec);
+    const int64_t codec_serial = skip_to_codec(in, oy, &og, offset, codec);
     if (codec_serial <= OGGEDIT_EOF)
         return codec_serial;
 
     /* Write it and skip the other BOS pages */
-    int serial = write_page_and_get_next(in, out, oy, &og);
+    int64_t serial = write_page_and_get_next(in, out, oy, &og);
     if ((serial = skip_to_header(in, oy, &og, serial, codec_serial)) <= OGGEDIT_EOF)
         return serial;
 

--- a/plugins/liboggedit/oggedit_internal.h
+++ b/plugins/liboggedit/oggedit_internal.h
@@ -50,18 +50,18 @@ int open_temp_file(const char *fname, char *tempname, FILE **out);
 FILE *open_new_file(const char *outname);
 off_t file_size(const char *fname);
 void cleanup(DB_FILE *in, FILE *out, ogg_sync_state *oy, void *buffer);
-int copy_up_to_codec(DB_FILE *in, FILE *out, ogg_sync_state *oy, ogg_page *og, const off_t start_offset, const off_t link_offset, const char *codec);
-int copy_up_to_header(DB_FILE *in, FILE *out, ogg_sync_state *oy, ogg_page *og, const int codec_serial);
+int64_t copy_up_to_codec(DB_FILE *in, FILE *out, ogg_sync_state *oy, ogg_page *og, const off_t start_offset, const off_t link_offset, const char *codec);
+int64_t copy_up_to_header(DB_FILE *in, FILE *out, ogg_sync_state *oy, ogg_page *og, const int64_t codec_serial);
 long flush_stream(FILE *out, ogg_stream_state *os);
 char *codec_names(DB_FILE *in, ogg_sync_state *oy, const off_t link_offset);
 off_t codec_stream_size(DB_FILE *in, ogg_sync_state *oy, const off_t start_offset, const off_t end_offset, const char *codec);
 char *parse_vendor(const ogg_packet *op, const size_t magic_length);
-int init_read_stream(DB_FILE *in, ogg_sync_state *oy, ogg_stream_state *os, ogg_page *og, const off_t offset, const char *codec);
-int read_packet(DB_FILE *in, ogg_sync_state *oy, ogg_stream_state *os, ogg_page *og, ogg_packet *header, int pages);
+int64_t init_read_stream(DB_FILE *in, ogg_sync_state *oy, ogg_stream_state *os, ogg_page *og, const off_t offset, const char *codec);
+int64_t read_packet(DB_FILE *in, ogg_sync_state *oy, ogg_stream_state *os, ogg_page *og, ogg_packet *header, int pages);
 ogg_packet *fill_vc_packet(const char *magic, const size_t magic_length, const char *vendor, const size_t num_tags, char **tags, const bool framing, const size_t padding, ogg_packet *op);
 size_t vc_size(const char *vendor, size_t num_tags, char **tags);
-int copy_remaining_pages(DB_FILE *in, FILE *out, ogg_sync_state *oy, const int codec_serial, uint32_t pageno);
-int write_all_streams(DB_FILE *in, FILE *out, ogg_sync_state *oy, const off_t offset);
-int write_one_stream(DB_FILE *in, FILE *out, ogg_sync_state *oy, const off_t offset, const char *codec);
+int64_t copy_remaining_pages(DB_FILE *in, FILE *out, ogg_sync_state *oy, const int64_t codec_serial, uint32_t pageno);
+int64_t write_all_streams(DB_FILE *in, FILE *out, ogg_sync_state *oy, const off_t offset);
+int64_t write_one_stream(DB_FILE *in, FILE *out, ogg_sync_state *oy, const off_t offset, const char *codec);
 
 #endif /* __OGGEDIT_INT_H */

--- a/plugins/liboggedit/oggedit_opus.c
+++ b/plugins/liboggedit/oggedit_opus.c
@@ -63,7 +63,7 @@ off_t oggedit_opus_stream_info(DB_FILE *in, const off_t start_offset, const off_
     ogg_sync_state oy;
     ogg_sync_init(&oy);
     *codecs = codec_names(in, &oy, start_offset);
-    const off_t stream_size = codec_stream_size(in, &oy, start_offset, end_offset, OPUSNAME);
+    const int64_t stream_size = codec_stream_size(in, &oy, start_offset, end_offset, OPUSNAME);
     cleanup(in, NULL, &oy, NULL);
     return stream_size;
 }
@@ -72,7 +72,7 @@ static ptrdiff_t check_opus_header(DB_FILE *in, ogg_sync_state *oy, const off_t 
 {
     ogg_stream_state os;
     ogg_page og;
-    const int serial = init_read_stream(in, oy, &os, &og, offset, OPUSNAME);
+    const int64_t serial = init_read_stream(in, oy, &os, &og, offset, OPUSNAME);
     if (serial <= OGGEDIT_EOF)
         return serial;
 
@@ -98,7 +98,7 @@ static ptrdiff_t check_opus_header(DB_FILE *in, ogg_sync_state *oy, const off_t 
     return op.bytes;
 }
 
-static long write_opus_tags(FILE *out, const int serial, const char *vendor, const size_t num_tags, char **tags, const size_t padding)
+static long write_opus_tags(FILE *out, const int64_t serial, const char *vendor, const size_t num_tags, char **tags, const size_t padding)
 {
     ogg_packet op;
     if (!fill_vc_packet(TAGMAGIC, strlen(TAGMAGIC), vendor, num_tags, tags, false, padding, &op))
@@ -153,7 +153,7 @@ off_t oggedit_write_opus_metadata(DB_FILE *in, const char *fname, const off_t of
 
     /* Write pages until we reach the correct OpusHead, then write OpusTags */
     ogg_page og;
-    const int opus_serial = copy_up_to_codec(in, out, &oy, &og, *tempname ? 0 : offset, offset, OPUSNAME);
+    int64_t opus_serial = copy_up_to_codec(in, out, &oy, &og, *tempname ? 0 : offset, offset, OPUSNAME);
     if (opus_serial <= OGGEDIT_EOF) {
         res = opus_serial;
         goto cleanup;
@@ -163,8 +163,11 @@ off_t oggedit_write_opus_metadata(DB_FILE *in, const char *fname, const off_t of
         og.body[17] = output_gain >> 8 & 0xFF;
         ogg_page_checksum_set(&og);
     }
-    if ((res = copy_up_to_header(in, out, &oy, &og, opus_serial)) <= OGGEDIT_EOF)
+    opus_serial = copy_up_to_header(in, out, &oy, &og, opus_serial);
+    if (opus_serial <= OGGEDIT_EOF) {
+        res = opus_serial;
         goto cleanup;
+    }
     const long pageno = write_opus_tags(out, opus_serial, vendor, num_tags, tags, (size_t)padding);
     if (pageno < OGGEDIT_EOF) {
         res = pageno;
@@ -173,8 +176,11 @@ off_t oggedit_write_opus_metadata(DB_FILE *in, const char *fname, const off_t of
 
     /* If we have tempfile, copy the remaining pages */
     if (*tempname) {
-        if ((res = copy_remaining_pages(in, out, &oy, opus_serial, pageno)) <= OGGEDIT_EOF)
+        opus_serial = copy_remaining_pages(in, out, &oy, opus_serial, pageno);
+        if (opus_serial <= OGGEDIT_EOF) {
+            res = opus_serial;
             goto cleanup;
+        }
         if (rename(tempname, fname)) {
             res = OGGEDIT_RENAME_FAILED;
             goto cleanup;

--- a/plugins/liboggedit/oggedit_vorbis.c
+++ b/plugins/liboggedit/oggedit_vorbis.c
@@ -50,7 +50,7 @@ static ptrdiff_t check_vorbis_headers(DB_FILE *in, ogg_sync_state *oy, const off
 {
     ogg_stream_state os;
     ogg_page og;
-    const int serial = init_read_stream(in, oy, &os, &og, offset, VORBISNAME);
+    const int64_t serial = init_read_stream(in, oy, &os, &og, offset, VORBISNAME);
     if (serial <= OGGEDIT_EOF)
         return serial;
 
@@ -79,7 +79,7 @@ static ptrdiff_t check_vorbis_headers(DB_FILE *in, ogg_sync_state *oy, const off
     return vc.bytes;
 }
 
-static long write_vorbis_tags(FILE *out, const int serial, const char *vendor, const size_t num_tags, char **tags, const size_t padding, ogg_packet *codebooks)
+static long write_vorbis_tags(FILE *out, const int64_t serial, const char *vendor, const size_t num_tags, char **tags, const size_t padding, ogg_packet *codebooks)
 {
     ogg_packet op;
     if (!fill_vc_packet(VCMAGIC, strlen(VCMAGIC), vendor, num_tags, tags, true, padding, &op))
@@ -137,13 +137,16 @@ off_t oggedit_write_vorbis_metadata(DB_FILE *in, const char *fname, const off_t 
 
     /* Write pages until the correct comment header */
     ogg_page og;
-    const int vorbis_serial = copy_up_to_codec(in, out, &oy, &og, *tempname ? 0 : offset, offset, VORBISNAME);
+    int64_t vorbis_serial = copy_up_to_codec(in, out, &oy, &og, *tempname ? 0 : offset, offset, VORBISNAME);
     if (vorbis_serial <= OGGEDIT_EOF) {
         res = vorbis_serial;
         goto cleanup;
     }
-    if ((res = copy_up_to_header(in, out, &oy, &og, vorbis_serial)) <= OGGEDIT_EOF)
+    vorbis_serial = copy_up_to_header(in, out, &oy, &og, vorbis_serial);
+    if (vorbis_serial <= OGGEDIT_EOF) {
+        res = vorbis_serial;
         goto cleanup;
+    }
     const long pageno = write_vorbis_tags(out, vorbis_serial, vendor, num_tags, tags, padding, &codebooks);
     if (pageno < OGGEDIT_EOF) {
         res = pageno;
@@ -152,8 +155,11 @@ off_t oggedit_write_vorbis_metadata(DB_FILE *in, const char *fname, const off_t 
 
     /* If we have tempfile, copy the remaining pages */
     if (*tempname) {
-        if ((res = copy_remaining_pages(in, out, &oy, vorbis_serial, pageno)) <= OGGEDIT_EOF)
+        vorbis_serial = copy_remaining_pages(in, out, &oy, vorbis_serial, pageno);
+        if (vorbis_serial <= OGGEDIT_EOF) {
+            res = vorbis_serial;
             goto cleanup;
+        }
         if (rename(tempname, fname)) {
             res = OGGEDIT_RENAME_FAILED;
             goto cleanup;


### PR DESCRIPTION
This fixes the problems with the example file in issue #1332, and hopefully in all other cases.  Internally this now uses signed 64 bit integers to allow the stream serial number to be represented as a positive number on all platforms.  Externally the interface is unchanged.
