### PR TITLE
coreaudio: when picking samplerate, compare to the next nearest, not itself

### DIFF
--- a/plugins/coreaudio/coreaudio.c
+++ b/plugins/coreaudio/coreaudio.c
@@ -113,7 +113,7 @@ get_best_samplerate (int samplerate) {
         int64_t dist = avail_samplerates[i] - samplerate;
 
         if (index == -1
-            || llabs(dist) < llabs(dist)
+            || llabs(dist) < llabs(nearest)
             || (nearest < 0 && dist >= 0 && avail_samplerates[i]>=samplerate)) {
             nearest = dist;
             index = i;


### PR DESCRIPTION
Looks like a simple enough error - this resolves #2101 for me.
