### PR TITLE
cocoaui: Shrink album art to fit if it is taller than the reserved space

### DIFF
--- a/plugins/cocoaui/DdbPlaylistViewController.m
+++ b/plugins/cocoaui/DdbPlaylistViewController.m
@@ -801,7 +801,16 @@ static void coverAvailCallback (NSImage *__strong img, void *user_data) {
 
     NSSize size = [image size];
 
-    [image drawInRect:NSMakeRect(art_x, ypos, art_width, size.height / (size.width / art_width))];
+    int render_width = art_width;
+    int render_height = size.height / (size.width / art_width);
+    if (render_height > art_height) {
+        ypos = min_y;
+        render_width = size.width / (size.height / art_height);
+        render_height = art_height;
+        art_x = (width - render_width) / 2;
+    }
+
+    [image drawInRect:NSMakeRect(art_x, ypos, render_width, render_height)];
 }
 
 - (void)selectRow:(DdbListviewRow_t)row withState:(BOOL)state {

--- a/plugins/cocoaui/DdbPlaylistViewController.m
+++ b/plugins/cocoaui/DdbPlaylistViewController.m
@@ -805,8 +805,8 @@ static void coverAvailCallback (NSImage *__strong img, void *user_data) {
     int render_height = size.height / (size.width / art_width);
     if (render_height > art_height) {
         ypos = min_y;
-        render_width = size.width / (size.height / art_height);
-        render_height = art_height;
+        render_width = size.width / (size.height / (grp_next_y - min_y));
+        render_height = (grp_next_y - min_y);
         art_x = (width - render_width) / 2;
     }
 


### PR DESCRIPTION
Attempts to resolve #2095 macOS: album art gets cropped vertically if it is taller than it is wide.

I looked at resizing the groups as the art gets loaded but this required me to invalidate lots of the view each time and worked out *very* slow. If this would be possible in a performant way, I'd prefer to do it however!

As an alternative, try shrinking album art vertically. It's not perfect, but at least all of the art is visible.