### PR TITLE
Fix use-after-free bug

### DIFF
--- a/plugins/gtkui/plcommon.c
+++ b/plugins/gtkui/plcommon.c
@@ -1308,7 +1308,7 @@ groups_changed (DdbListview *listview, const char *format)
         free (fmt->format);
         free (fmt->bytecode);
         free (fmt);
-        fmt = fmt->next;
+        fmt = next_fmt;
     }
     listview->group_formats = NULL;
     char *esc_format = parser_escape_string (format);


### PR DESCRIPTION
I scanned the code base with the tool [cppcheck](http://cppcheck.sourceforge.net/), and I discovered one interesting finding:

```
[gtkui/plcommon.c:1311]: (error) Dereferencing 'fmt' after it is deallocated / released
```

Given that a local variable was already declared and pointing to the next element, I assume this dereference is a small mistake that is easily corrected. 
