### PR TITLE
streamer: fix signalling of DB_EV_PAUSED

### DIFF
--- a/streamer.c
+++ b/streamer.c
@@ -2148,7 +2148,7 @@ _play_track (playItem_t *it, int startpaused) {
         else {
             int st = output->state();
             output->play ();
-            if (st == OUTPUT_STATE_PAUSED) {
+            if (st == OUTPUT_STATE_PAUSED || st == OUTPUT_STATE_STOPPED) {
                 messagepump_push(DB_EV_PAUSED, 0, 0, 0);
             }
         }


### PR DESCRIPTION
I just wanted to get the ball rolling on this.

Turns out there is no guarantee that `st` is always `OUTPUT_STATE_PAUSED` here if not playing which means that `DB_EV_PAUSED` is not signalled which breaks certain things like the spectrum vis which then doesn't start drawing on playback. Even if something externally doesn't rely on just `DB_EV_PAUSE` events like musical sprectrum which also hooks `DB_EV_STOP` it seems to fail to start the vis when deadbeef resumes playback on startup. This quick fix resolves those issues for me.
