### PR TITLE
Fix scrolling with arrow keys with pinned nested subgroups

### DIFF
--- a/plugins/gtkui/ddblistview.h
+++ b/plugins/gtkui/ddblistview.h
@@ -280,7 +280,7 @@ void
 ddb_listview_clear_sort (DdbListview *listview);
 
 int
-ddb_listview_get_row_pos (DdbListview *listview, int row_idx);
+ddb_listview_get_row_pos (DdbListview *listview, int row_idx, int *accumulated_title_height);
 
 void
 ddb_listview_groupcheck (DdbListview *listview);

--- a/plugins/gtkui/plcommon.c
+++ b/plugins/gtkui/plcommon.c
@@ -914,7 +914,7 @@ popup_menu_position_func (GtkMenu *menu, gint *x, gint *y, gboolean *push_in, gp
     }
     if (it) {
         // get Y position
-        *y = ddb_listview_get_row_pos (lv, idx) + winy;
+        *y = ddb_listview_get_row_pos (lv, idx, NULL) + winy;
         lv->binding->unref (it);
     }
     else {
@@ -1443,7 +1443,7 @@ list_handle_keypress (DdbListview *ps, int keyval, int state, int iter) {
     if (state & GDK_SHIFT_MASK) {
         if (cursor != prev) {
             int newscroll = ps->scrollpos;
-            int cursor_scroll = ddb_listview_get_row_pos (ps, cursor);
+            int cursor_scroll = ddb_listview_get_row_pos (ps, cursor, NULL);
             if (cursor_scroll < ps->scrollpos) {
                 newscroll = cursor_scroll;
             }


### PR DESCRIPTION
A small bug that slipped through the cracks in #2044. When scrolling through a playlist with arrow keys, the playlist scrolling doesn't take the height of nested subgroup labels into account, sometimes hiding the selected track under a pinned label. This fixes the bug by making the whole height of all the subgroups into account for calculating the scroll position.