### PR TITLE
Set plugins API to newest for all plugins

### DIFF
--- a/plugins/aac/aac.c
+++ b/plugins/aac/aac.c
@@ -1109,8 +1109,7 @@ static const char * exts[] = { "aac", "mp4", "m4a", "m4b", NULL };
 
 // define plugin interface
 static DB_decoder_t plugin = {
-    .plugin.api_vmajor = 1,
-    .plugin.api_vminor = 0,
+    DDB_PLUGIN_SET_API_VERSION
     .plugin.version_major = 1,
     .plugin.version_minor = 0,
 //    .plugin.flags = DDB_PLUGIN_FLAG_LOGGING,

--- a/plugins/adplug/plugin.c
+++ b/plugins/adplug/plugin.c
@@ -54,8 +54,7 @@ static const char settings_dlg[] =
 
 // define plugin interface
 DB_decoder_t adplug_plugin = {
-    .plugin.api_vmajor = 1,
-    .plugin.api_vminor = 0,
+    DDB_PLUGIN_SET_API_VERSION
     .plugin.version_major = 1,
     .plugin.version_minor = 0,
     .plugin.type = DB_PLUGIN_DECODER,

--- a/plugins/alac/alac_plugin.c
+++ b/plugins/alac/alac_plugin.c
@@ -763,8 +763,7 @@ static const char * exts[] = { "mp4", "m4a", NULL };
 
 // define plugin interface
 static DB_decoder_t alac_plugin = {
-    .plugin.api_vmajor = 1,
-    .plugin.api_vminor = 0,
+    DDB_PLUGIN_SET_API_VERSION
     .plugin.version_major = 1,
     .plugin.version_minor = 0,
     .plugin.type = DB_PLUGIN_DECODER,

--- a/plugins/alsa/alsa.c
+++ b/plugins/alsa/alsa.c
@@ -784,8 +784,7 @@ static const char settings_dlg[] =
 
 // define plugin interface
 static DB_output_t plugin = {
-    .plugin.api_vmajor = 1,
-    .plugin.api_vminor = 0,
+    DDB_PLUGIN_SET_API_VERSION
     .plugin.version_major = 1,
     .plugin.version_minor = 0,
     .plugin.type = DB_PLUGIN_OUTPUT,

--- a/plugins/artwork-legacy/artwork.c
+++ b/plugins/artwork-legacy/artwork.c
@@ -2226,8 +2226,8 @@ static const char settings_dlg[] =
 
 // define plugin interface
 static DB_artwork_plugin_t plugin = {
-    .plugin.plugin.api_vmajor = 1,
-    .plugin.plugin.api_vminor = 0,
+    .plugin.plugin.api_vmajor = DB_API_VERSION_MAJOR,
+    .plugin.plugin.api_vminor = DB_API_VERSION_MINOR,
     .plugin.plugin.version_major = 1,
     .plugin.plugin.version_minor = DDB_ARTWORK_VERSION,
     .plugin.plugin.type = DB_PLUGIN_MISC,

--- a/plugins/artwork/artwork.c
+++ b/plugins/artwork/artwork.c
@@ -2332,8 +2332,8 @@ static const char settings_dlg[] =
 
 // define plugin interface
 static ddb_artwork_plugin_t plugin = {
-    .plugin.plugin.api_vmajor = 1,
-    .plugin.plugin.api_vminor = 0,
+    .plugin.plugin.api_vmajor = DB_API_VERSION_MAJOR,
+    .plugin.plugin.api_vminor = DB_API_VERSION_MINOR,
     .plugin.plugin.version_major = DDB_ARTWORK_MAJOR_VERSION,
     .plugin.plugin.version_minor = DDB_ARTWORK_MINOR_VERSION,
     .plugin.plugin.type = DB_PLUGIN_MISC,

--- a/plugins/cdda/cdda.c
+++ b/plugins/cdda/cdda.c
@@ -1098,8 +1098,7 @@ static const char settings_dlg[] =
 
 // define plugin interface
 static DB_decoder_t plugin = {
-    .plugin.api_vmajor = 1,
-    .plugin.api_vminor = 0,
+    DDB_PLUGIN_SET_API_VERSION
     .plugin.version_major = 1,
     .plugin.version_minor = 0,
     .plugin.type = DB_PLUGIN_DECODER,

--- a/plugins/cocoaui/main.m
+++ b/plugins/cocoaui/main.m
@@ -47,8 +47,7 @@ int cocoaui_message (uint32_t _id, uintptr_t ctx, uint32_t p1, uint32_t p2) {
 
 DB_gui_t plugin = {
     .plugin.type = DB_PLUGIN_GUI,
-    .plugin.api_vmajor = 1,
-    .plugin.api_vminor = 5,
+    DDB_PLUGIN_SET_API_VERSION
     .plugin.version_major = 1,
     .plugin.version_minor = 0,
     .plugin.id = "cocoaui",

--- a/plugins/converter/converter.c
+++ b/plugins/converter/converter.c
@@ -1549,8 +1549,8 @@ converter_stop (void) {
 
 // define plugin interface
 static ddb_converter_t plugin = {
-    .misc.plugin.api_vmajor = 1,
-    .misc.plugin.api_vminor = 0,
+    .misc.plugin.api_vmajor = DB_API_VERSION_MAJOR,
+    .misc.plugin.api_vminor = DB_API_VERSION_MINOR,
     .misc.plugin.version_major = 1,
     .misc.plugin.version_minor = 5,
     .misc.plugin.flags = DDB_PLUGIN_FLAG_LOGGING,

--- a/plugins/converter/convgui.c
+++ b/plugins/converter/convgui.c
@@ -1822,8 +1822,7 @@ convgui_start (void) {
 }
 
 DB_misc_t plugin = {
-    .plugin.api_vmajor = 1,
-    .plugin.api_vminor = 5,
+    DDB_PLUGIN_SET_API_VERSION
     .plugin.version_major = 1,
     .plugin.version_minor = 2,
     .plugin.type = DB_PLUGIN_MISC,

--- a/plugins/coreaudio/coreaudio.c
+++ b/plugins/coreaudio/coreaudio.c
@@ -494,8 +494,7 @@ ca_plugin_stop (void) {
 }
 
 static DB_output_t plugin = {
-    .plugin.api_vmajor = 1,
-    .plugin.api_vminor = 0,
+    DDB_PLUGIN_SET_API_VERSION
     .plugin.version_major = 2,
     .plugin.version_minor = 0,
     .plugin.type = DB_PLUGIN_OUTPUT,

--- a/plugins/dca/dcaplug.c
+++ b/plugins/dca/dcaplug.c
@@ -729,8 +729,7 @@ dts_stop (void) {
 
 // define plugin interface
 static DB_decoder_t plugin = {
-    .plugin.api_vmajor = 1,
-    .plugin.api_vminor = 0,
+    DDB_PLUGIN_SET_API_VERSION
     .plugin.version_major = 1,
     .plugin.version_minor = 0,
     .plugin.type = DB_PLUGIN_DECODER,

--- a/plugins/dsp_libsrc/src.c
+++ b/plugins/dsp_libsrc/src.c
@@ -286,8 +286,7 @@ static const char settings_dlg[] =
 
 static DB_dsp_t plugin = {
     // need 1.1 api for pass_through
-    .plugin.api_vmajor = 1,
-    .plugin.api_vminor = 1,
+    DDB_PLUGIN_SET_API_VERSION
     .open = ddb_src_open,
     .close = ddb_src_close,
     .process = ddb_src_process,

--- a/plugins/dumb/cdumb.c
+++ b/plugins/dumb/cdumb.c
@@ -467,8 +467,7 @@ static const char settings_dlg[] =
 
 // define plugin interface
 static DB_decoder_t plugin = {
-    .plugin.api_vmajor = 1,
-    .plugin.api_vminor = 0,
+    DDB_PLUGIN_SET_API_VERSION
     .plugin.version_major = 1,
     .plugin.version_minor = 0,
     .plugin.type = DB_PLUGIN_DECODER,

--- a/plugins/ffap/ffap.c
+++ b/plugins/ffap/ffap.c
@@ -1905,8 +1905,7 @@ static const char *exts[] = { "ape", NULL };
 
 // define plugin interface
 static DB_decoder_t plugin = {
-    .plugin.api_vmajor = 1,
-    .plugin.api_vminor = 0,
+    DDB_PLUGIN_SET_API_VERSION
     .plugin.version_major = 1,
     .plugin.version_minor = 0,
     .plugin.type = DB_PLUGIN_DECODER,

--- a/plugins/ffmpeg/ffmpeg.c
+++ b/plugins/ffmpeg/ffmpeg.c
@@ -998,8 +998,7 @@ static const char settings_dlg[] =
 
 // define plugin interface
 static DB_decoder_t plugin = {
-    .plugin.api_vmajor = 1,
-    .plugin.api_vminor = 7,
+    DDB_PLUGIN_SET_API_VERSION
     .plugin.version_major = 1,
     .plugin.version_minor = 2,
     .plugin.type = DB_PLUGIN_DECODER,

--- a/plugins/flac/flac.c
+++ b/plugins/flac/flac.c
@@ -1275,8 +1275,7 @@ static const char *exts[] = { "flac", "oga", NULL };
 
 // define plugin interface
 static DB_decoder_t plugin = {
-    .plugin.api_vmajor = 1,
-    .plugin.api_vminor = 7,
+    DDB_PLUGIN_SET_API_VERSION
     .plugin.version_major = 1,
     .plugin.version_minor = 0,
     .plugin.type = DB_PLUGIN_DECODER,

--- a/plugins/gme/cgme.c
+++ b/plugins/gme/cgme.c
@@ -563,8 +563,7 @@ static const char settings_dlg[] =
 
 // define plugin interface
 static DB_decoder_t plugin = {
-    .plugin.api_vmajor = 1,
-    .plugin.api_vminor = 0,
+    DDB_PLUGIN_SET_API_VERSION
     .plugin.version_major = 1,
     .plugin.version_minor = 0,
 //    .plugin.flags = DDB_PLUGIN_FLAG_LOGGING,

--- a/plugins/hotkeys/hotkeys.c
+++ b/plugins/hotkeys/hotkeys.c
@@ -1263,8 +1263,8 @@ hotkeys_get_actions (DB_playItem_t *it)
 
 // define plugin interface
 static DB_hotkeys_plugin_t plugin = {
-    .misc.plugin.api_vmajor = 1,
-    .misc.plugin.api_vminor = 5,
+    .misc.plugin.api_vmajor = DB_API_VERSION_MAJOR,
+    .misc.plugin.api_vminor = DB_API_VERSION_MINOR,
     .misc.plugin.version_major = 1,
     .misc.plugin.version_minor = 1,
     .misc.plugin.type = DB_PLUGIN_MISC,

--- a/plugins/lastfm/lastfm.c
+++ b/plugins/lastfm/lastfm.c
@@ -900,8 +900,7 @@ static const char settings_dlg[] =
 
 // define plugin interface
 static DB_misc_t plugin = {
-    .plugin.api_vmajor = 1,
-    .plugin.api_vminor = 5,
+    DDB_PLUGIN_SET_API_VERSION
     .plugin.version_major = 1,
     .plugin.version_minor = 0,
     .plugin.type = DB_PLUGIN_MISC,

--- a/plugins/m3u/m3u.c
+++ b/plugins/m3u/m3u.c
@@ -623,8 +623,7 @@ m3uplug_save (ddb_playlist_t *plt, const char *fname, DB_playItem_t *first, DB_p
 
 static const char * exts[] = { "m3u", "m3u8", "pls", NULL };
 DB_playlist_t plugin = {
-    .plugin.api_vmajor = 1,
-    .plugin.api_vminor = 0,
+    DDB_PLUGIN_SET_API_VERSION
     .plugin.version_major = 1,
     .plugin.version_minor = 0,
     .plugin.type = DB_PLUGIN_PLAYLIST,

--- a/plugins/medialib/medialib.c
+++ b/plugins/medialib/medialib.c
@@ -415,8 +415,7 @@ typedef struct ddb_medialib_plugin_s {
 
 // define plugin interface
 static ddb_medialib_plugin_t plugin = {
-    .plugin.plugin.api_vmajor = 1,
-    .plugin.plugin.api_vminor = 0,
+    DDB_PLUGIN_SET_API_VERSION
     .plugin.plugin.version_major = 0,
     .plugin.plugin.version_minor = 1,
     .plugin.plugin.type = DB_PLUGIN_MISC,

--- a/plugins/mms/mmsplug.c
+++ b/plugins/mms/mmsplug.c
@@ -170,8 +170,7 @@ mms_abort (DB_FILE *fp) {
 }
 
 static DB_vfs_t plugin = {
-    .plugin.api_vmajor = 1,
-    .plugin.api_vminor = 0,
+    DDB_PLUGIN_SET_API_VERSION
     .plugin.version_major = 1,
     .plugin.version_minor = 0,
     .plugin.type = DB_PLUGIN_VFS,

--- a/plugins/mono2stereo/mono2stereo.c
+++ b/plugins/mono2stereo/mono2stereo.c
@@ -137,8 +137,7 @@ static const char settings_dlg[] =
 ;
 
 static DB_dsp_t plugin = {
-    .plugin.api_vmajor = 1,
-    .plugin.api_vminor = 0,
+    DDB_PLUGIN_SET_API_VERSION
     .open = m2s_open,
     .close = m2s_close,
     .process = m2s_process,

--- a/plugins/mp3/mp3.c
+++ b/plugins/mp3/mp3.c
@@ -1314,8 +1314,7 @@ static const char settings_dlg[] =
 
 // define plugin interface
 static DB_decoder_t plugin = {
-    .plugin.api_vmajor = 1,
-    .plugin.api_vminor = 10, // requires API level 10 for logger and replaygain support
+    DDB_PLUGIN_SET_API_VERSION
     .plugin.version_major = 1,
     .plugin.version_minor = 0,
     .plugin.type = DB_PLUGIN_DECODER,

--- a/plugins/musepack/musepack.c
+++ b/plugins/musepack/musepack.c
@@ -519,8 +519,7 @@ static const char * exts[] = { "mpc", "mpp", "mp+", NULL };
 
 // define plugin interface
 static DB_decoder_t plugin = {
-    .plugin.api_vmajor = 1,
-    .plugin.api_vminor = 0,
+    DDB_PLUGIN_SET_API_VERSION
     .plugin.version_major = 1,
     .plugin.version_minor = 0,
     .plugin.type = DB_PLUGIN_DECODER,

--- a/plugins/notify/notify.c
+++ b/plugins/notify/notify.c
@@ -350,8 +350,7 @@ static const char settings_dlg[] =
 ;
 
 DB_misc_t plugin = {
-    .plugin.api_vmajor = 1,
-    .plugin.api_vminor = 0,
+    DDB_PLUGIN_SET_API_VERSION
     .plugin.type = DB_PLUGIN_MISC,
     .plugin.version_major = 1,
     .plugin.version_minor = 0,

--- a/plugins/nullout/nullout.c
+++ b/plugins/nullout/nullout.c
@@ -196,8 +196,7 @@ nullout_load (DB_functions_t *api) {
 
 // define plugin interface
 static DB_output_t plugin = {
-    .plugin.api_vmajor = 1,
-    .plugin.api_vminor = 0,
+    DDB_PLUGIN_SET_API_VERSION
     .plugin.version_major = 1,
     .plugin.version_minor = 0,
     .plugin.type = DB_PLUGIN_OUTPUT,

--- a/plugins/oss/oss.c
+++ b/plugins/oss/oss.c
@@ -368,8 +368,7 @@ static const char settings_dlg[] =
 
 // define plugin interface
 static DB_output_t plugin = {
-    .plugin.api_vmajor = 1,
-    .plugin.api_vminor = 0,
+    DDB_PLUGIN_SET_API_VERSION
     .plugin.version_major = 1,
     .plugin.version_minor = 0,
     .plugin.type = DB_PLUGIN_OUTPUT,

--- a/plugins/pltbrowser/pltbrowser.c
+++ b/plugins/pltbrowser/pltbrowser.c
@@ -1000,8 +1000,7 @@ static const char pltbrowser_settings_dlg[] =
 ;
 
 static DB_misc_t plugin = {
-    .plugin.api_vmajor = 1,
-    .plugin.api_vminor = 5,
+    DDB_PLUGIN_SET_API_VERSION
     .plugin.version_major = 1,
     .plugin.version_minor = 0,
     .plugin.type = DB_PLUGIN_MISC,

--- a/plugins/psf/plugin.c
+++ b/plugins/psf/plugin.c
@@ -372,8 +372,7 @@ psfplug_stop (void) {
 }
 
 static DB_decoder_t plugin = {
-    .plugin.api_vmajor = 1,
-    .plugin.api_vminor = 0,
+    DDB_PLUGIN_SET_API_VERSION
     .plugin.version_major = 1,
     .plugin.version_minor = 1,
     .plugin.type = DB_PLUGIN_DECODER,

--- a/plugins/pulse/pulse.c
+++ b/plugins/pulse/pulse.c
@@ -359,8 +359,7 @@ static const char settings_dlg[] =
 
 static DB_output_t plugin =
 {
-    .plugin.api_vmajor = 1,
-    .plugin.api_vminor = 0,
+    DDB_PLUGIN_SET_API_VERSION
     .plugin.version_major = 0,
     .plugin.version_minor = 1,
     .plugin.type = DB_PLUGIN_OUTPUT,

--- a/plugins/rg_scanner/rg_scanner.c
+++ b/plugins/rg_scanner/rg_scanner.c
@@ -524,8 +524,8 @@ rg_remove (DB_playItem_t *track) {
 
 // plugin structure and info
 static ddb_rg_scanner_t plugin = {
-    .misc.plugin.api_vmajor = 1,
-    .misc.plugin.api_vminor = 10,
+    .misc.plugin.api_vmajor = DB_API_VERSION_MAJOR,
+    .misc.plugin.api_vminor = DB_API_VERSION_MINOR,
     .misc.plugin.version_major = 1,
     .misc.plugin.version_minor = 0,
     .misc.plugin.flags = DDB_PLUGIN_FLAG_LOGGING,

--- a/plugins/shellexec/shellexec.c
+++ b/plugins/shellexec/shellexec.c
@@ -576,8 +576,8 @@ shx_stop ()
 
 // define plugin interface
 static Shx_plugin_t plugin = {
-    .misc.plugin.api_vmajor = 1,
-    .misc.plugin.api_vminor = 5,
+    .misc.plugin.api_vmajor = DB_API_VERSION_MAJOR,
+    .misc.plugin.api_vminor = DB_API_VERSION_MINOR,
     .misc.plugin.version_major = 1,
     .misc.plugin.version_minor = 2,
     .misc.plugin.type = DB_PLUGIN_MISC,

--- a/plugins/shellexecui/shellexecui.c
+++ b/plugins/shellexecui/shellexecui.c
@@ -407,11 +407,10 @@ int shxui_connect() {
 }
 
 static DB_misc_t plugin = {
-    .plugin.type = DB_PLUGIN_MISC,
-    .plugin.api_vmajor = 1,
-    .plugin.api_vminor = 5,
+    DDB_PLUGIN_SET_API_VERSION
     .plugin.version_major = 1,
     .plugin.version_minor = 0,
+    .plugin.type = DB_PLUGIN_MISC,
 #if GTK_CHECK_VERSION(3,0,0)
     .plugin.id = "shellexecui_gtk3",
     .plugin.name = "Shellexec GTK3 UI",

--- a/plugins/shn/shn.c
+++ b/plugins/shn/shn.c
@@ -1808,8 +1808,7 @@ static const char settings_dlg[] =
 
 // define plugin interface
 static DB_decoder_t plugin = {
-    .plugin.api_vmajor = 1,
-    .plugin.api_vminor = 0,
+    DDB_PLUGIN_SET_API_VERSION
     .plugin.version_major = 1,
     .plugin.version_minor = 0,
     .plugin.type = DB_PLUGIN_DECODER,

--- a/plugins/sid/plugin.c
+++ b/plugins/sid/plugin.c
@@ -30,8 +30,7 @@ static const char settings_dlg[] =
 
 // define plugin interface
 DB_decoder_t sid_plugin = {
-    .plugin.api_vmajor = 1,
-    .plugin.api_vminor = 0,
+    DDB_PLUGIN_SET_API_VERSION
     .plugin.type = DB_PLUGIN_DECODER,
     .plugin.version_major = 1,
     .plugin.version_minor = 0,

--- a/plugins/sndfile/sndfile.c
+++ b/plugins/sndfile/sndfile.c
@@ -579,8 +579,7 @@ static const char settings_dlg[] =
 
 // define plugin interface
 static DB_decoder_t plugin = {
-    .plugin.api_vmajor = 1,
-    .plugin.api_vminor = 0,
+    DDB_PLUGIN_SET_API_VERSION
     .plugin.version_major = 1,
     .plugin.version_minor = 0,
     .plugin.type = DB_PLUGIN_DECODER,

--- a/plugins/soundtouch/plugin.c
+++ b/plugins/soundtouch/plugin.c
@@ -262,8 +262,7 @@ static const char settings_dlg[] =
 ;
 
 static DB_dsp_t plugin = {
-    .plugin.api_vmajor = 1,
-    .plugin.api_vminor = 0,
+    DDB_PLUGIN_SET_API_VERSION
     .open = st_open,
     .close = st_close,
     .process = st_process,

--- a/plugins/statusnotifier/ddb_statusnotifier.c
+++ b/plugins/statusnotifier/ddb_statusnotifier.c
@@ -207,8 +207,8 @@ static const char settings_dlg[] =
 ;
 
 static DB_statusnotifier_plugin_t plugin = {
-    .plugin.plugin.api_vmajor = 1,
-    .plugin.plugin.api_vminor = 8,
+    .plugin.plugin.api_vmajor = DB_API_VERSION_MAJOR,
+    .plugin.plugin.api_vminor = DB_API_VERSION_MINOR,
     .plugin.plugin.version_major = 0,
     .plugin.plugin.version_minor = 1,
     .plugin.plugin.type = DB_PLUGIN_MISC,

--- a/plugins/supereq/supereq.c
+++ b/plugins/supereq/supereq.c
@@ -265,8 +265,7 @@ static const char settings_dlg[] =
 ;
 
 static DB_dsp_t plugin = {
-    .plugin.api_vmajor = 1,
-    .plugin.api_vminor = 0,
+    DDB_PLUGIN_SET_API_VERSION
     .plugin.version_major = 1,
     .plugin.version_minor = 0,
     .plugin.type = DB_PLUGIN_DSP,

--- a/plugins/tta/ttaplug.c
+++ b/plugins/tta/ttaplug.c
@@ -316,8 +316,7 @@ static const char * exts[] = { "tta", NULL };
 
 // define plugin interface
 static DB_decoder_t plugin = {
-    .plugin.api_vmajor = 1,
-    .plugin.api_vminor = 0,
+    DDB_PLUGIN_SET_API_VERSION
     .plugin.version_major = 1,
     .plugin.version_minor = 0,
     .plugin.type = DB_PLUGIN_DECODER,

--- a/plugins/v2m/v2mplug.cpp
+++ b/plugins/v2m/v2mplug.cpp
@@ -246,8 +246,8 @@ extern "C" DB_plugin_t *
 v2m_load (DB_functions_t *api) {
     deadbeef = api;
 
-    v2m_plugin.plugin.api_vmajor = 1;
-    v2m_plugin.plugin.api_vminor = 0;
+    v2m_plugin.plugin.api_vmajor = DB_API_VERSION_MAJOR;
+    v2m_plugin.plugin.api_vminor = DB_API_VERSION_MINOR;
     v2m_plugin.plugin.type = DB_PLUGIN_DECODER;
     v2m_plugin.plugin.version_major = 1;
     v2m_plugin.plugin.version_minor = 0;

--- a/plugins/vfs_curl/vfs_curl.c
+++ b/plugins/vfs_curl/vfs_curl.c
@@ -1126,8 +1126,7 @@ static const char settings_dlg[] =
 ;
 
 static DB_vfs_t plugin = {
-    .plugin.api_vmajor = 1,
-    .plugin.api_vminor = 0,
+    DDB_PLUGIN_SET_API_VERSION
     .plugin.version_major = 1,
     .plugin.version_minor = 0,
     .plugin.type = DB_PLUGIN_VFS,

--- a/plugins/vfs_zip/vfs_zip.c
+++ b/plugins/vfs_zip/vfs_zip.c
@@ -323,8 +323,7 @@ vfs_zip_get_scheme_for_name (const char *fname) {
 }
 
 static DB_vfs_t plugin = {
-    .plugin.api_vmajor = 1,
-    .plugin.api_vminor = 6,
+    DDB_PLUGIN_SET_API_VERSION
     .plugin.version_major = 1,
     .plugin.version_minor = 0,
     .plugin.type = DB_PLUGIN_VFS,

--- a/plugins/vtx/vtx.c
+++ b/plugins/vtx/vtx.c
@@ -312,8 +312,7 @@ static const char settings_dlg[] =
 
 // define plugin interface
 static DB_decoder_t plugin = {
-    .plugin.api_vmajor = 1,
-    .plugin.api_vminor = 0,
+    DDB_PLUGIN_SET_API_VERSION
     .plugin.version_major = 1,
     .plugin.version_minor = 0,
     .plugin.type = DB_PLUGIN_DECODER,

--- a/plugins/wavpack/wavpack.c
+++ b/plugins/wavpack/wavpack.c
@@ -413,8 +413,7 @@ wv_write_metadata (DB_playItem_t *it) {
 static const char *exts[] = { "wv", NULL };
 // define plugin interface
 static DB_decoder_t plugin = {
-    .plugin.api_vmajor = 1,
-    .plugin.api_vminor = 0,
+    DDB_PLUGIN_SET_API_VERSION
     .plugin.version_major = 1,
     .plugin.version_minor = 0,
     .plugin.type = DB_PLUGIN_DECODER,

--- a/plugins/wildmidi/wildmidiplug.c
+++ b/plugins/wildmidi/wildmidiplug.c
@@ -220,8 +220,7 @@ static const char settings_dlg[] =
 ;
 // define plugin interface
 DB_decoder_t wmidi_plugin = {
-    .plugin.api_vmajor = 1,
-    .plugin.api_vminor = 0,
+    DDB_PLUGIN_SET_API_VERSION
     .plugin.type = DB_PLUGIN_DECODER,
     .plugin.version_major = 1,
     .plugin.version_minor = 0,

--- a/plugins/wma/wma_plugin.c
+++ b/plugins/wma/wma_plugin.c
@@ -461,8 +461,7 @@ static const char * exts[] = { "wma", NULL };
 
 // define plugin interface
 static DB_decoder_t plugin = {
-    .plugin.api_vmajor = 1,
-    .plugin.api_vminor = 7,
+    DDB_PLUGIN_SET_API_VERSION
     .plugin.version_major = 1,
     .plugin.version_minor = 0,
     .plugin.type = DB_PLUGIN_DECODER,


### PR DESCRIPTION
Sets plugins api for all plugins to `DB_API_VERSION_MAJOR` & `DB_API_VERSION_MINOR` or uses `DDB_PLUGIN_SET_API_VERSION` if possible.