### PR TITLE
po: Fix pl.po.

### DIFF
--- a/po/pl.po
+++ b/po/pl.po
@@ -2341,8 +2341,8 @@ msgstr "Przewiń 5 sekund do tyłu"
 
 #: ../translation/plugins.c:176
 #, c-format
-msgid "Seek 1% Forward"
-msgstr "Przewiń o 1% do przodu"
+msgid "Seek 1%% Forward"
+msgstr "Przewiń o 1%% do przodu"
 
 #: ../translation/plugins.c:177
 msgid "Seek 1% Backward"
@@ -2350,8 +2350,8 @@ msgstr "Przewiń o 1% do tyłu"
 
 #: ../translation/plugins.c:178
 #, c-format
-msgid "Seek 5% Forward"
-msgstr "Przewiń o 5% do przodu"
+msgid "Seek 5%% Forward"
+msgstr "Przewiń o 5%% do przodu"
 
 #: ../translation/plugins.c:179
 msgid "Seek 5% Backward"


### PR DESCRIPTION
I noticed that with `msgfmt -c` the `po/pl.po` file has two errors. I think the correct way to fix them is with two percentage signs to make it literal. At least `msgfmt -c` no longer complains.

The current error:
```
$ msgfmt -c po/pl.po 
po/pl.po:2345: format specifications in 'msgid' and 'msgstr' for argument 1 are not the same
po/pl.po:2354: format specifications in 'msgid' and 'msgstr' for argument 1 are not the same
msgfmt: found 2 fatal errors
```
Reference: https://www.gnu.org/software/gettext/manual/html_node/gcc_002dinternal_002dformat.html#gcc_002dinternal_002dformat