### PR TITLE
More work on dnd in the CocoaUI

### DIFF
--- a/plugins/cocoaui/DdbListview.m
+++ b/plugins/cocoaui/DdbListview.m
@@ -22,11 +22,10 @@
 */
 
 #import "DdbListview.h"
+#import "DdbShared.h"
 #include "../../deadbeef.h"
 
 extern DB_functions_t *deadbeef;
-
-static NSString *ddbPlaylistItemsUTIType = @"net.sourceforge.deadbeef.playlistItems";
 
 // data has to be serialized, so we code idx and not pointers
 @interface DdbListviewLocalDragDropHolder : NSObject<NSCoding, NSPasteboardReading, NSPasteboardWriting> {

--- a/plugins/cocoaui/DdbListview.m
+++ b/plugins/cocoaui/DdbListview.m
@@ -481,9 +481,11 @@ int grouptitleheight = 22;
 
         NSArray *paths = [pboard propertyListForType:NSFilenamesPboardType];
         if (row) {
-            [delegate externalDropItems:paths after:row];
+            // add before selected row
+            [delegate externalDropItems:paths after: [delegate rowForIndex:sel-1] ];
         }
         else {
+            // no selected row, add to end
             DdbListviewRow_t lastRow = [delegate rowForIndex:([delegate rowCount]-1)];
             [delegate externalDropItems:paths after: lastRow];
         }

--- a/plugins/cocoaui/DdbShared.h
+++ b/plugins/cocoaui/DdbShared.h
@@ -30,4 +30,6 @@ cocoaui_add_new_playlist (void);
 void
 cocoaui_playlist_set_curr (int playlist);
 
+extern NSString *ddbPlaylistItemsUTIType;
+
 #endif

--- a/plugins/cocoaui/DdbShared.m
+++ b/plugins/cocoaui/DdbShared.m
@@ -67,4 +67,4 @@ cocoaui_playlist_set_curr (int playlist) {
     deadbeef->conf_set_int ("playlist.current", playlist);
 }
 
-NSString *ddbPlaylistItemsUTIType = @"net.sourceforge.deadbeef.playlistItems";
+NSString *ddbPlaylistItemsUTIType = @"org.deadbeef.playlistItems";

--- a/plugins/cocoaui/DdbShared.m
+++ b/plugins/cocoaui/DdbShared.m
@@ -67,4 +67,4 @@ cocoaui_playlist_set_curr (int playlist) {
     deadbeef->conf_set_int ("playlist.current", playlist);
 }
 
-
+NSString *ddbPlaylistItemsUTIType = @"net.sourceforge.deadbeef.playlistItems";

--- a/plugins/cocoaui/widgets/DdbTabStrip.m
+++ b/plugins/cocoaui/widgets/DdbTabStrip.m
@@ -128,6 +128,8 @@ static int max_tab_size = 200;
         [self setupTrackingArea];
 
         [self setScrollPos:deadbeef->conf_get_int ("cocoaui.tabscroll", 0)];
+
+        [self registerForDraggedTypes:[NSArray arrayWithObjects:ddbPlaylistItemsUTIType, NSFilenamesPboardType, nil]];
     }
     return self;
 }
@@ -833,8 +835,22 @@ plt_get_title_wrapper (int plt) {
 - (BOOL)isFlipped {
     return YES;
 }
-// FIXME dnd motion must activate playlist
-// ...
+
+- (BOOL)wantsPeriodicDraggingUpdates {
+    // we only want to be informed of dnd drag updates when mouse moves
+    return NO;
+}
+
+- (NSDragOperation)draggingUpdated:(id<NSDraggingInfo>)sender {
+
+    NSPoint coord = [sender draggingLocation];
+    int tabUnderCursor = [self tabUnderCursor: coord.x];
+    if (tabUnderCursor != -1) {
+        cocoaui_playlist_set_curr (tabUnderCursor);
+    }
+
+    return NSDragOperationNone;
+}
 
 - (int)widgetMessage:(uint32_t)_id ctx:(uintptr_t)ctx p1:(uint32_t)p1 p2:(uint32_t)p2 {
     // FIXME: it's completely unclear why the code below is needed on playlist change/switch.


### PR DESCRIPTION
- You can d'n'd to a different playlist. Tab will get selected if you drag over it.
- Same behaviour between internal and external drops, that is, all will be added before the selected row, if any, or at the end of the playlist if none selected.

Visual indicator is still needed.