### PR TITLE
main: fix when executable in path

### DIFF
--- a/main.c
+++ b/main.c
@@ -862,8 +862,7 @@ main (int argc, char *argv[]) {
         *e = 0;
     }
     else {
-        trace_err ("couldn't determine install folder from path %s\n", argv[0]);
-        exit (-1);
+        strcpy (dbinstalldir, PREFIX);
     }
 
     // detect portable version by looking for plugins/ and deadbeef.png and portable_full by config/


### PR DESCRIPTION
When deadbeef is installed and run with `deadbeef` it will fail, because it can't find path it was run from.

On linux it's possible to read executable location through `readlink("/proc/self/exe", buf, bufsize)` I don't know if you want it or not through.