### PR TITLE
fix invalid desktop file

### DIFF
--- a/deadbeef.desktop.in
+++ b/deadbeef.desktop.in
@@ -20,43 +20,8 @@ Categories=Audio;AudioVideo;Player;GTK;
 Keywords=Sound;Music;Audio;Player;Musicplayer;MP3
 Keywords[zh_TW]=Sound;Music;Audio;Player;Musicplayer;MP3;音樂;音樂播放器;播放器;音訊
 
-X-Ayatana-Desktop-Shortcuts=Play;Pause;Stop;Next;Prev
+Actions=Play;Pause;Stop;Next;Prev
 X-PulseAudio-Properties=media.role=music
-
-[Play Shortcut Group]
-Name=Play
-Name[zh_CN]=播放
-Name[zh_TW]=播放
-Exec=deadbeef --play
-TargetEnvironment=Unity
-
-[Pause Shortcut Group]
-Name=Pause
-Name[zh_CN]=暂停
-Name[zh_TW]=暫停
-Exec=deadbeef --pause
-TargetEnvironment=Unity
-
-[Stop Shortcut Group]
-Name=Stop
-Name[zh_CN]=停止
-Name[zh_TW]=停止
-Exec=deadbeef --stop
-TargetEnvironment=Unity
-
-[Next Shortcut Group]
-Name=Next
-Name[zh_CN]=下一首
-Name[zh_TW]=下一首
-Exec=deadbeef --next
-TargetEnvironment=Unity
-
-[Prev Shortcut Group]
-Name=Prev
-Name[zh_CN]=上一首
-Name[zh_TW]=上一首
-Exec=deadbeef --prev
-TargetEnvironment=Unity
 
 [Desktop Action Play]
 Name=Play


### PR DESCRIPTION
In Debian 9 with LXDE, deadbeef would not start and show a warning about the invalid desktop instead.

"Shortcut Group" is a incompatible extension used by the unity desktop. The Desktop switched to the standard "Actions" syntax in Ubuntu 12.04. Source: https://bugs.launchpad.net/unity/+bug/789867