### PR TITLE
Move fopen out of pl_lock in decoders

### DIFF
--- a/junklib.c
+++ b/junklib.c
@@ -4982,9 +4982,7 @@ error:
         free (buffer);
     }
     if (!err) {
-        pl_lock ();
         rename (tmppath, fname);
-        pl_unlock ();
     }
     else {
         unlink (tmppath);

--- a/plugins/aac/aac.c
+++ b/plugins/aac/aac.c
@@ -27,6 +27,7 @@
 #include <stdlib.h>
 #include <math.h>
 #include "../../deadbeef.h"
+#include "../../strdupa.h"
 #include "aac_parser.h"
 
 #include "mp4ff.h"
@@ -294,8 +295,9 @@ aac_init (DB_fileinfo_t *_info, DB_playItem_t *it) {
     aac_info_t *info = (aac_info_t *)_info;
 
     deadbeef->pl_lock ();
-    info->file = deadbeef->fopen (deadbeef->pl_find_meta (it, ":URI"));
+    const char *uri = strdupa (deadbeef->pl_find_meta (it, ":URI"));
     deadbeef->pl_unlock ();
+    info->file = deadbeef->fopen (uri);
     if (!info->file) {
         return -1;
     }

--- a/plugins/adplug/adplug-db.cpp
+++ b/plugins/adplug/adplug-db.cpp
@@ -25,6 +25,7 @@
 #include <string.h>
 #include <stdlib.h>
 #include "../../deadbeef.h"
+#include "../../strdupa.h"
 #include "adplug.h"
 #include "emuopl.h"
 #include "kemuopl.h"
@@ -95,10 +96,11 @@ adplug_init (DB_fileinfo_t *_info, DB_playItem_t *it) {
         }
     }
     deadbeef->pl_lock ();
-    info->decoder = CAdPlug::factory (deadbeef->pl_find_meta (it, ":URI"), info->opl, CAdPlug::players);
+    const char *uri = strdupa (deadbeef->pl_find_meta (it, ":URI"));
     deadbeef->pl_unlock ();
+    info->decoder = CAdPlug::factory (uri, info->opl, CAdPlug::players);
     if (!info->decoder) {
-        trace ("adplug: failed to open %s\n", deadbeef->pl_find_meta (it, ":URI"));
+        trace ("adplug: failed to open %s\n", uri);
         return -1;
     }
 

--- a/plugins/alac/alac_plugin.c
+++ b/plugins/alac/alac_plugin.c
@@ -34,6 +34,7 @@
 #include <stdio.h>
 #include <unistd.h>
 #include <fcntl.h>
+#include "../../strdupa.h"
 
 #define USE_MP4FF 1
 
@@ -226,8 +227,9 @@ alacplug_init (DB_fileinfo_t *_info, DB_playItem_t *it) {
     alacplug_info_t *info = (alacplug_info_t *)_info;
 
     deadbeef->pl_lock ();
-    info->file = deadbeef->fopen (deadbeef->pl_find_meta (it, ":URI"));
+    const char *uri = strdupa (deadbeef->pl_find_meta (it, ":URI"));
     deadbeef->pl_unlock ();
+    info->file = deadbeef->fopen (uri);
     if (!info->file) {
         return -1;
     }

--- a/plugins/dca/dcaplug.c
+++ b/plugins/dca/dcaplug.c
@@ -25,6 +25,7 @@
 #  include <config.h>
 #endif
 #include "../../deadbeef.h"
+#include "../../strdupa.h"
 #include "dca.h"
 #include "gettimeofday.h"
 
@@ -405,10 +406,11 @@ dts_init (DB_fileinfo_t *_info, DB_playItem_t *it) {
     ddb_dca_state_t *info = (ddb_dca_state_t *)_info;
 
     deadbeef->pl_lock ();
-    info->file = deadbeef->fopen (deadbeef->pl_find_meta (it, ":URI"));
+    const char *uri = strdupa (deadbeef->pl_find_meta (it, ":URI"));
     deadbeef->pl_unlock ();
+    info->file = deadbeef->fopen (uri);
     if (!info->file) {
-        trace ("dca: failed to open %s\n", deadbeef->pl_find_meta (it, ":URI"));
+        trace ("dca: failed to open %s\n", uri);
         return -1;
     }
 

--- a/plugins/dumb/cdumb.c
+++ b/plugins/dumb/cdumb.c
@@ -31,6 +31,7 @@
 #include "internal/it.h"
 #include "modloader.h"
 #include "../../deadbeef.h"
+#include "../../strdupa.h"
 
 //#define trace(...) { fprintf(stderr, __VA_ARGS__); }
 #define trace(fmt,...)
@@ -76,19 +77,17 @@ cdumb_init (DB_fileinfo_t *_info, DB_playItem_t *it) {
     trace ("cdumb_init %s\n", deadbeef->pl_find_meta (it, ":URI"));
     dumb_info_t *info = (dumb_info_t *)_info;
 
-	int is_dos, is_it, is_ptcompat;
-	deadbeef->pl_lock ();
-    {
-        const char *uri = deadbeef->pl_find_meta (it, ":URI");
-        const char *ext = uri + strlen (uri) - 1;
-        while (*ext != '.' && ext > uri) {
-            ext--;
-        }
-        ext++;
-        const char *ftype;
-        info->duh = g_open_module (uri, &is_it, &is_dos, &is_ptcompat, 0, &ftype);
-    }
+    int is_dos, is_it, is_ptcompat;
+    deadbeef->pl_lock ();
+    const char *uri = strdupa(deadbeef->pl_find_meta (it, ":URI"));
     deadbeef->pl_unlock ();
+    const char *ext = uri + strlen (uri) - 1;
+    while (*ext != '.' && ext > uri) {
+        ext--;
+    }
+    ext++;
+    const char *ftype;
+    info->duh = g_open_module (uri, &is_it, &is_dos, &is_ptcompat, 0, &ftype);
 
     dumb_it_do_initial_runthrough (info->duh);
 
@@ -327,12 +326,11 @@ cdumb_read_metadata (DB_playItem_t *it) {
     int is_ptcompat;
 
     deadbeef->pl_lock ();
-    {
-        const char *fname = deadbeef->pl_find_meta (it, ":URI");
-        const char *ftype;
-        duh = g_open_module(fname, &is_it, &is_dos, &is_ptcompat, 0, &ftype);
-    }
+    const char *fname = strdupa(deadbeef->pl_find_meta (it, ":URI"));
     deadbeef->pl_unlock ();
+    const char *ftype;
+    duh = g_open_module(fname, &is_it, &is_dos, &is_ptcompat, 0, &ftype);
+
     if (!duh) {
         unload_duh (duh);
         return -1;

--- a/plugins/ffap/ffap.c
+++ b/plugins/ffap/ffap.c
@@ -38,6 +38,7 @@
 #include <assert.h>
 #include <math.h>
 #include "../../deadbeef.h"
+#include "../../strdupa.h"
 
 #ifdef TARGET_ANDROID
 int posix_memalign (void **memptr, size_t alignment, size_t size) {
@@ -701,8 +702,9 @@ ffap_init (DB_fileinfo_t *_info, DB_playItem_t *it)
     ape_info_t *info = (ape_info_t*)_info;
 
     deadbeef->pl_lock ();
-    info->fp = deadbeef->fopen (deadbeef->pl_find_meta (it, ":URI"));
+    const char *uri = strdupa (deadbeef->pl_find_meta (it, ":URI"));
     deadbeef->pl_unlock ();
+    info->fp = deadbeef->fopen (uri);
     if (!info->fp) {
         return -1;
     }
@@ -1855,8 +1857,9 @@ ffap_seek (DB_fileinfo_t *_info, float seconds) {
 
 static int ffap_read_metadata (DB_playItem_t *it) {
     deadbeef->pl_lock ();
-    DB_FILE *fp = deadbeef->fopen (deadbeef->pl_find_meta (it, ":URI"));
+    const char *uri = strdupa (deadbeef->pl_find_meta (it, ":URI"));
     deadbeef->pl_unlock ();
+    DB_FILE *fp = deadbeef->fopen (uri);
     if (!fp) {
         return -1;
     }

--- a/plugins/flac/flac.c
+++ b/plugins/flac/flac.c
@@ -277,11 +277,12 @@ cflac_open2 (uint32_t hints, DB_playItem_t *it) {
     }
 
     deadbeef->pl_lock();
-    info->file = deadbeef->fopen(deadbeef->pl_find_meta(it, ":URI"));
-    if (!info->file) {
-        trace("cflac_open2 failed to open file %s\n", deadbeef->pl_find_meta(it, ":URI"));
-    }
+    const char *uri = strdupa (deadbeef->pl_find_meta (it, ":URI"));
     deadbeef->pl_unlock();
+    info->file = deadbeef->fopen(uri);
+    if (!info->file) {
+        trace("cflac_open2 failed to open file %s\n", uri);
+    }
 
     return (DB_fileinfo_t *)info;
 }
@@ -293,10 +294,11 @@ cflac_init (DB_fileinfo_t *_info, DB_playItem_t *it) {
 
     if (!info->file) {
         deadbeef->pl_lock ();
-        info->file = deadbeef->fopen (deadbeef->pl_find_meta (it, ":URI"));
+	const char *uri = strdupa (deadbeef->pl_find_meta (it, ":URI"));
         deadbeef->pl_unlock ();
+        info->file = deadbeef->fopen (uri);
         if (!info->file) {
-            trace ("cflac_init failed to open file %s\n", deadbeef->pl_find_meta(it, ":URI"));
+            trace ("cflac_init failed to open file %s\n", uri);
             return -1;
         }
     }
@@ -1006,8 +1008,9 @@ cflac_read_metadata (DB_playItem_t *it) {
         return -1;
     }
     deadbeef->pl_lock ();
-    DB_FILE *file = deadbeef->fopen (deadbeef->pl_find_meta (it, ":URI"));
+    const char *uri = strdupa (deadbeef->pl_find_meta (it, ":URI"));
     deadbeef->pl_unlock ();
+    DB_FILE *file = deadbeef->fopen (uri);
     if (!file) {
         return -1;
     }

--- a/plugins/gme/cgme.c
+++ b/plugins/gme/cgme.c
@@ -32,6 +32,7 @@
 #include "gme/gme.h"
 #include <zlib.h>
 #include "../../deadbeef.h"
+#include "../../strdupa.h"
 #if HAVE_SYS_CDEFS_H
 #include <sys/cdefs.h>
 #endif
@@ -185,45 +186,39 @@ cgme_init (DB_fileinfo_t *_info, DB_playItem_t *it) {
 
     gme_err_t res = "gme uninitialized";
     deadbeef->pl_lock ();
-    {
-        const char *fname = deadbeef->pl_find_meta (it, ":URI");
-        char *buffer;
-        int sz;
-        if (!read_gzfile (fname, &buffer, &sz)) {
-            res = gme_open_data (buffer, sz, &info->emu, samplerate);
-            free (buffer);
-        }
-        if (res) {
-            DB_FILE *f = deadbeef->fopen (fname);
-            if (!f) {
-                deadbeef->pl_unlock ();
-                return -1;
-            }
-            int64_t sz = deadbeef->fgetlength (f);
-            if (sz <= 0) {
-                deadbeef->fclose (f);
-                deadbeef->pl_unlock ();
-                return -1;
-            }
-            char *buf = malloc (sz);
-            if (!buf) {
-                deadbeef->fclose (f);
-                deadbeef->pl_unlock ();
-                return -1;
-            }
-            int64_t rb = deadbeef->fread (buf, 1, sz, f);
-            deadbeef->fclose(f);
-            if (rb != sz) {
-                free (buf);
-                deadbeef->pl_unlock ();
-                return -1;
-            }
-
-            res = gme_open_data (buf, sz, &info->emu, samplerate);
-            free (buf);
-        }
-    }
+    const char *fname = strdupa(deadbeef->pl_find_meta (it, ":URI"));
     deadbeef->pl_unlock ();
+    char *buffer;
+    int sz;
+    if (!read_gzfile (fname, &buffer, &sz)) {
+        res = gme_open_data (buffer, sz, &info->emu, samplerate);
+        free (buffer);
+    }
+    if (res) {
+        DB_FILE *f = deadbeef->fopen (fname);
+        if (!f) {
+            return -1;
+        }
+        int64_t sz = deadbeef->fgetlength (f);
+        if (sz <= 0) {
+            deadbeef->fclose (f);
+            return -1;
+        }
+        char *buf = malloc (sz);
+        if (!buf) {
+            deadbeef->fclose (f);
+            return -1;
+        }
+        int64_t rb = deadbeef->fread (buf, 1, sz, f);
+        deadbeef->fclose(f);
+        if (rb != sz) {
+            free (buf);
+            return -1;
+        }
+
+        res = gme_open_data (buf, sz, &info->emu, samplerate);
+        free (buf);
+    }
 
     if (res) {
         trace ("failed with error %d\n", res);

--- a/plugins/mp3/mp3.c
+++ b/plugins/mp3/mp3.c
@@ -29,6 +29,7 @@
 #include <unistd.h>
 #include <sys/time.h>
 #include "../../deadbeef.h"
+#include "../../strdupa.h"
 #include "mp3.h"
 #ifdef USE_LIBMAD
 #include "mp3_mad.h"
@@ -807,8 +808,9 @@ cmp3_init (DB_fileinfo_t *_info, DB_playItem_t *it) {
     _info->plugin = &plugin;
     memset (&info->buffer, 0, sizeof (info->buffer));
     deadbeef->pl_lock ();
-    info->buffer.file = deadbeef->fopen (deadbeef->pl_find_meta (it, ":URI"));
+    const char *uri = strdupa (deadbeef->pl_find_meta (it, ":URI"));
     deadbeef->pl_unlock ();
+    info->buffer.file = deadbeef->fopen (uri);
     if (!info->buffer.file) {
         return -1;
     }
@@ -1241,8 +1243,9 @@ cmp3_insert (ddb_playlist_t *plt, DB_playItem_t *after, const char *fname) {
 int
 cmp3_read_metadata (DB_playItem_t *it) {
     deadbeef->pl_lock ();
-    DB_FILE *fp = deadbeef->fopen (deadbeef->pl_find_meta (it, ":URI"));
+    const char *uri = strdupa (deadbeef->pl_find_meta (it, ":URI"));
     deadbeef->pl_unlock ();
+    DB_FILE *fp = deadbeef->fopen (uri);
     if (!fp) {
         return -1;
     }

--- a/plugins/musepack/musepack.c
+++ b/plugins/musepack/musepack.c
@@ -33,6 +33,7 @@
 #  include <config.h>
 #endif
 #include "../../deadbeef.h"
+#include "../../strdupa.h"
 
 #define min(x,y) ((x)<(y)?(x):(y))
 #define max(x,y) ((x)>(y)?(x):(y))
@@ -105,8 +106,9 @@ musepack_init (DB_fileinfo_t *_info, DB_playItem_t *it) {
     info->reader.canseek = musepack_vfs_canseek;
 
     deadbeef->pl_lock ();
-    DB_FILE *fp = deadbeef->fopen (deadbeef->pl_find_meta (it, ":URI"));
+    const char *uri = strdupa (deadbeef->pl_find_meta (it, ":URI"));
     deadbeef->pl_unlock ();
+    DB_FILE *fp = deadbeef->fopen (uri);
     if (!fp) {
         return -1;
     }
@@ -476,8 +478,9 @@ musepack_insert (ddb_playlist_t *plt, DB_playItem_t *after, const char *fname) {
 
 static int musepack_read_metadata (DB_playItem_t *it) {
     deadbeef->pl_lock ();
-    DB_FILE *fp = deadbeef->fopen (deadbeef->pl_find_meta (it, ":URI"));
+    const char *uri = strdupa (deadbeef->pl_find_meta (it, ":URI"));
     deadbeef->pl_unlock ();
+    DB_FILE *fp = deadbeef->fopen (uri);
     if (!fp) {
         return -1;
     }

--- a/plugins/opus/opus.c
+++ b/plugins/opus/opus.c
@@ -103,8 +103,9 @@ opusdec_open (uint32_t hints) {
 static DB_fileinfo_t *
 opusdec_open2 (uint32_t hints, DB_playItem_t *it) {
     deadbeef->pl_lock ();
-    DB_FILE *fp = deadbeef->fopen (deadbeef->pl_find_meta (it, ":URI"));
+    const char *uri = strdupa (deadbeef->pl_find_meta (it, ":URI"));
     deadbeef->pl_unlock ();
+    DB_FILE *fp = deadbeef->fopen (uri);
 
     if (!fp) {
         return NULL;
@@ -253,8 +254,9 @@ opusdec_init (DB_fileinfo_t *_info, DB_playItem_t *it) {
 
     if (!info->info.file) {
         deadbeef->pl_lock ();
-        DB_FILE *fp = deadbeef->fopen (deadbeef->pl_find_meta (it, ":URI"));
+	const char *uri = strdupa (deadbeef->pl_find_meta (it, ":URI"));
         deadbeef->pl_unlock ();
+        DB_FILE *fp = deadbeef->fopen (uri);
 
         if (!fp) {
             return -1;
@@ -568,8 +570,9 @@ opusdec_read_metadata (DB_playItem_t *it) {
     const OpusHead *head = NULL;
 
     deadbeef->pl_lock ();
-    fp = deadbeef->fopen (deadbeef->pl_find_meta (it, ":URI"));
+    const char *uri = strdupa (deadbeef->pl_find_meta (it, ":URI"));
     deadbeef->pl_unlock ();
+    fp = deadbeef->fopen (uri);
     if (!fp) {
         goto error;
     }

--- a/plugins/psf/plugin.c
+++ b/plugins/psf/plugin.c
@@ -19,6 +19,7 @@
 #include <stdlib.h>
 #include <string.h>
 #include "../../deadbeef.h"
+#include "../../strdupa.h"
 #include "ao.h"
 #include "eng_protos.h"
 
@@ -66,8 +67,9 @@ psfplug_init (DB_fileinfo_t *_info, DB_playItem_t *it) {
     info->duration = deadbeef->pl_get_item_duration (it);
 
     deadbeef->pl_lock ();
-    DB_FILE *file = deadbeef->fopen (deadbeef->pl_find_meta (it, ":URI"));
+    const char *uri = strdupa (deadbeef->pl_find_meta (it, ":URI"));
     deadbeef->pl_unlock ();
+    DB_FILE *file = deadbeef->fopen (uri);
     if (!file) {
         trace ("psf: failed to fopen %s\n", deadbeef->pl_find_meta (it, ":URI"));
         return -1;

--- a/plugins/sc68/in_sc68.c
+++ b/plugins/sc68/in_sc68.c
@@ -25,6 +25,7 @@
 #include <stdlib.h>
 #include <limits.h>
 #include "../../deadbeef.h"
+#include "../../strdupa.h"
 #include "sc68/sc68.h"
 
 #define trace(...) { fprintf(stderr, __VA_ARGS__); }
@@ -67,9 +68,9 @@ in_sc68_init (DB_fileinfo_t *_info, DB_playItem_t *it) {
 
     // Load an sc68 file.
     deadbeef->pl_lock ();
-    const char *fname = deadbeef->pl_find_meta (it, ":URI");
-    int res = sc68_load_uri(info->sc68, fname);
+    const char *fname = strdupa (deadbeef->pl_find_meta (it, ":URI"));
     deadbeef->pl_unlock ();
+    int res = sc68_load_uri(info->sc68, fname);
 
     if (res) {
         return -1;
@@ -296,9 +297,9 @@ in_sc68_read_metadata (DB_playItem_t *it) {
 
     // Load an sc68 file.
     deadbeef->pl_lock ();
-    const char *fname = deadbeef->pl_find_meta (it, ":URI");
-    int res = sc68_load_uri (sc68, fname);
+    const char *fname = strdupa (deadbeef->pl_find_meta (it, ":URI"));
     deadbeef->pl_unlock ();
+    int res = sc68_load_uri (sc68, fname);
 
     if (res) {
         return -1;

--- a/plugins/shn/shn.c
+++ b/plugins/shn/shn.c
@@ -31,6 +31,7 @@
 #include <math.h>
 #include "shorten.h"
 #include "../../deadbeef.h"
+#include "../../strdupa.h"
 #include "bitshift.h"
 
 //#define trace(...) { fprintf(stderr, __VA_ARGS__); }
@@ -330,10 +331,11 @@ shn_init(DB_fileinfo_t *_info, DB_playItem_t *it) {
     DB_FILE *f;
 
     deadbeef->pl_lock ();
-	f = deadbeef->fopen (deadbeef->pl_find_meta (it, ":URI"));
-	deadbeef->pl_unlock ();
+    const char *uri = strdupa (deadbeef->pl_find_meta (it, ":URI"));
+    deadbeef->pl_unlock ();
+    f = deadbeef->fopen (uri);
     if (!f) {
-        trace ("shn: failed to open %s\n", deadbeef->pl_find_meta (it, ":URI"));
+        trace ("shn: failed to open %s\n", uri);
         return -1;
     }
 

--- a/plugins/sid/csid.cpp
+++ b/plugins/sid/csid.cpp
@@ -29,6 +29,7 @@
 // #include "sidplay/sidendian.h"
 
 #include "../../deadbeef.h"
+#include "../../strdupa.h"
 #include "csid.h"
 
 extern DB_decoder_t sid_plugin;
@@ -303,8 +304,9 @@ csid_init (DB_fileinfo_t *_info, DB_playItem_t *it) {
     // libsidplay crashes if file doesn't exist
     // so i have to check it here
     deadbeef->pl_lock ();
-    DB_FILE *fp = deadbeef->fopen (deadbeef->pl_find_meta (it, ":URI"));
+    const char *uri = strdupa (deadbeef->pl_find_meta (it, ":URI"));
     deadbeef->pl_unlock ();
+    DB_FILE *fp = deadbeef->fopen (uri);
     if (!fp ){
         return -1;
     }

--- a/plugins/sndfile/sndfile.c
+++ b/plugins/sndfile/sndfile.c
@@ -27,6 +27,7 @@
 #include <math.h>
 #include <stdlib.h>
 #include "../../deadbeef.h"
+#include "../../strdupa.h"
 
 #define min(x,y) ((x)<(y)?(x):(y))
 #define max(x,y) ((x)>(y)?(x):(y))
@@ -163,10 +164,11 @@ sndfile_init (DB_fileinfo_t *_info, DB_playItem_t *it) {
 
     SF_INFO inf;
     deadbeef->pl_lock ();
-    DB_FILE *fp = deadbeef->fopen (deadbeef->pl_find_meta (it, ":URI"));
+    const char *uri = strdupa (deadbeef->pl_find_meta (it, ":URI"));
     deadbeef->pl_unlock ();
+    DB_FILE *fp = deadbeef->fopen (uri);
     if (!fp) {
-        trace ("sndfile: failed to open %s\n", deadbeef->pl_find_meta (it, ":URI"));
+        trace ("sndfile: failed to open %s\n", uri);
         return -1;
     }
     int64_t fsize = deadbeef->fgetlength (fp);

--- a/plugins/tta/ttaplug.c
+++ b/plugins/tta/ttaplug.c
@@ -71,20 +71,18 @@ tta_init (DB_fileinfo_t *_info, DB_playItem_t *it) {
     tta_info_t *info = (tta_info_t *)_info;
 
     deadbeef->pl_lock ();
-    const char *fname = deadbeef->pl_find_meta (it, ":URI")
+    const char *fname = strdupa (deadbeef->pl_find_meta (it, ":URI"));
+    deadbeef->pl_unlock ();
     trace ("open_tta_file %s\n", fname);
     if (open_tta_file (fname, &info->tta, 0) != 0) {
-        deadbeef->pl_unlock ();
         fprintf (stderr, "tta: failed to open %s\n", fname);
         return -1;
     }
 
     if (player_init (&info->tta) != 0) {
-        deadbeef->pl_unlock ();
         fprintf (stderr, "tta: failed to init player for %s\n", fname);
         return -1;
     }
-    deadbeef->pl_unlock ();
 
     _info->fmt.bps = info->tta.BPS;
     _info->fmt.channels = info->tta.NCH;
@@ -251,8 +249,9 @@ tta_insert (ddb_playlist_t *plt, DB_playItem_t *after, const char *fname) {
 
 static int tta_read_metadata (DB_playItem_t *it) {
     deadbeef->pl_lock ();
-    DB_FILE *fp = deadbeef->fopen (deadbeef->pl_find_meta (it, ":URI"));
+    const char *uri = strdupa (deadbeef->pl_find_meta (it, ":URI"));
     deadbeef->pl_unlock ();
+    DB_FILE *fp = deadbeef->fopen (uri);
     if (!fp) {
         return -1;
     }

--- a/plugins/tta/ttaplug.c
+++ b/plugins/tta/ttaplug.c
@@ -35,6 +35,7 @@
 #  include <config.h>
 #endif
 #include "../../deadbeef.h"
+#include "../../strdupa.h"
 
 #define min(x,y) ((x)<(y)?(x):(y))
 #define max(x,y) ((x)>(y)?(x):(y))

--- a/plugins/vorbis/vorbis.c
+++ b/plugins/vorbis/vorbis.c
@@ -237,11 +237,12 @@ cvorbis_open2 (uint32_t hints, DB_playItem_t *it) {
     }
 
     deadbeef->pl_lock();
-    info->info.file = deadbeef->fopen(deadbeef->pl_find_meta (it, ":URI"));
-    if (!info->info.file) {
-        trace("cvorbis_open2 failed to open file %s\n", deadbeef->pl_find_meta(it, ":URI"));
-    }
+    const char *uri = strdupa (deadbeef->pl_find_meta (it, ":URI"));
     deadbeef->pl_unlock();
+    info->info.file = deadbeef->fopen(uri);
+    if (!info->info.file) {
+        trace("cvorbis_open2 failed to open file %s\n", uri);
+    }
 
     return &info->info;
 }
@@ -255,10 +256,11 @@ cvorbis_init (DB_fileinfo_t *_info, DB_playItem_t *it) {
 
     if (!info->info.file) {
         deadbeef->pl_lock ();
-        info->info.file = deadbeef->fopen (deadbeef->pl_find_meta (it, ":URI"));
+	const char *uri = strdupa (deadbeef->pl_find_meta (it, ":URI"));
         deadbeef->pl_unlock ();
+        info->info.file = deadbeef->fopen (uri);
         if (!info->info.file) {
-            trace ("cvorbis_init failed to open file %s\n", deadbeef->pl_find_meta (it, ":URI"));
+            trace ("cvorbis_init failed to open file %s\n", uri);
             return -1;
         }
     }
@@ -656,14 +658,15 @@ cvorbis_read_metadata (DB_playItem_t *it) {
     vorbis_info *vi = NULL;
 
     deadbeef->pl_lock ();
-    fp = deadbeef->fopen (deadbeef->pl_find_meta (it, ":URI"));
+    const char *uri = strdupa (deadbeef->pl_find_meta (it, ":URI"));
     deadbeef->pl_unlock ();
+    fp = deadbeef->fopen (uri);
     if (!fp) {
-        trace ("cvorbis_read_metadata: failed to fopen %s\n", deadbeef->pl_find_meta (it, ":URI"));
+        trace ("cvorbis_read_metadata: failed to fopen %s\n", uri);
         return -1;
     }
     if (fp->vfs->is_streaming ()) {
-        trace ("cvorbis_read_metadata: failed to fopen %s\n", deadbeef->pl_find_meta (it, ":URI"));
+        trace ("cvorbis_read_metadata: failed to fopen %s\n", uri);
         return -1;
     }
     ov_callbacks ovcb = {
@@ -680,7 +683,7 @@ cvorbis_read_metadata (DB_playItem_t *it) {
     int tracknum = deadbeef->pl_find_meta_int (it, ":TRACKNUM", -1);
     vi = ov_info (&vorbis_file, tracknum);
     if (!vi) {
-        trace ("cvorbis_read_metadata: failed to ov_open %s\n", deadbeef->pl_find_meta (it, ":URI"));
+        trace ("cvorbis_read_metadata: failed to ov_open %s\n", uri);
         ov_clear (&vorbis_file);
         return -1;
     }

--- a/plugins/vtx/vtx.c
+++ b/plugins/vtx/vtx.c
@@ -26,6 +26,7 @@
 #include <stdlib.h>
 #include <string.h>
 #include "../../deadbeef.h"
+#include "../../strdupa.h"
 #include "ayemu.h"
 
 #define min(x,y) ((x)<(y)?(x):(y))
@@ -69,10 +70,11 @@ vtx_init (DB_fileinfo_t *_info, DB_playItem_t *it) {
     char *buf = NULL;
 
     deadbeef->pl_lock ();
-    DB_FILE *fp = deadbeef->fopen (deadbeef->pl_find_meta (it, ":URI"));
+    const char *uri = strdupa (deadbeef->pl_find_meta (it, ":URI"));
     deadbeef->pl_unlock ();
+    DB_FILE *fp = deadbeef->fopen (uri);
     if (!fp) {
-        trace ("vtx: failed to open file %s\n", deadbeef->pl_find_meta (it, ":URI"));
+        trace ("vtx: failed to open file %s\n", uri);
         return -1;
     }
 

--- a/plugins/wavpack/wavpack.c
+++ b/plugins/wavpack/wavpack.c
@@ -37,6 +37,7 @@
 #include <stdlib.h>
 #include <math.h>
 #include "../../deadbeef.h"
+#include "../../strdupa.h"
 
 #define min(x,y) ((x)<(y)?(x):(y))
 #define max(x,y) ((x)>(y)?(x):(y))
@@ -126,8 +127,9 @@ static int
 wv_init (DB_fileinfo_t *_info, DB_playItem_t *it) {
     wvctx_t *info = (wvctx_t *)_info;
     deadbeef->pl_lock ();
-    info->file = deadbeef->fopen (deadbeef->pl_find_meta (it, ":URI"));
+    const char *uri = strdupa (deadbeef->pl_find_meta (it, ":URI"));
     deadbeef->pl_unlock ();
+    info->file = deadbeef->fopen (uri);
     if (!info->file) {
         return -1;
     }
@@ -138,13 +140,14 @@ wv_init (DB_fileinfo_t *_info, DB_playItem_t *it) {
     char *c_fname = alloca (strlen (uri) + 2);
     if (c_fname) {
         strcpy (c_fname, uri);
+        deadbeef->pl_unlock ();
         strcat (c_fname, "c");
         info->c_file = deadbeef->fopen (c_fname);
     }
     else {
+        deadbeef->pl_unlock ();
         fprintf (stderr, "wavpack warning: failed to alloc memory for correction file name\n");
     }
-    deadbeef->pl_unlock ();
 #endif
 
     char error[80];
@@ -376,8 +379,9 @@ wv_insert (ddb_playlist_t *plt, DB_playItem_t *after, const char *fname) {
 int
 wv_read_metadata (DB_playItem_t *it) {
     deadbeef->pl_lock ();
-    DB_FILE *fp = deadbeef->fopen (deadbeef->pl_find_meta (it, ":URI"));
+    const char *uri = strdupa (deadbeef->pl_find_meta (it, ":URI"));
     deadbeef->pl_unlock ();
+    DB_FILE *fp = deadbeef->fopen (uri);
     if (!fp) {
         return -1;
     }

--- a/plugins/wavpack/wavpack.c
+++ b/plugins/wavpack/wavpack.c
@@ -136,7 +136,7 @@ wv_init (DB_fileinfo_t *_info, DB_playItem_t *it) {
 
 #ifndef TINYWV
     deadbeef->pl_lock ();
-    const char *uri = deadbeef->pl_find_meta (it, ":URI");
+    uri = deadbeef->pl_find_meta (it, ":URI");
     char *c_fname = alloca (strlen (uri) + 2);
     if (c_fname) {
         strcpy (c_fname, uri);

--- a/plugins/wildmidi/wildmidiplug.c
+++ b/plugins/wildmidi/wildmidiplug.c
@@ -30,6 +30,7 @@
 #include <stdlib.h>
 #include <string.h>
 #include "../../deadbeef.h"
+#include "../../strdupa.h"
 #include "wildmidi_lib.h"
 #ifdef HAVE_CONFIG_H
 #include "../../config.h"
@@ -70,10 +71,11 @@ wmidi_init (DB_fileinfo_t *_info, DB_playItem_t *it) {
     wmidi_info_t *info = (wmidi_info_t *)_info;
 
     deadbeef->pl_lock ();
-    info->m = WildMidi_Open (deadbeef->pl_find_meta (it, ":URI"));
+    const char *uri = strdupa (deadbeef->pl_find_meta (it, ":URI"));
     deadbeef->pl_unlock ();
+    info->m = WildMidi_Open (uri);
     if (!info->m) {
-        trace ("wmidi: failed to open %s\n", deadbeef->pl_find_meta (it, ":URI"));
+        trace ("wmidi: failed to open %s\n", uri);
         return -1;
     }
 

--- a/shared/mp4tagutil.c
+++ b/shared/mp4tagutil.c
@@ -26,6 +26,7 @@
 #include <fcntl.h>
 #include "mp4tagutil.h"
 #include "mp4ff.h"
+#include "../strdupa.h"
 
 #ifndef __linux__
 #define off64_t off_t
@@ -94,8 +95,9 @@ static const char *metainfo[] = {
 int
 mp4_write_metadata (DB_playItem_t *it) {
     deadbeef->pl_lock ();
-    DB_FILE *fp = deadbeef->fopen (deadbeef->pl_find_meta (it, ":URI"));
+    const char *uri = strdupa (deadbeef->pl_find_meta (it, ":URI"));
     deadbeef->pl_unlock ();
+    DB_FILE *fp = deadbeef->fopen (uri);
 
     if (!fp) {
         return -1;
@@ -128,8 +130,9 @@ mp4_write_metadata (DB_playItem_t *it) {
     }
 
     deadbeef->pl_lock ();
-    int fd_out = open (deadbeef->pl_find_meta (it, ":URI"), O_LARGEFILE | O_RDWR);
+    uri = strdupa (deadbeef->pl_find_meta (it, ":URI"));
     deadbeef->pl_unlock ();
+    int fd_out = open (uri, O_LARGEFILE | O_RDWR);
 
     mp4ff_callback_t write_cb = {
         .read = stdio_read,
@@ -291,8 +294,9 @@ mp4_read_metadata_file (DB_playItem_t *it, DB_FILE *fp) {
 int
 mp4_read_metadata (DB_playItem_t *it) {
     deadbeef->pl_lock ();
-    DB_FILE *fp = deadbeef->fopen (deadbeef->pl_find_meta (it, ":URI"));
+    const char *uri = strdupa (deadbeef->pl_find_meta (it, ":URI"));
     deadbeef->pl_unlock ();
+    DB_FILE *fp = deadbeef->fopen (uri);
     if (!fp) {
         return -1;
     }

--- a/strdupa.h
+++ b/strdupa.h
@@ -31,8 +31,8 @@
     ({									      \
       const char *old = (s);					      \
       size_t len = strlen (old) + 1;				      \
-      char *new = (char *) alloca (len);			      \
-      (char *) memcpy (new, old, len);				      \
+      char *newstr = (char *) alloca (len);			      \
+      (char *) memcpy (newstr, old, len);				      \
     })
 #endif
 


### PR DESCRIPTION
fix #2034 

I have a question, why WMA (and v2m) decoder doesn't use pl_lock when calling pl_find_meta function while the others do?