### PR TITLE
gtkui: move wingeom_restore call after window_init_hooks

### DIFF
--- a/plugins/gtkui/gtkui.c
+++ b/plugins/gtkui/gtkui.c
@@ -1276,7 +1276,6 @@ gtkui_mainwin_init(void) {
         gtk_window_set_icon_from_file (GTK_WINDOW (mainwin), iconpath, NULL);
     }
 
-    wingeom_restore (mainwin, "mainwin", 40, 40, 500, 300, 0);
 
     gtkui_on_configchanged (NULL);
 
@@ -1315,6 +1314,7 @@ gtkui_mainwin_init(void) {
     for (int i = 0; i < window_init_hooks_count; i++) {
         window_init_hooks[i].callback (window_init_hooks[i].userdata);
     }
+    wingeom_restore (mainwin, "mainwin", 40, 40, 500, 300, 0);
     gtk_widget_show (mainwin);
 
     init_widget_layout ();


### PR DESCRIPTION
this is to account for the client side decoration added by my headerbar plugin so window is positioned correctly
it also makes more sense to have this right before gtk_widget_show