### PR TITLE
gtkui: GNOME is phasing out AppMenu so we check if desktop prefers to…

### DIFF
--- a/plugins/gtkui/deadbeefapp.c
+++ b/plugins/gtkui/deadbeefapp.c
@@ -99,8 +99,18 @@ static void
 deadbeef_app_startup (GApplication *application) {
     G_APPLICATION_CLASS (deadbeef_app_parent_class)->startup (application);
 
-    g_action_map_add_action_entries (G_ACTION_MAP (application), app_entries, G_N_ELEMENTS (app_entries), application);
-    DEADBEEF_APP (application)->logaction = G_SIMPLE_ACTION (g_action_map_lookup_action ( G_ACTION_MAP (application), "log"));
+#if GTK_CHECK_VERSION(3,14,0)
+    int preferappmenu = gtk_application_prefers_app_menu (application);
+#else
+    int preferappmenu = 1;
+#endif
+
+    if (preferappmenu) {
+        g_action_map_add_action_entries (G_ACTION_MAP (application), app_entries, G_N_ELEMENTS (app_entries), application);
+        DEADBEEF_APP (application)->logaction = G_SIMPLE_ACTION (g_action_map_lookup_action ( G_ACTION_MAP (application), "log"));
+    } else {
+        gtk_application_set_app_menu (application, NULL);
+    }
 
     gtkui_mainwin_init ();
 }


### PR DESCRIPTION
… have it

References:
- https://gitlab.gnome.org/GNOME/Initiatives/wikis/App-Menu-Retirement
- https://developer.gnome.org/ApplicationMenu/