### PR TITLE
Add M_PI definition to files, where it can be missing

### DIFF
--- a/fft.c
+++ b/fft.c
@@ -25,6 +25,9 @@
 #endif
 #include "deadbeef.h"
 #include <math.h>
+#ifndef M_PI
+#define M_PI 3.1415926535897932384626433832795029
+#endif
 #include <complex.h>
 
 #define N (DDB_FREQ_BANDS * 2)

--- a/plugins/rg_scanner/ebur128/ebur128.c
+++ b/plugins/rg_scanner/ebur128/ebur128.c
@@ -5,6 +5,9 @@
 #include <float.h>
 #include <limits.h>
 #include <math.h> /* You may have to define _USE_MATH_DEFINES if you use MSVC */
+#ifndef M_PI
+#define M_PI 3.1415926535897932384626433832795029
+#endif
 #include <stdio.h>
 #include <stdlib.h>
 


### PR DESCRIPTION
In these files `M_PI` is being used, but we cannot be sure that it has been defined. Deadbeef uses C99 standard by default (`-std=c99`) which does not include `M_PI` definition. Code compiles fine on most systems, because `M_PI` is included with GNU extensions.

To maintain compatibility with C99 check if `M_PI` is already defined, and if not, define it manually. This approach is already being used by some plugins in deadbeef.