### PR TITLE
Move from deprecated function get_plugin_dir()

### DIFF
--- a/deadbeef.h
+++ b/deadbeef.h
@@ -694,6 +694,7 @@ typedef struct {
     // system folders
     // normally functions will return standard folders derived from --prefix
     // portable version will return pathes specified in comments below
+    // DEPRECATED IN API LEVEL 8, use get_system_dir instead
     const char *(*get_config_dir) (void) DEPRECATED_18; // installdir/config | $XDG_CONFIG_HOME/.config/deadbeef
     const char *(*get_prefix) (void) DEPRECATED_18; // installdir | PREFIX
     const char *(*get_doc_dir) (void) DEPRECATED_18; // installdir/doc | DOCDIR

--- a/plugins.c
+++ b/plugins.c
@@ -972,7 +972,7 @@ plug_load_all (void) {
 
     background_jobs_mutex = mutex_create ();
 
-    const char *dirname = deadbeef->get_plugin_dir ();
+    const char *dirname = plug_get_system_dir (DDB_SYS_DIR_PLUGIN);
 
     // remember how many plugins to skip if called Nth time
     plugin_t *prev_plugins_tail = plugins_tail;


### PR DESCRIPTION
Switch from deprecated `get_plugin_dir` to `get_system_dir` in plugins.c. Additionally navigate to this function in `deadbeef.h`.