### PR TITLE
lastfm: fix scrobbling when skipping tracks and playing the same track

### DIFF
--- a/streamer.c
+++ b/streamer.c
@@ -2158,7 +2158,6 @@ _play_track (playItem_t *it, int startpaused) {
     output->stop ();
     streamer_reset(1);
     streamer_is_buffering = 1;
-    streamer_set_playing_track(NULL);
     streamer_set_buffering_track (it);
     handle_track_change (it);
     if (!stream_track(it, startpaused)) {


### PR DESCRIPTION
Fixes #2075
I attempted to fix both of these problems. Everything works as expected but I am not sure if there are unintended consequences of not setting playing_track to NULL first in _play_track.