### PR TITLE
Makefile.am: Fix distcheck.

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -69,6 +69,6 @@ docs_DATA = README help.txt about.txt translators.txt ChangeLog\
 desktopdir = $(datadir)/applications
 desktop_DATA = deadbeef.desktop
 
-EXTRA_DIST = $(docs_DATA) $(desktop_DATA) $(INTLTOOL_FILES) translation/extra.c sj_to_unicode.h examples/decoder_template.c examples/dsp_template.c yasmwrapper.sh
+EXTRA_DIST = $(docs_DATA) $(desktop_DATA) $(INTLTOOL_FILES) translation/extra.c translation/plugins.c sj_to_unicode.h examples/decoder_template.c examples/dsp_template.c yasmwrapper.sh
 
 ACLOCAL_AMFLAGS = -I m4


### PR DESCRIPTION
Fixes the following issue with `make distcheck`.
```
Making check in po
make[2]: Entering directory '/tmp/deadbeef/deadbeef-devel/_build/sub/po'
make[2]: *** No rule to make target '../../../translation/plugins.c', needed by 'deadbeef.pot'.  Stop.
make[2]: Leaving directory '/tmp/deadbeef/deadbeef-devel/_build/sub/po'
make[1]: *** [Makefile:906: check-recursive] Error 1
make[1]: Leaving directory '/tmp/deadbeef/deadbeef-devel/_build/sub'
make: *** [Makefile:1119: distcheck] Error 1
```
Now `distcheck` succeeds for me.