### PR TITLE
flac/junklib/vorbis/mp4tagutil: format replaygain tags correctly

### DIFF
--- a/junklib.c
+++ b/junklib.c
@@ -149,10 +149,10 @@ static const char *frame_mapping[] = {
 
 // replaygain key names in both id3v2.3+ TXX and APEv2
 static const char *tag_rg_names[] = {
-    "replaygain_album_gain",
-    "replaygain_album_peak",
-    "replaygain_track_gain",
-    "replaygain_track_peak",
+    "REPLAYGAIN_ALBUM_GAIN",
+    "REPLAYGAIN_ALBUM_PEAK",
+    "REPLAYGAIN_TRACK_GAIN",
+    "REPLAYGAIN_TRACK_PEAK",
     NULL
 };
 
@@ -4778,7 +4778,17 @@ junk_rewrite_tags (playItem_t *it, uint32_t junk_flags, int id3v2_version, const
             if (pl_find_meta (it, ddb_internal_rg_keys[n])) {
                 float value = pl_get_item_replaygain (it, n);
                 char s[100];
-                snprintf (s, sizeof (s), "%f", value);
+                // https://wiki.hydrogenaud.io/index.php?title=ReplayGain_2.0_specification#Metadata_format
+                switch (n) {
+                case DDB_REPLAYGAIN_ALBUMGAIN:
+                case DDB_REPLAYGAIN_TRACKGAIN:
+                    snprintf (s, sizeof (s), "%.2f dB", value);
+                    break;
+                case DDB_REPLAYGAIN_ALBUMPEAK:
+                case DDB_REPLAYGAIN_TRACKPEAK:
+                    snprintf (s, sizeof (s), "%.6f", value);
+                    break;
+                }
                 junk_id3v2_add_txxx_frame (&id3v2, tag_rg_names[n], s, strlen (s));
             }
         }
@@ -4913,7 +4923,17 @@ junk_rewrite_tags (playItem_t *it, uint32_t junk_flags, int id3v2_version, const
             if (pl_find_meta (it, ddb_internal_rg_keys[0])) {
                 float value = pl_get_item_replaygain (it, n);
                 char s[100];
-                snprintf (s, sizeof (s), "%f", value);
+                // https://wiki.hydrogenaud.io/index.php?title=ReplayGain_2.0_specification#Metadata_format
+                switch (n) {
+                case DDB_REPLAYGAIN_ALBUMGAIN:
+                case DDB_REPLAYGAIN_TRACKGAIN:
+                    snprintf (s, sizeof (s), "%.2f dB", value);
+                    break;
+                case DDB_REPLAYGAIN_ALBUMPEAK:
+                case DDB_REPLAYGAIN_TRACKPEAK:
+                    snprintf (s, sizeof (s), "%.6f", value);
+                    break;
+                }
                 junk_apev2_add_text_frame (&apev2, tag_rg_names[n], s);
             }
         }

--- a/plugins/flac/flac.c
+++ b/plugins/flac/flac.c
@@ -1214,10 +1214,10 @@ cflac_write_metadata (DB_playItem_t *it) {
     }
 
     static const char *tag_rg_names[] = {
-        "replaygain_album_gain",
-        "replaygain_album_peak",
-        "replaygain_track_gain",
-        "replaygain_track_peak",
+        "REPLAYGAIN_ALBUM_GAIN",
+        "REPLAYGAIN_ALBUM_PEAK",
+        "REPLAYGAIN_TRACK_GAIN",
+        "REPLAYGAIN_TRACK_PEAK",
         NULL
     };
 
@@ -1235,7 +1235,17 @@ cflac_write_metadata (DB_playItem_t *it) {
         if (deadbeef->pl_find_meta (it, ddb_internal_rg_keys[n])) {
             float value = deadbeef->pl_get_item_replaygain (it, n);
             char s[100];
-            snprintf (s, sizeof (s), "%s=%f", tag_rg_names[n], value);
+            // https://wiki.hydrogenaud.io/index.php?title=ReplayGain_2.0_specification#Metadata_format
+            switch (n) {
+            case DDB_REPLAYGAIN_ALBUMGAIN:
+            case DDB_REPLAYGAIN_TRACKGAIN:
+                snprintf (s, sizeof (s), "%s=%.2f dB", tag_rg_names[n], value);
+                break;
+            case DDB_REPLAYGAIN_ALBUMPEAK:
+            case DDB_REPLAYGAIN_TRACKPEAK:
+                snprintf (s, sizeof (s), "%s=%.6f", tag_rg_names[n], value);
+                break;
+            }
             FLAC__StreamMetadata_VorbisComment_Entry ent = {
                 .length = (FLAC__uint32)strlen (s),
                 .entry = (FLAC__byte*)s

--- a/plugins/vorbis/vorbis.c
+++ b/plugins/vorbis/vorbis.c
@@ -731,7 +731,17 @@ tags_list(DB_playItem_t *it, OggVorbis_File *vorbis_file)
         if (deadbeef->pl_find_meta (it, ddb_internal_rg_keys[n])) {
             float value = deadbeef->pl_get_item_replaygain (it, n);
             char s[100];
-            snprintf (s, sizeof (s), "%f", value);
+            // https://wiki.hydrogenaud.io/index.php?title=ReplayGain_2.0_specification#Metadata_format
+            switch (n) {
+            case DDB_REPLAYGAIN_ALBUMGAIN:
+            case DDB_REPLAYGAIN_TRACKGAIN:
+                snprintf (s, sizeof (s), "%.2f dB", value);
+                break;
+            case DDB_REPLAYGAIN_ALBUMPEAK:
+            case DDB_REPLAYGAIN_TRACKPEAK:
+                snprintf (s, sizeof (s), "%.6f", value);
+                break;
+            }
             split_tag (tags, tag_rg_names[n], s, (int)strlen (s)+1);
         }
     }

--- a/shared/mp4tagutil.c
+++ b/shared/mp4tagutil.c
@@ -168,10 +168,10 @@ mp4_write_metadata (DB_playItem_t *it) {
     }
 
     static const char *tag_rg_names[] = {
-        "replaygain_album_gain",
-        "replaygain_album_peak",
-        "replaygain_track_gain",
-        "replaygain_track_peak",
+        "REPLAYGAIN_ALBUM_GAIN",
+        "REPLAYGAIN_ALBUM_PEAK",
+        "REPLAYGAIN_TRACK_GAIN",
+        "REPLAYGAIN_TRACK_PEAK",
         NULL
     };
 
@@ -189,7 +189,17 @@ mp4_write_metadata (DB_playItem_t *it) {
         if (deadbeef->pl_find_meta (it, ddb_internal_rg_keys[n])) {
             float value = deadbeef->pl_get_item_replaygain (it, n);
             char s[100];
-            snprintf (s, sizeof (s), "%f", value);
+            // https://wiki.hydrogenaud.io/index.php?title=ReplayGain_2.0_specification#Metadata_format
+            switch (n) {
+            case DDB_REPLAYGAIN_ALBUMGAIN:
+            case DDB_REPLAYGAIN_TRACKGAIN:
+                snprintf (s, sizeof (s), "%.2f dB", value);
+                break;
+            case DDB_REPLAYGAIN_ALBUMPEAK:
+            case DDB_REPLAYGAIN_TRACKPEAK:
+                snprintf (s, sizeof (s), "%.6f", value);
+                break;
+            }
             mp4ff_tag_add_field (&mp4->tags, tag_rg_names[n], s);
         }
     }


### PR DESCRIPTION
Not all ReplayGain tags are written correctly.

* `REPLAYGAIN_*_GAIN` tags should have two decimal places and have a " dB" suffix.
* `REPLAYGAIN_*_PEAK` tags should have six decimal places.
* Tag keys should be all uppercase.

https://wiki.hydrogenaud.io/index.php?title=ReplayGain_2.0_specification#Metadata_format