### PR TITLE
Replaygain dialogs enlarged

### DIFF
--- a/plugins/gtkui/deadbeef.glade
+++ b/plugins/gtkui/deadbeef.glade
@@ -10542,7 +10542,7 @@ Descending</property>
 </widget>
 
 <widget class="GtkWindow" id="rg_scan_progress">
-  <property name="width_request">440</property>
+  <property name="width_request">550</property>
   <property name="visible">True</property>
   <property name="title" translatable="yes">ReplayGain Scan Progress</property>
   <property name="type">GTK_WINDOW_TOPLEVEL</property>
@@ -10695,7 +10695,7 @@ Descending</property>
 </widget>
 
 <widget class="GtkWindow" id="rg_scan_results">
-  <property name="width_request">550</property>
+  <property name="width_request">900</property>
   <property name="height_request">350</property>
   <property name="visible">True</property>
   <property name="title" translatable="yes">ReplayGain Scan Results</property>

--- a/plugins/gtkui/interface.c
+++ b/plugins/gtkui/interface.c
@@ -147,6 +147,7 @@ create_mainwin (void)
   separator2 = gtk_separator_menu_item_new ();
   gtk_widget_show (separator2);
   gtk_container_add (GTK_CONTAINER (File_menu), separator2);
+  gtk_widget_set_sensitive (separator2, FALSE);
 
   add_files = gtk_image_menu_item_new_with_mnemonic (_("Add file(s)"));
   gtk_widget_show (add_files);
@@ -171,6 +172,7 @@ create_mainwin (void)
   separatormenuitem1 = gtk_separator_menu_item_new ();
   gtk_widget_show (separatormenuitem1);
   gtk_container_add (GTK_CONTAINER (File_menu), separatormenuitem1);
+  gtk_widget_set_sensitive (separatormenuitem1, FALSE);
 
   new_playlist1 = gtk_menu_item_new_with_mnemonic (_("New playlist"));
   gtk_widget_show (new_playlist1);
@@ -187,6 +189,7 @@ create_mainwin (void)
   separator8 = gtk_separator_menu_item_new ();
   gtk_widget_show (separator8);
   gtk_container_add (GTK_CONTAINER (File_menu), separator8);
+  gtk_widget_set_sensitive (separator8, FALSE);
 
   quit = gtk_image_menu_item_new_with_mnemonic (_("_Quit"));
   gtk_widget_show (quit);
@@ -284,6 +287,7 @@ create_mainwin (void)
   separator5 = gtk_separator_menu_item_new ();
   gtk_widget_show (separator5);
   gtk_container_add (GTK_CONTAINER (Edit_menu), separator5);
+  gtk_widget_set_sensitive (separator5, FALSE);
 
   preferences = gtk_menu_item_new_with_mnemonic (_("Preferences"));
   gtk_widget_show (preferences);
@@ -395,6 +399,7 @@ create_mainwin (void)
   separator11 = gtk_separator_menu_item_new ();
   gtk_widget_show (separator11);
   gtk_container_add (GTK_CONTAINER (Playback_menu), separator11);
+  gtk_widget_set_sensitive (separator11, FALSE);
 
   jump_to_current_track1 = gtk_menu_item_new_with_mnemonic (_("Jump to current track"));
   gtk_widget_show (jump_to_current_track1);
@@ -422,6 +427,7 @@ create_mainwin (void)
   separator10 = gtk_separator_menu_item_new ();
   gtk_widget_show (separator10);
   gtk_container_add (GTK_CONTAINER (Help_menu), separator10);
+  gtk_widget_set_sensitive (separator10, FALSE);
 
   gpl1 = gtk_menu_item_new_with_mnemonic (_("_GPLv2"));
   gtk_widget_show (gpl1);
@@ -434,6 +440,7 @@ create_mainwin (void)
   separator9 = gtk_separator_menu_item_new ();
   gtk_widget_show (separator9);
   gtk_container_add (GTK_CONTAINER (Help_menu), separator9);
+  gtk_widget_set_sensitive (separator9, FALSE);
 
   about1 = gtk_image_menu_item_new_with_mnemonic (_("_About"));
   gtk_widget_show (about1);
@@ -5293,7 +5300,7 @@ create_rg_scan_progress (void)
   GtkWidget *rg_scan_progress_cancel;
 
   rg_scan_progress = gtk_window_new (GTK_WINDOW_TOPLEVEL);
-  gtk_widget_set_size_request (rg_scan_progress, 440, -1);
+  gtk_widget_set_size_request (rg_scan_progress, 550, -1);
   gtk_window_set_title (GTK_WINDOW (rg_scan_progress), _("ReplayGain Scan Progress"));
 
   vbox50 = gtk_vbox_new (FALSE, 8);
@@ -5361,7 +5368,7 @@ create_rg_scan_results (void)
   GtkWidget *rg_scan_results_cancel;
 
   rg_scan_results = gtk_window_new (GTK_WINDOW_TOPLEVEL);
-  gtk_widget_set_size_request (rg_scan_results, 550, 350);
+  gtk_widget_set_size_request (rg_scan_results, 900, 350);
   gtk_window_set_title (GTK_WINDOW (rg_scan_results), _("ReplayGain Scan Results"));
 
   vbox51 = gtk_vbox_new (FALSE, 8);


### PR DESCRIPTION
The Replaygain scanner dialogs are a bit small and could be enlarged. On the screenshot you can see the change, left as it is current and right new size.

![Unbenannt](https://user-images.githubusercontent.com/39984895/58439350-dca89000-80d3-11e9-9965-7c77ce82ce99.png)


