### PR TITLE
Implement subgroups for GTK

### DIFF
--- a/plugins/gtkui/ddblistview.c
+++ b/plugins/gtkui/ddblistview.c
@@ -922,8 +922,7 @@ ddb_listview_list_render_subgroup (DdbListview *listview, cairo_t *cr, GdkRectan
             subgroup_title_offset = subgroup_artwork_offset;
         }
         else {
-            // TODO: Configurable
-            subgroup_title_offset = title_offset + 10;
+            subgroup_title_offset = title_offset + listview->subgroup_title_padding;
         }
 
         if (grp->subgroups) {
@@ -968,7 +967,7 @@ ddb_listview_list_render (DdbListview *listview, cairo_t *cr, GdkRectangle *clip
     int cursor_index = listview->binding->cursor();
 
     // Calculate which side of the playlist the (first) album art cover is on to tell where to draw subgroup titles
-    int subgroup_artwork_offset = 10;
+    int subgroup_artwork_offset = listview->subgroup_title_padding;
     int x = 0;
     for (DdbListviewColumn *c = listview->columns; c; x += c->width, c = c->next) {
         if (listview->binding->is_album_art_column(c->user_data)) {

--- a/plugins/gtkui/ddblistview.c
+++ b/plugins/gtkui/ddblistview.c
@@ -723,7 +723,7 @@ ddb_listview_list_pickpoint_subgroup (DdbListview *listview, DdbListviewGroup *g
                 pick_ctx->grp_idx = 0;
                 return 1;
             }
-            if (is_album_art_column) {
+            if (is_album_art_column && group_level == listview->artwork_subgroup_level) {
                 pick_ctx->type = PICK_ALBUM_ART;
                 pick_ctx->item_grp_idx = idx;
                 pick_ctx->grp_idx = min ((y - grp_title_height) / rowheight, grp->num_items - 1);

--- a/plugins/gtkui/ddblistview.c
+++ b/plugins/gtkui/ddblistview.c
@@ -3433,7 +3433,7 @@ build_groups (DdbListview *listview) {
     // groups
     if (listview->grouptitle_height) {
         DdbListviewGroup *last_group[group_depth];
-        char group_titles[group_depth][1024];
+        char (*group_titles)[1024] = malloc(sizeof(char[1024]) * group_depth);
         DdbListviewGroup *grp = listview->groups;
         // populate all subgroups from the first item
         for (int i = 0; i < group_depth; i++) {
@@ -3484,6 +3484,7 @@ build_groups (DdbListview *listview) {
                 full_height += height;
             }
         }
+        free(group_titles);
     }
     // no groups fast path
     else {

--- a/plugins/gtkui/ddblistview.c
+++ b/plugins/gtkui/ddblistview.c
@@ -1565,11 +1565,23 @@ ddb_listview_list_render_row_foreground (DdbListview *ps, cairo_t *cr, DdbListvi
 static void
 ddb_listview_list_render_album_art (DdbListview *ps, cairo_t *cr, DdbListviewGroup *grp, int pinned, int grp_next_y, int y, GdkRectangle *clip) {
     int x = -ps->hscrollpos;
+    int min_y;
+    if (pinned) {
+        if (grp->group_label_visible) {
+            min_y = ps->grouptitle_height;
+        }
+        else {
+            min_y = 0;
+        }
+    }
+    else {
+        min_y = y;
+    }
     for (DdbListviewColumn *c = ps->columns; c && x < clip->x+clip->width; x += c->width, c = c->next) {
         if (ps->binding->is_album_art_column(c->user_data) && x + c->width > clip->x) {
             fill_list_background(ps, cr, x, y, c->width, grp->height-ps->grouptitle_height, clip);
             if (ps->grouptitle_height > 0) {
-                ps->binding->draw_album_art(ps, cr, grp->head, c->user_data, pinned, grp_next_y, x, y, c->width, grp->height-ps->grouptitle_height);
+                ps->binding->draw_album_art(ps, cr, grp->head, c->user_data, min_y, grp_next_y, x, y, c->width, grp->height-ps->grouptitle_height);
             }
         }
     }

--- a/plugins/gtkui/ddblistview.c
+++ b/plugins/gtkui/ddblistview.c
@@ -3385,27 +3385,32 @@ new_group (DdbListview *listview, DdbListviewIter it, int group_label_visible) {
     return grp;
 }
 
-static int
-calc_subgroup_visible_titles(DdbListviewGroup *grp) {
-    int count = 0;
+static void
+calc_subgroup_extra_spacing(DdbListviewGroup *grp, int *visible_titles, int *spacing_count) {
     DdbListviewGroup *next = grp;
     while (next) {
         if (next->subgroups) {
-            count += calc_subgroup_visible_titles(next->subgroups);
+            calc_subgroup_extra_spacing(next->subgroups, visible_titles, spacing_count);
         }
         if (next->group_label_visible) {
-            count++;
+            (*visible_titles)++;
+        }
+        if (next->next) {
+            (*spacing_count)++;
         }
         next = next->next;
     }
-    return count;
 }
 
 static int
 calc_group_height(DdbListview *listview, DdbListviewGroup *grp, int min_height, int is_last) {
-    // if we have subgroups, account for their headers
+    int visible_titles = 0;
+    int spacing_count = 0;
+    // if we have subgroups, account for their headers and spacing
+    calc_subgroup_extra_spacing(grp->subgroups, &visible_titles, &spacing_count);
     grp->height = max(grp->num_items * listview->rowheight, min_height);
-    grp->height += calc_subgroup_visible_titles(grp->subgroups) * listview->grouptitle_height;
+    grp->height += visible_titles * listview->grouptitle_height;
+    grp->height += spacing_count * gtkui_groups_spacing;
     if (grp->group_label_visible) {
         grp->height += listview->grouptitle_height;
     }

--- a/plugins/gtkui/ddblistview.c
+++ b/plugins/gtkui/ddblistview.c
@@ -3426,29 +3426,27 @@ build_groups (DdbListview *listview) {
             int make_new_group_offset = -1;
             for (int i = 0; i < group_depth; i++) {
                 char next_title[1024];
-                last_group[i]->num_items++;
                 listview->binding->get_group(listview, it, next_title, sizeof(next_title), i);
                 if (strcmp (group_titles[i], next_title)) {
                     make_new_group_offset = i;
                     break;
                 }
+                last_group[i]->num_items++;
             }
             if (make_new_group_offset >= 0) {
                 // finish remaining groups
                 // must be done in reverse order so heights are calculated correctly
                 for (int i = group_depth - 1; i >= make_new_group_offset; i--) {
                     char next_title[1024];
+                    last_group[i]->num_items++;
                     listview->binding->get_group(listview, it, next_title, sizeof(next_title), i);
-                    DdbListviewGroup *new_grp = it ? new_group(listview, it, next_title[0] != 0) : NULL;
-                    if (i == make_new_group_offset) {
-                        last_group[i]->next = new_grp;
-                    }
-                    else {
-                        last_group[i]->num_items++;
-                    }
                     int height = calc_group_height (listview, last_group[i], i == listview->artwork_subgroup_level ? min_height : min_no_artwork_height, !(it > 0));
                     if (i == 0) {
                         full_height += height;
+                    }
+                    DdbListviewGroup *new_grp = it ? new_group(listview, it, next_title[0] != 0) : NULL;
+                    if (i == make_new_group_offset) {
+                        last_group[i]->next = new_grp;
                     }
                     last_group[i] = new_grp;
                     if (last_group[i] && i < group_depth - 1) {

--- a/plugins/gtkui/ddblistview.c
+++ b/plugins/gtkui/ddblistview.c
@@ -1188,7 +1188,9 @@ invalidate_group (DdbListview *ps, int at_y)
     }
 
     int group_titles_height = group->group_label_visible ? ps->grouptitle_height : 0;
-    group_titles_height += find_subgroup_title_heights(ps, group->subgroups, next_group_y - group->height, at_y);
+    if (group->subgroups) {
+        group_titles_height += find_subgroup_title_heights(ps, group->subgroups, next_group_y - group->height, at_y);
+    }
 
     int group_height = next_group_y - at_y;
     if (next_group_y > at_y) {

--- a/plugins/gtkui/ddblistview.c
+++ b/plugins/gtkui/ddblistview.c
@@ -3325,7 +3325,8 @@ build_groups (DdbListview *listview) {
                 else {
                     if (strcmp(group_titles[i], next_title)) {
                         full_height += calc_group_height (listview, last_group[i], min_height, !(it > 0));
-                        last_group[i] = it ? new_subgroup(listview) : NULL;
+                        last_group[i]->next = it ? new_subgroup(listview) : NULL;
+                        last_group[i] = last_group[i]->next;
                         strcpy (group_titles[i], next_title);
                         new_group = 1;
                         if (i == group_depth-1) {
@@ -3344,6 +3345,11 @@ build_groups (DdbListview *listview) {
             }
             it = next_playitem(listview, it);
         }
+        // calculate final group heights
+        for (int i = group_depth - 1; i >= 0; i--) {
+            full_height += calc_group_height (listview, last_group[i], min_height, 1);
+        }
+
         free(last_group);
         free(group_titles);
     }

--- a/plugins/gtkui/ddblistview.c
+++ b/plugins/gtkui/ddblistview.c
@@ -880,13 +880,11 @@ fill_list_background (DdbListview *listview, cairo_t *cr, int x, int y, int w, i
     render_treeview_background(listview, cr, FALSE, TRUE, x, y, w, h, clip);
 }
 
-static int
+static void
 ddb_listview_list_render_subgroup (DdbListview *listview, cairo_t *cr, GdkRectangle *clip, DdbListviewGroup *grp, int idx, int grp_y, const int cursor_index, const int current_group_depth, int title_offset, const int subgroup_artwork_offset, const int pin_offset) {
     const int scrollx = -listview->hscrollpos;
     const int row_height = listview->rowheight;
     const int total_width = listview->totalwidth;
-
-    int subgroup_pinned_height = 0;
 
     // find 1st group
     while (grp && grp_y + grp->height < clip->y) {
@@ -925,7 +923,7 @@ ddb_listview_list_render_subgroup (DdbListview *listview, cairo_t *cr, GdkRectan
 
         if (grp->subgroups) {
             // render subgroups before album art and titles
-            subgroup_pinned_height += ddb_listview_list_render_subgroup(listview, cr, clip, grp->subgroups, idx, grp_y + title_height, cursor_index, current_group_depth + 1, subgroup_title_offset, subgroup_artwork_offset, pin_offset + title_height);
+            ddb_listview_list_render_subgroup(listview, cr, clip, grp->subgroups, idx, grp_y + title_height, cursor_index, current_group_depth + 1, subgroup_title_offset, subgroup_artwork_offset, pin_offset + title_height);
         }
 
         int grp_next_y = grp_y + grp->height;
@@ -934,7 +932,7 @@ ddb_listview_list_render_subgroup (DdbListview *listview, cairo_t *cr, GdkRectan
             int min_y;
             if (is_pinned) {
                 if (grp->group_label_visible) {
-                    min_y = min(title_height+pin_offset, grp_next_y-subgroup_pinned_height);
+                    min_y = min(title_height+pin_offset, grp_next_y);
                 }
             }
             else {
@@ -945,12 +943,11 @@ ddb_listview_list_render_subgroup (DdbListview *listview, cairo_t *cr, GdkRectan
 
         if (is_pinned && clip->y <= title_height + pin_offset) {
             // draw pinned group title
-            int y = min(pin_offset, grp_next_y-title_height-subgroup_pinned_height);
+            int y = min(pin_offset, grp_next_y-title_height);
             fill_list_background(listview, cr, scrollx, y, total_width, title_height, clip);
             if (listview->binding->draw_group_title && title_height > 0) {
                 listview->binding->draw_group_title(listview, cr, grp->head, title_offset, y, total_width-title_offset, title_height, current_group_depth);
             }
-            subgroup_pinned_height += title_height;
         }
         else if (clip->y <= grp_y + title_height) {
             // draw normal group title
@@ -963,8 +960,6 @@ ddb_listview_list_render_subgroup (DdbListview *listview, cairo_t *cr, GdkRectan
         grp_y += grp->height;
         grp = grp->next;
     }
-
-    return subgroup_pinned_height;
 }
 
 static void

--- a/plugins/gtkui/ddblistview.c
+++ b/plugins/gtkui/ddblistview.c
@@ -3428,16 +3428,16 @@ build_groups (DdbListview *listview) {
                 for (int i = group_depth - 1; i >= make_new_group_offset; i--) {
                     char next_title[1024];
                     listview->binding->get_group(listview, it, next_title, sizeof(next_title), i);
-                    int height = calc_group_height (listview, last_group[i], i == listview->artwork_subgroup_level ? min_height : min_no_artwork_height, !(it > 0));
-                    if (i == 0) {
-                        full_height += height;
-                    }
                     DdbListviewGroup *new_grp = it ? new_group(listview, it, next_title[0] != 0) : NULL;
                     if (i == make_new_group_offset) {
                         last_group[i]->next = new_grp;
                     }
                     else {
                         last_group[i]->num_items++;
+                    }
+                    int height = calc_group_height (listview, last_group[i], i == listview->artwork_subgroup_level ? min_height : min_no_artwork_height, !(it > 0));
+                    if (i == 0) {
+                        full_height += height;
                     }
                     last_group[i] = new_grp;
                     if (last_group[i] && i < group_depth - 1) {

--- a/plugins/gtkui/ddblistview.c
+++ b/plugins/gtkui/ddblistview.c
@@ -946,7 +946,7 @@ ddb_listview_list_render_subgroup (DdbListview *listview, cairo_t *cr, GdkRectan
         if (is_pinned && clip->y <= title_height + pin_offset) {
             // draw pinned group title
             int y = min(pin_offset, grp_next_y-title_height-subgroup_pinned_height);
-            fill_list_background(listview, cr, scrollx+title_offset, y, total_width-title_offset, title_height, clip);
+            fill_list_background(listview, cr, scrollx, y, total_width, title_height, clip);
             if (listview->binding->draw_group_title && title_height > 0) {
                 listview->binding->draw_group_title(listview, cr, grp->head, scrollx+title_offset, y, total_width-title_offset, title_height, current_group_depth);
             }

--- a/plugins/gtkui/ddblistview.c
+++ b/plugins/gtkui/ddblistview.c
@@ -920,7 +920,7 @@ ddb_listview_list_render_subgroup (DdbListview *listview, cairo_t *cr, GdkRectan
             subgroup_title_offset = subgroup_artwork_offset;
         }
         else {
-            subgroup_title_offset = title_offset + listview->subgroup_title_padding;
+            subgroup_title_offset = title_offset + (grp->group_label_visible ? listview->subgroup_title_padding : 0);
         }
 
         if (grp->subgroups) {

--- a/plugins/gtkui/ddblistview.c
+++ b/plugins/gtkui/ddblistview.c
@@ -887,7 +887,6 @@ fill_list_background (DdbListview *listview, cairo_t *cr, int x, int y, int w, i
 static void
 ddb_listview_list_render_subgroup (DdbListview *listview, cairo_t *cr, GdkRectangle *clip, DdbListviewGroup *grp, int cursor_index, int idx, int grp_y, int current_group_depth) {
     const int scrollx = -listview->hscrollpos;
-    const int title_height = grp->group_label_visible ? listview->grouptitle_height : 0;
     const int row_height = listview->rowheight;
     const int total_width = listview->totalwidth;
 
@@ -900,11 +899,7 @@ ddb_listview_list_render_subgroup (DdbListview *listview, cairo_t *cr, GdkRectan
     DdbListviewGroup *pin_grp = gtkui_groups_pinned && grp && grp_y < 0 && grp_y + grp->height >= 0 ? grp : NULL;
 
     while (grp && grp_y < clip->y + clip->height) {
-        int title_height = 0;
-        if (grp->group_label_visible) {
-            title_height = listview->grouptitle_height; 
-        }
-        int grp_height = title_height + grp->num_items * row_height;
+        const int title_height = grp->group_label_visible ? listview->grouptitle_height : 0;
 
         // only render list items when at the deepest group level
         if (!grp->subgroups) {

--- a/plugins/gtkui/ddblistview.c
+++ b/plugins/gtkui/ddblistview.c
@@ -969,6 +969,8 @@ ddb_listview_list_render (DdbListview *listview, cairo_t *cr, GdkRectangle *clip
             // draw pinned group title
             fill_list_background(listview, cr, scrollx, 0, total_width, min(title_height, grp_next_y), clip);
             if (listview->binding->draw_group_title && title_height > 0) {
+                // TODO: make the offset configurable?
+                // ALSO TODO: deal with album art
                 listview->binding->draw_group_title(listview, cr, grp->head, scrollx + 10 * current_group_depth, min(0, grp_next_y-title_height), total_width, title_height, current_group_depth);
             }
         }
@@ -3423,7 +3425,7 @@ build_groups (DdbListview *listview) {
     if (!it) {
         return 0;
     }
-    if (/*!listview->group_formats || */!listview->group_formats->group_format || !listview->group_formats->group_format[0]) {
+    if (!listview->group_formats->group_format || !listview->group_formats->group_format[0]) {
         listview->grouptitle_height = 0;
     }
     else {

--- a/plugins/gtkui/ddblistview.c
+++ b/plugins/gtkui/ddblistview.c
@@ -908,7 +908,7 @@ ddb_listview_list_render (DdbListview *listview, cairo_t *cr, GdkRectangle *clip
     }
 
     // find 1st group/subgroup
-    DdbListviewGroup **grps = alloca(sizeof(DdbListviewGroup *) * group_depth);
+    DdbListviewGroup *grps[group_depth];
     DdbListviewGroup *grp = listview->groups;
     int idx = 0;
     int grp_current_y = -listview->scrollpos;
@@ -3453,8 +3453,8 @@ build_groups (DdbListview *listview) {
     int full_height = 0;
     // groups
     if (listview->grouptitle_height) {
-        DdbListviewGroup **last_group = alloca(sizeof(DdbListviewGroup *) * group_depth);
-        char (*group_titles)[1024] = alloca(sizeof(char[1024]) * group_depth);
+        DdbListviewGroup *last_group[group_depth];
+        char group_titles[group_depth][1024];
         DdbListviewGroup *grp = listview->groups;
         // populate all subgroups from the first item
         for (int i = 0; i < group_depth; i++) {

--- a/plugins/gtkui/ddblistview.c
+++ b/plugins/gtkui/ddblistview.c
@@ -655,11 +655,11 @@ ddb_listview_is_album_art_column (DdbListview *listview, int x)
 // returns Y coordinate of an item by its index
 static int
 ddb_listview_get_row_pos_subgroup (DdbListview *listview, DdbListviewGroup *grp, int y, int idx, int row_idx) {
-    int title_height = 0;
-    if (grp->group_label_visible) {
-        title_height = listview->grouptitle_height;
-    }
     while (grp) {
+        int title_height = 0;
+        if (grp->group_label_visible) {
+            title_height = listview->grouptitle_height;
+        }
         if (idx + grp->num_items > row_idx) {
             int i;
             if (grp->subgroups) {
@@ -706,12 +706,12 @@ static int
 ddb_listview_list_pickpoint_subgroup (DdbListview *listview, DdbListviewGroup *grp, int x, int y, int idx, int grp_y, DdbListviewPickContext *pick_ctx) {
     const int orig_y = y;
     const int ry = y - listview->scrollpos;
-    const int grp_title_height = grp->group_label_visible ? listview->grouptitle_height : 0;
     const int rowheight = listview->rowheight;
     const int is_album_art_column = ddb_listview_is_album_art_column (listview, x);
 
     while (grp) {
         const int h = grp->height;
+        const int grp_title_height = grp->group_label_visible ? listview->grouptitle_height : 0;
         if (y >= grp_y && y < grp_y + h) {
             pick_ctx->grp = grp;
             y -= grp_y;

--- a/plugins/gtkui/ddblistview.h
+++ b/plugins/gtkui/ddblistview.h
@@ -192,6 +192,7 @@ struct _DdbListview {
     ddb_playlist_t *plt; // current playlist (refcounted), must be unreffed with the group
     struct _DdbListviewGroup *groups;
     int artwork_subgroup_level;
+    int subgroup_title_padding;
     int groups_build_idx; // must be the same as playlist modification idx
     int grouptitle_height;
     int calculated_grouptitle_height;

--- a/plugins/gtkui/ddblistview.h
+++ b/plugins/gtkui/ddblistview.h
@@ -191,6 +191,7 @@ struct _DdbListview {
 
     ddb_playlist_t *plt; // current playlist (refcounted), must be unreffed with the group
     struct _DdbListviewGroup *groups;
+    int artwork_subgroup_level;
     int groups_build_idx; // must be the same as playlist modification idx
     int grouptitle_height;
     int calculated_grouptitle_height;

--- a/plugins/gtkui/ddblistview.h
+++ b/plugins/gtkui/ddblistview.h
@@ -54,6 +54,7 @@ typedef void * DdbPlaylistHandle;
 
 struct _DdbListviewGroup {
     DdbListviewIter head;
+    struct _DdbListviewGroup *subgroups;
     int32_t height;
     int32_t num_items;
     int pinned;
@@ -86,7 +87,7 @@ typedef struct {
     void (*select) (DdbListviewIter, int sel);
     int (*is_selected) (DdbListviewIter);
 
-    int (*get_group) (DdbListview *listview, DdbListviewIter it, char *str, int size);
+    int (*get_group) (DdbListview *listview, DdbListviewIter it, char *str, int size, int index);
 
     void (*drag_n_drop) (DdbListviewIter before, DdbPlaylistHandle playlist_from, uint32_t *indices, int length, int copy);
     void (*external_drag_n_drop) (DdbListviewIter before, char *mem, int length);
@@ -117,6 +118,17 @@ typedef struct {
 
 struct _DdbListviewColumn;
 struct _DdbListviewGroup;
+
+struct _DdbListviewGroupFormats {
+    // group format string that's supposed to get parsed by tf
+    char *group_format;
+    // tf bytecode for group title
+    char *group_title_bytecode;
+
+    struct _DdbListviewGroupFormats *next;
+};
+
+typedef struct _DdbListviewGroupFormats DdbListviewGroupFormats;
 
 struct _DdbListview {
     GtkTable parent;
@@ -195,10 +207,7 @@ struct _DdbListview {
     drawctx_t grpctx;
     drawctx_t hdrctx;
 
-    // group format string that's supposed to get parsed by tf
-    char *group_format;
-    // tf bytecode for group title
-    char *group_title_bytecode;
+    DdbListviewGroupFormats *group_formats;
 
     guint tf_redraw_timeout_id;
     int tf_redraw_track_idx;

--- a/plugins/gtkui/ddblistview.h
+++ b/plugins/gtkui/ddblistview.h
@@ -241,15 +241,15 @@ ddb_listview_size_columns_without_scrollbar (DdbListview *listview);
 int
 ddb_listview_column_get_count (DdbListview *listview);
 void
-ddb_listview_column_append (DdbListview *listview, const char *title, int width, int align_right, minheight_cb_t, int min_height_top_group_only, int color_override, GdkColor color, void *user_data);
+ddb_listview_column_append (DdbListview *listview, const char *title, int width, int align_right, minheight_cb_t, int is_artwork, int color_override, GdkColor color, void *user_data);
 void
-ddb_listview_column_insert (DdbListview *listview, int before, const char *title, int width, int align_right, minheight_cb_t, int min_height_top_group_only, int color_override, GdkColor color, void *user_data);
+ddb_listview_column_insert (DdbListview *listview, int before, const char *title, int width, int align_right, minheight_cb_t, int is_artwork, int color_override, GdkColor color, void *user_data);
 void
 ddb_listview_column_remove (DdbListview *listview, int idx);
 int
-ddb_listview_column_get_info (DdbListview *listview, int col, const char **title, int *width, int *align_right, minheight_cb_t *, int *min_height_top_group_only, int *color_override, GdkColor *color, void **user_data);
+ddb_listview_column_get_info (DdbListview *listview, int col, const char **title, int *width, int *align_right, minheight_cb_t *, int *is_artwork, int *color_override, GdkColor *color, void **user_data);
 int
-ddb_listview_column_set_info (DdbListview *listview, int col, const char *title, int width, int align_right, minheight_cb_t, int min_height_top_group_only, int color_override, GdkColor color, void *user_data);
+ddb_listview_column_set_info (DdbListview *listview, int col, const char *title, int width, int align_right, minheight_cb_t, int is_artwork, int color_override, GdkColor color, void *user_data);
 
 // if 'gtkui.sticky_sort' is 1: sort columns by their current sort order
 // otherwise clear sort order

--- a/plugins/gtkui/ddblistview.h
+++ b/plugins/gtkui/ddblistview.h
@@ -119,16 +119,16 @@ typedef struct {
 struct _DdbListviewColumn;
 struct _DdbListviewGroup;
 
-struct _DdbListviewGroupFormats {
+struct _DdbListviewGroupFormat {
     // group format string that's supposed to get parsed by tf
-    char *group_format;
+    char *format;
     // tf bytecode for group title
-    char *group_title_bytecode;
+    char *bytecode;
 
-    struct _DdbListviewGroupFormats *next;
+    struct _DdbListviewGroupFormat *next;
 };
 
-typedef struct _DdbListviewGroupFormats DdbListviewGroupFormats;
+typedef struct _DdbListviewGroupFormat DdbListviewGroupFormat;
 
 struct _DdbListview {
     GtkTable parent;
@@ -209,7 +209,7 @@ struct _DdbListview {
     drawctx_t grpctx;
     drawctx_t hdrctx;
 
-    DdbListviewGroupFormats *group_formats;
+    DdbListviewGroupFormat *group_formats;
 
     guint tf_redraw_timeout_id;
     int tf_redraw_track_idx;

--- a/plugins/gtkui/ddblistview.h
+++ b/plugins/gtkui/ddblistview.h
@@ -57,7 +57,7 @@ struct _DdbListviewGroup {
     struct _DdbListviewGroup *subgroups;
     int32_t height;
     int32_t num_items;
-    int pinned;
+    int group_label_visible;
     struct _DdbListviewGroup *next;
 };
 

--- a/plugins/gtkui/ddblistview.h
+++ b/plugins/gtkui/ddblistview.h
@@ -92,7 +92,7 @@ typedef struct {
     void (*drag_n_drop) (DdbListviewIter before, DdbPlaylistHandle playlist_from, uint32_t *indices, int length, int copy);
     void (*external_drag_n_drop) (DdbListviewIter before, char *mem, int length);
 
-    void (*draw_group_title) (DdbListview *listview, cairo_t *drawable, DdbListviewIter iter, int x, int y, int width, int height);
+    void (*draw_group_title) (DdbListview *listview, cairo_t *drawable, DdbListviewIter iter, int x, int y, int width, int height, int group_depth);
     void (*draw_album_art) (DdbListview *listview, cairo_t *cr, DB_playItem_t *it, void *user_data, int pinned, int next_y, int x, int y, int width, int height);
     void (*draw_column_data) (DdbListview *listview, cairo_t *cr, DdbListviewIter it, int idx, int align, void *user_data, GdkColor *fg_clr, int x, int y, int width, int height, int even);
 
@@ -239,15 +239,15 @@ ddb_listview_size_columns_without_scrollbar (DdbListview *listview);
 int
 ddb_listview_column_get_count (DdbListview *listview);
 void
-ddb_listview_column_append (DdbListview *listview, const char *title, int width, int align_right, minheight_cb_t, int color_override, GdkColor color, void *user_data);
+ddb_listview_column_append (DdbListview *listview, const char *title, int width, int align_right, minheight_cb_t, int min_height_top_group_only, int color_override, GdkColor color, void *user_data);
 void
-ddb_listview_column_insert (DdbListview *listview, int before, const char *title, int width, int align_right, minheight_cb_t, int color_override, GdkColor color, void *user_data);
+ddb_listview_column_insert (DdbListview *listview, int before, const char *title, int width, int align_right, minheight_cb_t, int min_height_top_group_only, int color_override, GdkColor color, void *user_data);
 void
 ddb_listview_column_remove (DdbListview *listview, int idx);
 int
-ddb_listview_column_get_info (DdbListview *listview, int col, const char **title, int *width, int *align_right, minheight_cb_t *, int *color_override, GdkColor *color, void **user_data);
+ddb_listview_column_get_info (DdbListview *listview, int col, const char **title, int *width, int *align_right, minheight_cb_t *, int *min_height_top_group_only, int *color_override, GdkColor *color, void **user_data);
 int
-ddb_listview_column_set_info (DdbListview *listview, int col, const char *title, int width, int align_right, minheight_cb_t, int color_override, GdkColor color, void *user_data);
+ddb_listview_column_set_info (DdbListview *listview, int col, const char *title, int width, int align_right, minheight_cb_t, int min_height_top_group_only, int color_override, GdkColor color, void *user_data);
 
 // if 'gtkui.sticky_sort' is 1: sort columns by their current sort order
 // otherwise clear sort order

--- a/plugins/gtkui/mainplaylist.c
+++ b/plugins/gtkui/mainplaylist.c
@@ -211,7 +211,7 @@ void
 main_playlist_init (GtkWidget *widget) {
     // make listview widget and bind it to data
     DdbListview *listview = DDB_LISTVIEW(widget);
-    pl_common_set_group_format (listview, "gtkui.playlist.group_by_tf", "gtkui.playlist.group_artwork_level");
+    pl_common_set_group_format (listview, "gtkui.playlist.group_by_tf", "gtkui.playlist.group_artwork_level", "gtkui.playlist.subgroup_title_padding");
     main_binding.ref = (void (*) (DdbListviewIter))deadbeef->pl_item_ref;
     main_binding.unref = (void (*) (DdbListviewIter))deadbeef->pl_item_unref;
     main_binding.is_selected = (int (*) (DdbListviewIter))deadbeef->pl_is_selected;

--- a/plugins/gtkui/mainplaylist.c
+++ b/plugins/gtkui/mainplaylist.c
@@ -211,7 +211,7 @@ void
 main_playlist_init (GtkWidget *widget) {
     // make listview widget and bind it to data
     DdbListview *listview = DDB_LISTVIEW(widget);
-    pl_common_set_group_format (listview, "gtkui.playlist.group_by_tf");
+    pl_common_set_group_format (listview, "gtkui.playlist.group_by_tf", "gtkui.playlist.group_artwork_level");
     main_binding.ref = (void (*) (DdbListviewIter))deadbeef->pl_item_ref;
     main_binding.unref = (void (*) (DdbListviewIter))deadbeef->pl_item_unref;
     main_binding.is_selected = (int (*) (DdbListviewIter))deadbeef->pl_is_selected;

--- a/plugins/gtkui/mainplaylist.c
+++ b/plugins/gtkui/mainplaylist.c
@@ -161,9 +161,9 @@ main_draw_column_data (DdbListview *listview, cairo_t *cr, DdbListviewIter it, i
 }
 
 static void
-main_draw_group_title (DdbListview *listview, cairo_t *drawable, DdbListviewIter it, int x, int y, int width, int height)
+main_draw_group_title (DdbListview *listview, cairo_t *drawable, DdbListviewIter it, int x, int y, int width, int height, int group_depth)
 {
-    pl_common_draw_group_title (listview, drawable, it, PL_MAIN, x, y, width, height);
+    pl_common_draw_group_title (listview, drawable, it, PL_MAIN, x, y, width, height, group_depth);
 }
 
 static DdbListviewBinding main_binding = {

--- a/plugins/gtkui/plcommon.c
+++ b/plugins/gtkui/plcommon.c
@@ -2057,17 +2057,17 @@ pl_common_col_sort (int sort_order, int iter, void *user_data) {
 }
 
 void
-pl_common_set_group_format (DdbListview *listview, char *format_conf) {
+pl_common_set_group_format (DdbListview *listview, char *format_conf, char *artwork_level_conf) {
     deadbeef->conf_lock ();
     char *format = strdup (deadbeef->conf_get_str_fast (format_conf, ""));
+    listview->artwork_subgroup_level = deadbeef->conf_get_int (artwork_level_conf, 0);
     deadbeef->conf_unlock ();
     parser_unescape_quoted_string (format);
     listview->group_formats = NULL;
 
-    char *mutable_format = strdup (format);
     char *saveptr;
     // TODO: is this an okay delimiter?
-    char *token = strtok_r(mutable_format, "|", &saveptr);
+    char *token = strtok_r(format, "|", &saveptr);
 
     // always have at least one
     listview->group_formats = calloc(sizeof(DdbListviewGroupFormats), 1);
@@ -2081,7 +2081,6 @@ pl_common_set_group_format (DdbListview *listview, char *format_conf) {
         fmt->group_format = strdup (token);
         fmt->group_title_bytecode = deadbeef->tf_compile (fmt->group_format);
     }
-    free (mutable_format);
 
     free (format);
 }

--- a/plugins/gtkui/plcommon.c
+++ b/plugins/gtkui/plcommon.c
@@ -375,7 +375,7 @@ cover_draw_exact (DB_playItem_t *it, int x, int min_y, int max_y, int width, int
 }
 
 void
-pl_common_draw_album_art (DdbListview *listview, cairo_t *cr, DB_playItem_t *it, void *user_data, int pinned, int next_y, int x, int y, int width, int height) {
+pl_common_draw_album_art (DdbListview *listview, cairo_t *cr, DB_playItem_t *it, void *user_data, int min_y, int next_y, int x, int y, int width, int height) {
     int art_width = width - ART_PADDING_HORZ * 2;
     int art_height = height - ART_PADDING_VERT * 2;
     if (art_width < 8 || art_height < 8 || !it) {
@@ -385,7 +385,7 @@ pl_common_draw_album_art (DdbListview *listview, cairo_t *cr, DB_playItem_t *it,
     col_info_t *info = user_data;
 
     int art_x = x + ART_PADDING_HORZ;
-    int min_y = (pinned ? listview->grouptitle_height : y) + ART_PADDING_VERT;
+    min_y += ART_PADDING_VERT;
     if (info->cover_size == art_width) {
         cover_draw_exact(it, art_x, min_y, next_y, art_width, art_height, cr, user_data);
     }

--- a/plugins/gtkui/plcommon.c
+++ b/plugins/gtkui/plcommon.c
@@ -2057,10 +2057,11 @@ pl_common_col_sort (int sort_order, int iter, void *user_data) {
 }
 
 void
-pl_common_set_group_format (DdbListview *listview, char *format_conf, char *artwork_level_conf) {
+pl_common_set_group_format (DdbListview *listview, char *format_conf, char *artwork_level_conf, char *subgroup_padding_conf) {
     deadbeef->conf_lock ();
     char *format = strdup (deadbeef->conf_get_str_fast (format_conf, ""));
     listview->artwork_subgroup_level = deadbeef->conf_get_int (artwork_level_conf, 0);
+    listview->subgroup_title_padding = deadbeef->conf_get_int (subgroup_padding_conf, 10);
     deadbeef->conf_unlock ();
     parser_unescape_quoted_string (format);
     listview->group_formats = NULL;

--- a/plugins/gtkui/plcommon.c
+++ b/plugins/gtkui/plcommon.c
@@ -1295,7 +1295,7 @@ groups_changed (DdbListview *listview, const char *format)
 
     // TODO: unhardcode these when done testing
     DdbListviewGroupFormats *subgroup = calloc(sizeof(DdbListviewGroupFormats), 1);
-    subgroup->group_format = strdup ("$ifgreater(%discnumber%,1,$if2(%discsubtitle%,Disc %discnumber%),)");
+    subgroup->group_format = strdup ("$ifgreater(%totaldiscs%,1,$if2(%discsubtitle%,Disc %discnumber%),)");
     subgroup->group_title_bytecode = deadbeef->tf_compile (subgroup->group_format);
     listview->group_formats->next = subgroup;
 
@@ -2051,7 +2051,7 @@ pl_common_set_group_format (DdbListview *listview, char *format_conf) {
 
     // TODO: unhardcode these when done testing
     DdbListviewGroupFormats *subgroup = calloc(sizeof(DdbListviewGroupFormats), 0);
-    subgroup->group_format = strdup ("$ifgreater(%discnumber%,1,$if2(%discsubtitle%,Disc %discnumber%),)");
+    subgroup->group_format = strdup ("$ifgreater(%totaldiscs%,1,$if2(%discsubtitle%,Disc %discnumber%),)");
     subgroup->group_title_bytecode = deadbeef->tf_compile (subgroup->group_format);
     listview->group_formats->next = subgroup;
 }

--- a/plugins/gtkui/plcommon.h
+++ b/plugins/gtkui/plcommon.h
@@ -77,7 +77,7 @@ void
 pl_common_free_col_info (void *data);
 
 int
-pl_common_get_group (DdbListview *listview, DdbListviewIter it, char *str, int size);
+pl_common_get_group (DdbListview *listview, DdbListviewIter it, char *str, int size, int index);
 
 void
 pl_common_draw_group_title (DdbListview *listview, cairo_t *drawable, DdbListviewIter it, int iter, int x, int y, int width, int height);

--- a/plugins/gtkui/plcommon.h
+++ b/plugins/gtkui/plcommon.h
@@ -89,7 +89,7 @@ void
 pl_common_col_sort (int sort_order, int iter, void *user_data);
 
 void
-pl_common_set_group_format (DdbListview *listview, char *format_conf, char *artwork_level_conf);
+pl_common_set_group_format (DdbListview *listview, char *format_conf, char *artwork_level_conf, char *subgroup_padding_conf);
 
 // import old playlist configuration from "playlist.%02d" syntax with old title
 // formatting to the new JSON syntax with new title formatting

--- a/plugins/gtkui/plcommon.h
+++ b/plugins/gtkui/plcommon.h
@@ -80,7 +80,7 @@ int
 pl_common_get_group (DdbListview *listview, DdbListviewIter it, char *str, int size, int index);
 
 void
-pl_common_draw_group_title (DdbListview *listview, cairo_t *drawable, DdbListviewIter it, int iter, int x, int y, int width, int height);
+pl_common_draw_group_title (DdbListview *listview, cairo_t *drawable, DdbListviewIter it, int iter, int x, int y, int width, int height, int group_depth);
 
 void
 pl_common_selection_changed (DdbListview *ps, int iter, DB_playItem_t *it);

--- a/plugins/gtkui/plcommon.h
+++ b/plugins/gtkui/plcommon.h
@@ -89,7 +89,7 @@ void
 pl_common_col_sort (int sort_order, int iter, void *user_data);
 
 void
-pl_common_set_group_format (DdbListview *listview, char *format_conf, char *artwork_level_conf, char *subgroup_padding_conf);
+pl_common_set_group_format (DdbListview *listview, const char *format_conf, const char *artwork_level_conf, const char *subgroup_padding_conf);
 
 // import old playlist configuration from "playlist.%02d" syntax with old title
 // formatting to the new JSON syntax with new title formatting

--- a/plugins/gtkui/plcommon.h
+++ b/plugins/gtkui/plcommon.h
@@ -89,7 +89,7 @@ void
 pl_common_col_sort (int sort_order, int iter, void *user_data);
 
 void
-pl_common_set_group_format (DdbListview *listview, char *format_conf);
+pl_common_set_group_format (DdbListview *listview, char *format_conf, char *artwork_level_conf);
 
 // import old playlist configuration from "playlist.%02d" syntax with old title
 // formatting to the new JSON syntax with new title formatting

--- a/plugins/gtkui/plcommon.h
+++ b/plugins/gtkui/plcommon.h
@@ -44,7 +44,7 @@ int
 pl_common_is_album_art_column (void *user_data);
 
 void
-pl_common_draw_album_art (DdbListview *listview, cairo_t *cr, DB_playItem_t *it, void *user_data, int pinned, int next_y, int x, int y, int width, int height);
+pl_common_draw_album_art (DdbListview *listview, cairo_t *cr, DB_playItem_t *it, void *user_data, int min_y, int next_y, int x, int y, int width, int height);
 
 void
 list_context_menu (DdbListview *listview, DdbListviewIter it, int idx, int iter);

--- a/plugins/gtkui/search.c
+++ b/plugins/gtkui/search.c
@@ -654,6 +654,6 @@ search_playlist_init (GtkWidget *mainwin) {
     }
     search_binding.columns_changed = search_columns_changed;
 
-    pl_common_set_group_format (listview, "gtkui.search.group_by_tf");
+    pl_common_set_group_format (listview, "gtkui.search.group_by_tf", "gtkui.search.group_artwork_level");
     window_title_bytecode = deadbeef->tf_compile (_("Search [(%list_total% results)]"));
 }

--- a/plugins/gtkui/search.c
+++ b/plugins/gtkui/search.c
@@ -654,6 +654,6 @@ search_playlist_init (GtkWidget *mainwin) {
     }
     search_binding.columns_changed = search_columns_changed;
 
-    pl_common_set_group_format (listview, "gtkui.search.group_by_tf", "gtkui.search.group_artwork_level");
+    pl_common_set_group_format (listview, "gtkui.search.group_by_tf", "gtkui.search.group_artwork_level", "gtkui.search.subgroup_title_padding");
     window_title_bytecode = deadbeef->tf_compile (_("Search [(%list_total% results)]"));
 }

--- a/plugins/gtkui/search.c
+++ b/plugins/gtkui/search.c
@@ -570,9 +570,9 @@ search_draw_column_data (DdbListview *listview, cairo_t *cr, DdbListviewIter it,
 }
 
 static void
-search_draw_group_title (DdbListview *listview, cairo_t *drawable, DdbListviewIter it, int x, int y, int width, int height)
+search_draw_group_title (DdbListview *listview, cairo_t *drawable, DdbListviewIter it, int x, int y, int width, int height, int group_depth)
 {
-    pl_common_draw_group_title (listview, drawable, it, PL_SEARCH, x, y, width, height);
+    pl_common_draw_group_title (listview, drawable, it, PL_SEARCH, x, y, width, height, group_depth);
 }
 
 void


### PR DESCRIPTION
This is a first pass at implementing #1145. It allows for an arbitrary number of nested groups and allows for formats that allow for groups with empty/invisible titles.

![screenshot from 2018-08-30 22-10-12](https://user-images.githubusercontent.com/1023440/44890908-3f364200-aca2-11e8-9649-8d96c21f2d1f.png)

Current Implementation List:
- [x] Parse groups to make sublists
- [x] Render subgroups correctly
- [x] Detect entries with mouse events correctly with subgroups
- [x] Implement pinning for subgroups - currently gets drawn/written over due to render changes
- [x] Draw artwork correctly - currently gets drawn/written over due to render changes
- [x] Configurable indentation for sublevels
- [x] Draw subgroups with artwork fields correctly - currently does not adjust its position to wrap around it
- [x] Add pinning to all subgroups, not just one

These two will be in a future PR:
- Change the way subgroups are stored in preferences to allow for unique TF sequences per group, not using a delimiting token.
- Make a new "Group By" dialog exposing the new functionality.

Questions:
- ~~How do we want to store subgroups in settings? Right now I pack it into the normal group setting and use a pipe `|` to separate them.~~ **This will be changed to store them as unique strings in settings in a future PR. For the time being, `|||` will be used instead.**
- ~~How do we want pinning to function? Does it pin every subgroup, or only the top-level one?~~ **Changed to allow you to configure which level you want pinned.**
- ~~Same with artwork. Should it only be displayed with the top level group? Or be configurable somehow?~~ **Changed it to display with the configured pinned group.**
- ~~How should we draw subgroups around artwork if the artwork column is not the easy case of being the first or last column?~~ **Added detection of which side of the playlist artwork is on.**