### PR TITLE
Automatic playlist sorting

### DIFF
--- a/playlist.c
+++ b/playlist.c
@@ -3813,29 +3813,40 @@ plt_add_files_end (playlist_t *plt, int visibility) {
     }
     background_job_decrement ();
     
-    // Autosort playlist
-    int autosort_enabled = deadbeef->conf_get_int ("gtkui.autosort_enabled", 0);
-    if (autosort_enabled == 1){
+    plt_autosort (plt);
+}
 
-        ddb_playlist_t *plt = deadbeef->plt_get_curr ();
-        const char *last_format = deadbeef->conf_get_str_fast ("gtkui.last_used_sortby_format", "None");
-        const char *formats = "%album% %artist% %title% %tracknumber% %year%";
-
-        if (strstr (formats, last_format) != NULL){
-            deadbeef->plt_sort_v2 (plt, PL_MAIN, -1, last_format, DDB_SORT_ASCENDING);
-        } else if (strcmp(last_format, "%random%") == 0){
-            deadbeef->plt_sort_v2 (plt, PL_MAIN, -1, NULL, DDB_SORT_RANDOM);
-        } else if (strcmp(last_format, "%custom%") == 0) {
-            int order = deadbeef->conf_get_int ("gtkui.sortby_order", 0);
-            const char *fmt = deadbeef->conf_get_str_fast ("gtkui.sortby_fmt_v2", "");
-            deadbeef->plt_sort_v2 (plt, PL_MAIN, -1, fmt, order == 0 ? DDB_SORT_ASCENDING : DDB_SORT_DESCENDING);
-        }
-
-        deadbeef->plt_save_config (plt);
-        deadbeef->plt_unref (plt);
-
-        deadbeef->sendmessage (DB_EV_PLAYLISTCHANGED, 0, DDB_PLAYLIST_CHANGE_CONTENT, 0);
+void
+plt_autosort (playlist_t *plt) {
+    int autosort_enabled = deadbeef->plt_find_meta_int (plt, "autosort_enabled", 0);
+    if (autosort_enabled != 1) {
+        return;
     }
+
+    const char *last_format = deadbeef->plt_find_meta (plt, "last_used_sortby_format");
+    if (last_format == NULL) {
+        return;
+    }
+    const char *formats = "%album% %artist% %title% %tracknumber% %year%";
+    if (strstr (formats, last_format) != NULL) {
+        deadbeef->plt_sort_v2 (plt, PL_MAIN, -1, last_format, DDB_SORT_ASCENDING);
+    }
+    else if (strcmp (last_format, "%random%") == 0) {
+         deadbeef->plt_sort_v2 (plt, PL_MAIN, -1, NULL, DDB_SORT_RANDOM);
+    }
+    else if (strcmp (last_format, "%custom%") == 0) {
+        int order = deadbeef->plt_find_meta_int (plt, "sortby_order", 0);
+        const char *fmt = deadbeef->plt_find_meta (plt, "sortby_fmt_v2");
+        if (fmt == NULL) {
+            return;
+        }
+        deadbeef->plt_sort_v2 (plt, PL_MAIN, -1, fmt, order == 0 ? DDB_SORT_ASCENDING : DDB_SORT_DESCENDING);
+    }
+
+    deadbeef->plt_save_config (plt);
+    deadbeef->plt_unref (plt);
+
+    deadbeef->sendmessage (DB_EV_PLAYLISTCHANGED, 0, DDB_PLAYLIST_CHANGE_CONTENT, 0);
 }
 
 void

--- a/playlist.c
+++ b/playlist.c
@@ -3816,31 +3816,6 @@ plt_add_files_end (playlist_t *plt, int visibility) {
     plt_autosort (plt);
 }
 
-static void
-plt_autosort (playlist_t *plt) {
-    int autosort_enabled = plt_find_meta_int (plt, "autosort_enabled", 0);
-    if (autosort_enabled != 1) {
-        return;
-    }
-
-    const char *autosort_mode = plt_find_meta (plt, "autosort_mode");
-    if (strcmp (autosort_mode, "tf") == 0) {
-        int order = plt_find_meta_int (plt, "autosort_ascending", 0);
-        const char *fmt = plt_find_meta (plt, "autosort_tf");
-        if (fmt == NULL) {
-            return;
-        }
-        deadbeef->plt_sort_v2 (plt, PL_MAIN, -1, fmt, order == 0 ? DDB_SORT_ASCENDING : DDB_SORT_DESCENDING);
-    }
-    else if (strcmp (autosort_mode, "random") == 0) {
-        deadbeef->plt_sort_v2 (plt, PL_MAIN, -1, NULL, DDB_SORT_RANDOM);
-    }
-
-    plt_save_config (plt);
-    plt_unref (plt);
-
-    deadbeef->sendmessage (DB_EV_PLAYLISTCHANGED, 0, DDB_PLAYLIST_CHANGE_CONTENT, 0);
-}
 
 void
 plt_deselect_all (playlist_t *playlist) {

--- a/playlist.c
+++ b/playlist.c
@@ -3816,35 +3816,32 @@ plt_add_files_end (playlist_t *plt, int visibility) {
     plt_autosort (plt);
 }
 
-void
+static void
 plt_autosort (playlist_t *plt) {
-    int autosort_enabled = deadbeef->plt_find_meta_int (plt, "autosort_enabled", 0);
+    int autosort_enabled = plt_find_meta_int (plt, "autosort_enabled", 0);
     if (autosort_enabled != 1) {
         return;
     }
 
-    const char *last_format = deadbeef->plt_find_meta (plt, "last_used_sortby_format");
-    if (last_format == NULL) {
-        return;
+    int autosort_mode = plt_find_meta_int (plt, "autosort_mode", 0);
+    if (autosort_mode <= 4) {
+        const char *formats[5] = {"%title%", "%tracknumber%", "%album%", "%artist%", "%year%"};
+        plt_sort_v2 (plt, PL_MAIN, -1, formats[autosort_mode], DDB_SORT_ASCENDING);
     }
-    const char *formats = "%album% %artist% %title% %tracknumber% %year%";
-    if (strstr (formats, last_format) != NULL) {
-        deadbeef->plt_sort_v2 (plt, PL_MAIN, -1, last_format, DDB_SORT_ASCENDING);
+    else if (autosort_mode == 5) {
+        plt_sort_v2 (plt, PL_MAIN, -1, NULL, DDB_SORT_RANDOM);
     }
-    else if (strcmp (last_format, "%random%") == 0) {
-         deadbeef->plt_sort_v2 (plt, PL_MAIN, -1, NULL, DDB_SORT_RANDOM);
-    }
-    else if (strcmp (last_format, "%custom%") == 0) {
-        int order = deadbeef->plt_find_meta_int (plt, "sortby_order", 0);
-        const char *fmt = deadbeef->plt_find_meta (plt, "sortby_fmt_v2");
+    else if (autosort_mode == 6) {
+        int order = plt_find_meta_int (plt, "sortby_order", 0);
+        const char *fmt = plt_find_meta (plt, "sortby_fmt_v2");
         if (fmt == NULL) {
             return;
         }
-        deadbeef->plt_sort_v2 (plt, PL_MAIN, -1, fmt, order == 0 ? DDB_SORT_ASCENDING : DDB_SORT_DESCENDING);
+        plt_sort_v2 (plt, PL_MAIN, -1, fmt, order == 0 ? DDB_SORT_ASCENDING : DDB_SORT_DESCENDING);
     }
 
-    deadbeef->plt_save_config (plt);
-    deadbeef->plt_unref (plt);
+    plt_save_config (plt);
+    plt_unref (plt);
 
     deadbeef->sendmessage (DB_EV_PLAYLISTCHANGED, 0, DDB_PLAYLIST_CHANGE_CONTENT, 0);
 }

--- a/playlist.c
+++ b/playlist.c
@@ -3830,10 +3830,10 @@ plt_autosort (playlist_t *plt) {
         if (fmt == NULL) {
             return;
         }
-        plt_sort_v2 (plt, PL_MAIN, -1, fmt, order == 0 ? DDB_SORT_ASCENDING : DDB_SORT_DESCENDING);
+        deadbeef->plt_sort_v2 (plt, PL_MAIN, -1, fmt, order == 0 ? DDB_SORT_ASCENDING : DDB_SORT_DESCENDING);
     }
     else if (strcmp (autosort_mode, "random") == 0) {
-        plt_sort_v2 (plt, PL_MAIN, -1, NULL, DDB_SORT_RANDOM);
+        deadbeef->plt_sort_v2 (plt, PL_MAIN, -1, NULL, DDB_SORT_RANDOM);
     }
 
     plt_save_config (plt);

--- a/playlist.c
+++ b/playlist.c
@@ -3813,11 +3813,11 @@ plt_add_files_end (playlist_t *plt, int visibility) {
     }
     background_job_decrement ();
     
-    plt_autosort (plt, d.plt);
+    plt_autosort (plt);
 }
 
 static void
-plt_autosort (playlist_t *plt, ddb_playlist_t *ddbplt) {
+plt_autosort (playlist_t *plt) {
     int autosort_enabled = plt_find_meta_int (plt, "autosort_enabled", 0);
     if (autosort_enabled != 1) {
         return;
@@ -3830,10 +3830,10 @@ plt_autosort (playlist_t *plt, ddb_playlist_t *ddbplt) {
         if (fmt == NULL) {
             return;
         }
-        deadbeef->plt_sort_v2 (ddbplt, PL_MAIN, -1, fmt, order == 0 ? DDB_SORT_ASCENDING : DDB_SORT_DESCENDING);
+        plt_sort_v2 (plt, PL_MAIN, -1, fmt, order == 0 ? DDB_SORT_ASCENDING : DDB_SORT_DESCENDING);
     }
     else if (strcmp (autosort_mode, "random") == 0) {
-        deadbeef->plt_sort_v2 (ddbplt, PL_MAIN, -1, NULL, DDB_SORT_RANDOM);
+        plt_sort_v2 (plt, PL_MAIN, -1, NULL, DDB_SORT_RANDOM);
     }
 
     plt_save_config (plt);

--- a/playlist.c
+++ b/playlist.c
@@ -66,6 +66,7 @@
 #include "strdupa.h"
 #include "tf.h"
 #include "playqueue.h"
+#include "sort.h"
 
 #include "cueutil.h"
 

--- a/playlist.c
+++ b/playlist.c
@@ -3813,31 +3813,27 @@ plt_add_files_end (playlist_t *plt, int visibility) {
     }
     background_job_decrement ();
     
-    plt_autosort (plt);
+    plt_autosort (plt, d.plt);
 }
 
 static void
-plt_autosort (playlist_t *plt) {
+plt_autosort (playlist_t *plt, ddb_playlist_t *ddbplt) {
     int autosort_enabled = plt_find_meta_int (plt, "autosort_enabled", 0);
     if (autosort_enabled != 1) {
         return;
     }
 
-    int autosort_mode = plt_find_meta_int (plt, "autosort_mode", 0);
-    if (autosort_mode <= 4) {
-        const char *formats[5] = {"%title%", "%tracknumber%", "%album%", "%artist%", "%year%"};
-        plt_sort_v2 (plt, PL_MAIN, -1, formats[autosort_mode], DDB_SORT_ASCENDING);
-    }
-    else if (autosort_mode == 5) {
-        plt_sort_v2 (plt, PL_MAIN, -1, NULL, DDB_SORT_RANDOM);
-    }
-    else if (autosort_mode == 6) {
-        int order = plt_find_meta_int (plt, "sortby_order", 0);
-        const char *fmt = plt_find_meta (plt, "sortby_fmt_v2");
+    const char *autosort_mode = plt_find_meta (plt, "autosort_mode");
+    if (strcmp (autosort_mode, "tf") == 0) {
+        int order = plt_find_meta_int (plt, "autosort_ascending", 0);
+        const char *fmt = plt_find_meta (plt, "autosort_tf");
         if (fmt == NULL) {
             return;
         }
-        plt_sort_v2 (plt, PL_MAIN, -1, fmt, order == 0 ? DDB_SORT_ASCENDING : DDB_SORT_DESCENDING);
+        deadbeef->plt_sort_v2 (ddbplt, PL_MAIN, -1, fmt, order == 0 ? DDB_SORT_ASCENDING : DDB_SORT_DESCENDING);
+    }
+    else if (strcmp (autosort_mode, "random") == 0) {
+        deadbeef->plt_sort_v2 (ddbplt, PL_MAIN, -1, NULL, DDB_SORT_RANDOM);
     }
 
     plt_save_config (plt);

--- a/playlist.h
+++ b/playlist.h
@@ -541,7 +541,7 @@ void
 plt_add_files_end (playlist_t *plt, int visibility);
 
 static void
-plt_autosort (playlist_t *plt);
+plt_autosort (playlist_t *plt, ddb_playlist_t *ddbplt);
 
 void
 plt_deselect_all (playlist_t *plt);

--- a/playlist.h
+++ b/playlist.h
@@ -540,9 +540,6 @@ plt_add_files_begin (playlist_t *plt, int visibility);
 void
 plt_add_files_end (playlist_t *plt, int visibility);
 
-static void
-plt_autosort (playlist_t *plt);
-
 void
 plt_deselect_all (playlist_t *plt);
 

--- a/playlist.h
+++ b/playlist.h
@@ -540,6 +540,9 @@ plt_add_files_begin (playlist_t *plt, int visibility);
 void
 plt_add_files_end (playlist_t *plt, int visibility);
 
+static void
+plt_autosort (playlist_t *plt);
+
 void
 plt_deselect_all (playlist_t *plt);
 

--- a/playlist.h
+++ b/playlist.h
@@ -541,7 +541,7 @@ void
 plt_add_files_end (playlist_t *plt, int visibility);
 
 static void
-plt_autosort (playlist_t *plt, ddb_playlist_t *ddbplt);
+plt_autosort (playlist_t *plt);
 
 void
 plt_deselect_all (playlist_t *plt);

--- a/plugins/gtkui/actionhandlers.c
+++ b/plugins/gtkui/actionhandlers.c
@@ -678,9 +678,9 @@ action_sort_custom_handler_cb (void *data) {
         deadbeef->plt_unref (plt);
 
         deadbeef->sendmessage (DB_EV_PLAYLISTCHANGED, 0, DDB_PLAYLIST_CHANGE_CONTENT, 0);
-        plt_replace_meta (plt, "autosort_mode", "tf");
-        plt_replace_meta (plt, "autosort_tf", fmt);
-        plt_set_meta_int (plt, "autosort_ascending", order);
+        deadbeef->plt_replace_meta (plt, "autosort_mode", "tf");
+        deadbeef->plt_replace_meta (plt, "autosort_tf", fmt);
+        deadbeef->plt_set_meta_int (plt, "autosort_ascending", order);
     }
 
     gtk_widget_destroy (dlg);

--- a/plugins/gtkui/actionhandlers.c
+++ b/plugins/gtkui/actionhandlers.c
@@ -678,6 +678,7 @@ action_sort_custom_handler_cb (void *data) {
         deadbeef->plt_unref (plt);
 
         deadbeef->sendmessage (DB_EV_PLAYLISTCHANGED, 0, DDB_PLAYLIST_CHANGE_CONTENT, 0);
+        deadbeef->conf_set_str ("gtkui.last_used_sortby_format", "%custom%");
     }
 
     gtk_widget_destroy (dlg);

--- a/plugins/gtkui/actionhandlers.c
+++ b/plugins/gtkui/actionhandlers.c
@@ -678,7 +678,7 @@ action_sort_custom_handler_cb (void *data) {
         deadbeef->plt_unref (plt);
 
         deadbeef->sendmessage (DB_EV_PLAYLISTCHANGED, 0, DDB_PLAYLIST_CHANGE_CONTENT, 0);
-        deadbeef->plt_replace_meta (plt, "last_used_sortby_format", "%custom%");
+        deadbeef->plt_set_meta_int (plt, "autosort_mode", 6);
         deadbeef->plt_replace_meta (plt, "sortby_fmt_v2", fmt);
         deadbeef->plt_set_meta_int (plt, "sortby_order", order);
     }

--- a/plugins/gtkui/actionhandlers.c
+++ b/plugins/gtkui/actionhandlers.c
@@ -678,9 +678,9 @@ action_sort_custom_handler_cb (void *data) {
         deadbeef->plt_unref (plt);
 
         deadbeef->sendmessage (DB_EV_PLAYLISTCHANGED, 0, DDB_PLAYLIST_CHANGE_CONTENT, 0);
-        deadbeef->plt_replace_meta (plt, "autosort_mode", "tf");
-        deadbeef->plt_replace_meta (plt, "autosort_tf", fmt);
-        deadbeef->plt_set_meta_int (plt, "autosort_ascending", order);
+        plt_replace_meta (plt, "autosort_mode", "tf");
+        plt_replace_meta (plt, "autosort_tf", fmt);
+        plt_set_meta_int (plt, "autosort_ascending", order);
     }
 
     gtk_widget_destroy (dlg);

--- a/plugins/gtkui/actionhandlers.c
+++ b/plugins/gtkui/actionhandlers.c
@@ -678,9 +678,9 @@ action_sort_custom_handler_cb (void *data) {
         deadbeef->plt_unref (plt);
 
         deadbeef->sendmessage (DB_EV_PLAYLISTCHANGED, 0, DDB_PLAYLIST_CHANGE_CONTENT, 0);
-        deadbeef->plt_set_meta_int (plt, "autosort_mode", 6);
-        deadbeef->plt_replace_meta (plt, "sortby_fmt_v2", fmt);
-        deadbeef->plt_set_meta_int (plt, "sortby_order", order);
+        deadbeef->plt_replace_meta (plt, "autosort_mode", "tf");
+        deadbeef->plt_replace_meta (plt, "autosort_tf", fmt);
+        deadbeef->plt_set_meta_int (plt, "autosort_ascending", order);
     }
 
     gtk_widget_destroy (dlg);

--- a/plugins/gtkui/actionhandlers.c
+++ b/plugins/gtkui/actionhandlers.c
@@ -678,7 +678,9 @@ action_sort_custom_handler_cb (void *data) {
         deadbeef->plt_unref (plt);
 
         deadbeef->sendmessage (DB_EV_PLAYLISTCHANGED, 0, DDB_PLAYLIST_CHANGE_CONTENT, 0);
-        deadbeef->conf_set_str ("gtkui.last_used_sortby_format", "%custom%");
+        deadbeef->plt_replace_meta (plt, "last_used_sortby_format", "%custom%");
+        deadbeef->plt_replace_meta (plt, "sortby_fmt_v2", fmt);
+        deadbeef->plt_set_meta_int (plt, "sortby_order", order);
     }
 
     gtk_widget_destroy (dlg);

--- a/plugins/gtkui/callbacks.c
+++ b/plugins/gtkui/callbacks.c
@@ -667,9 +667,9 @@ on_sort_by_title_activate              (GtkMenuItem     *menuitem,
     deadbeef->plt_unref (plt);
 
     deadbeef->sendmessage (DB_EV_PLAYLISTCHANGED, 0, DDB_PLAYLIST_CHANGE_CONTENT, 0);
-    deadbeef->plt_replace_meta (plt, "autosort_tf", "%title%");
-    deadbeef->plt_replace_meta (plt, "autosort_mode", "tf");
-    deadbeef->plt_set_meta_int (plt, "autosort_ascending", 0);
+    plt_replace_meta (plt, "autosort_tf", "%title%");
+    plt_replace_meta (plt, "autosort_mode", "tf");
+    plt_set_meta_int (plt, "autosort_ascending", 0);
 }
 
 
@@ -683,9 +683,9 @@ on_sort_by_track_nr_activate           (GtkMenuItem     *menuitem,
     deadbeef->plt_unref (plt);
 
     deadbeef->sendmessage (DB_EV_PLAYLISTCHANGED, 0, DDB_PLAYLIST_CHANGE_CONTENT, 0);
-    deadbeef->plt_replace_meta (plt, "autosort_tf", "%tracknumber%");
-    deadbeef->plt_replace_meta (plt, "autosort_mode", "tf");
-    deadbeef->plt_set_meta_int (plt, "autosort_ascending", 0);
+    plt_replace_meta (plt, "autosort_tf", "%tracknumber%");
+    plt_replace_meta (plt, "autosort_mode", "tf");
+    plt_set_meta_int (plt, "autosort_ascending", 0);
 }
 
 
@@ -699,9 +699,9 @@ on_sort_by_album_activate              (GtkMenuItem     *menuitem,
     deadbeef->plt_unref (plt);
 
     deadbeef->sendmessage (DB_EV_PLAYLISTCHANGED, 0, DDB_PLAYLIST_CHANGE_CONTENT, 0);
-    deadbeef->plt_replace_meta (plt, "autosort_tf", "%album%");
-    deadbeef->plt_replace_meta (plt, "autosort_mode", "tf");
-    deadbeef->plt_set_meta_int (plt, "autosort_ascending", 0);
+    plt_replace_meta (plt, "autosort_tf", "%album%");
+    plt_replace_meta (plt, "autosort_mode", "tf");
+    plt_set_meta_int (plt, "autosort_ascending", 0);
 }
 
 
@@ -715,9 +715,9 @@ on_sort_by_artist_activate             (GtkMenuItem     *menuitem,
     deadbeef->plt_unref (plt);
 
     deadbeef->sendmessage (DB_EV_PLAYLISTCHANGED, 0, DDB_PLAYLIST_CHANGE_CONTENT, 0);
-    deadbeef->plt_replace_meta (plt, "autosort_tf", "%artist%");
-    deadbeef->plt_replace_meta (plt, "autosort_mode", "tf");
-    deadbeef->plt_set_meta_int (plt, "autosort_ascending", 0);
+    plt_replace_meta (plt, "autosort_tf", "%artist%");
+    plt_replace_meta (plt, "autosort_mode", "tf");
+    plt_set_meta_int (plt, "autosort_ascending", 0);
 }
 
 
@@ -730,9 +730,9 @@ on_sort_by_date_activate               (GtkMenuItem     *menuitem,
     deadbeef->plt_save_config (plt);
     deadbeef->plt_unref (plt);
     deadbeef->sendmessage (DB_EV_PLAYLISTCHANGED, 0, DDB_PLAYLIST_CHANGE_CONTENT, 0);
-    deadbeef->plt_replace_meta (plt, "autosort_tf", "%year%");
-    deadbeef->plt_replace_meta (plt, "autosort_mode", "tf");
-    deadbeef->plt_set_meta_int (plt, "autosort_ascending", 0);
+    plt_replace_meta (plt, "autosort_tf", "%year%");
+    plt_replace_meta (plt, "autosort_mode", "tf");
+    plt_set_meta_int (plt, "autosort_ascending", 0);
 }
 
 
@@ -746,7 +746,7 @@ on_sort_by_random_activate               (GtkMenuItem     *menuitem,
     deadbeef->plt_unref (plt);
 
     deadbeef->sendmessage (DB_EV_PLAYLISTCHANGED, 0, DDB_PLAYLIST_CHANGE_CONTENT, 0);
-    deadbeef->plt_replace_meta (plt, "autosort_mode", "random");
+    plt_replace_meta (plt, "autosort_mode", "random");
 }
 
 

--- a/plugins/gtkui/callbacks.c
+++ b/plugins/gtkui/callbacks.c
@@ -667,7 +667,9 @@ on_sort_by_title_activate              (GtkMenuItem     *menuitem,
     deadbeef->plt_unref (plt);
 
     deadbeef->sendmessage (DB_EV_PLAYLISTCHANGED, 0, DDB_PLAYLIST_CHANGE_CONTENT, 0);
-    deadbeef->plt_set_meta_int (plt, "autosort_mode", 0);
+    deadbeef->plt_replace_meta (plt, "autosort_tf", "%title%");
+    deadbeef->plt_replace_meta (plt, "autosort_mode", "tf");
+    deadbeef->plt_set_meta_int (plt, "autosort_ascending", 0);
 }
 
 
@@ -681,7 +683,9 @@ on_sort_by_track_nr_activate           (GtkMenuItem     *menuitem,
     deadbeef->plt_unref (plt);
 
     deadbeef->sendmessage (DB_EV_PLAYLISTCHANGED, 0, DDB_PLAYLIST_CHANGE_CONTENT, 0);
-    deadbeef->plt_set_meta_int (plt, "autosort_mode", 1);
+    deadbeef->plt_replace_meta (plt, "autosort_tf", "%tracknumber%");
+    deadbeef->plt_replace_meta (plt, "autosort_mode", "tf");
+    deadbeef->plt_set_meta_int (plt, "autosort_ascending", 0);
 }
 
 
@@ -695,7 +699,9 @@ on_sort_by_album_activate              (GtkMenuItem     *menuitem,
     deadbeef->plt_unref (plt);
 
     deadbeef->sendmessage (DB_EV_PLAYLISTCHANGED, 0, DDB_PLAYLIST_CHANGE_CONTENT, 0);
-    deadbeef->plt_set_meta_int (plt, "autosort_mode", 2);
+    deadbeef->plt_replace_meta (plt, "autosort_tf", "%album%");
+    deadbeef->plt_replace_meta (plt, "autosort_mode", "tf");
+    deadbeef->plt_set_meta_int (plt, "autosort_ascending", 0);
 }
 
 
@@ -709,7 +715,9 @@ on_sort_by_artist_activate             (GtkMenuItem     *menuitem,
     deadbeef->plt_unref (plt);
 
     deadbeef->sendmessage (DB_EV_PLAYLISTCHANGED, 0, DDB_PLAYLIST_CHANGE_CONTENT, 0);
-    deadbeef->plt_set_meta_int (plt, "autosort_mode", 3);
+    deadbeef->plt_replace_meta (plt, "autosort_tf", "%artist%");
+    deadbeef->plt_replace_meta (plt, "autosort_mode", "tf");
+    deadbeef->plt_set_meta_int (plt, "autosort_ascending", 0);
 }
 
 
@@ -722,7 +730,9 @@ on_sort_by_date_activate               (GtkMenuItem     *menuitem,
     deadbeef->plt_save_config (plt);
     deadbeef->plt_unref (plt);
     deadbeef->sendmessage (DB_EV_PLAYLISTCHANGED, 0, DDB_PLAYLIST_CHANGE_CONTENT, 0);
-    deadbeef->plt_set_meta_int (plt, "autosort_mode", 4);
+    deadbeef->plt_replace_meta (plt, "autosort_tf", "%year%");
+    deadbeef->plt_replace_meta (plt, "autosort_mode", "tf");
+    deadbeef->plt_set_meta_int (plt, "autosort_ascending", 0);
 }
 
 
@@ -736,7 +746,7 @@ on_sort_by_random_activate               (GtkMenuItem     *menuitem,
     deadbeef->plt_unref (plt);
 
     deadbeef->sendmessage (DB_EV_PLAYLISTCHANGED, 0, DDB_PLAYLIST_CHANGE_CONTENT, 0);
-    deadbeef->plt_set_meta_int (plt, "autosort_mode", 5);
+    deadbeef->plt_replace_meta (plt, "autosort_mode", "random");
 }
 
 

--- a/plugins/gtkui/callbacks.c
+++ b/plugins/gtkui/callbacks.c
@@ -667,9 +667,9 @@ on_sort_by_title_activate              (GtkMenuItem     *menuitem,
     deadbeef->plt_unref (plt);
 
     deadbeef->sendmessage (DB_EV_PLAYLISTCHANGED, 0, DDB_PLAYLIST_CHANGE_CONTENT, 0);
-    plt_replace_meta (plt, "autosort_tf", "%title%");
-    plt_replace_meta (plt, "autosort_mode", "tf");
-    plt_set_meta_int (plt, "autosort_ascending", 0);
+    deadbeef->plt_replace_meta (plt, "autosort_tf", "%title%");
+    deadbeef->plt_replace_meta (plt, "autosort_mode", "tf");
+    deadbeef->plt_set_meta_int (plt, "autosort_ascending", 0);
 }
 
 
@@ -683,9 +683,9 @@ on_sort_by_track_nr_activate           (GtkMenuItem     *menuitem,
     deadbeef->plt_unref (plt);
 
     deadbeef->sendmessage (DB_EV_PLAYLISTCHANGED, 0, DDB_PLAYLIST_CHANGE_CONTENT, 0);
-    plt_replace_meta (plt, "autosort_tf", "%tracknumber%");
-    plt_replace_meta (plt, "autosort_mode", "tf");
-    plt_set_meta_int (plt, "autosort_ascending", 0);
+    deadbeef->plt_replace_meta (plt, "autosort_tf", "%tracknumber%");
+    deadbeef->plt_replace_meta (plt, "autosort_mode", "tf");
+    deadbeef->plt_set_meta_int (plt, "autosort_ascending", 0);
 }
 
 
@@ -699,9 +699,9 @@ on_sort_by_album_activate              (GtkMenuItem     *menuitem,
     deadbeef->plt_unref (plt);
 
     deadbeef->sendmessage (DB_EV_PLAYLISTCHANGED, 0, DDB_PLAYLIST_CHANGE_CONTENT, 0);
-    plt_replace_meta (plt, "autosort_tf", "%album%");
-    plt_replace_meta (plt, "autosort_mode", "tf");
-    plt_set_meta_int (plt, "autosort_ascending", 0);
+    deadbeef->plt_replace_meta (plt, "autosort_tf", "%album%");
+    deadbeef->plt_replace_meta (plt, "autosort_mode", "tf");
+    deadbeef->plt_set_meta_int (plt, "autosort_ascending", 0);
 }
 
 
@@ -715,9 +715,9 @@ on_sort_by_artist_activate             (GtkMenuItem     *menuitem,
     deadbeef->plt_unref (plt);
 
     deadbeef->sendmessage (DB_EV_PLAYLISTCHANGED, 0, DDB_PLAYLIST_CHANGE_CONTENT, 0);
-    plt_replace_meta (plt, "autosort_tf", "%artist%");
-    plt_replace_meta (plt, "autosort_mode", "tf");
-    plt_set_meta_int (plt, "autosort_ascending", 0);
+    deadbeef->plt_replace_meta (plt, "autosort_tf", "%artist%");
+    deadbeef->plt_replace_meta (plt, "autosort_mode", "tf");
+    deadbeef->plt_set_meta_int (plt, "autosort_ascending", 0);
 }
 
 
@@ -730,9 +730,9 @@ on_sort_by_date_activate               (GtkMenuItem     *menuitem,
     deadbeef->plt_save_config (plt);
     deadbeef->plt_unref (plt);
     deadbeef->sendmessage (DB_EV_PLAYLISTCHANGED, 0, DDB_PLAYLIST_CHANGE_CONTENT, 0);
-    plt_replace_meta (plt, "autosort_tf", "%year%");
-    plt_replace_meta (plt, "autosort_mode", "tf");
-    plt_set_meta_int (plt, "autosort_ascending", 0);
+    deadbeef->plt_replace_meta (plt, "autosort_tf", "%year%");
+    deadbeef->plt_replace_meta (plt, "autosort_mode", "tf");
+    deadbeef->plt_set_meta_int (plt, "autosort_ascending", 0);
 }
 
 
@@ -746,7 +746,7 @@ on_sort_by_random_activate               (GtkMenuItem     *menuitem,
     deadbeef->plt_unref (plt);
 
     deadbeef->sendmessage (DB_EV_PLAYLISTCHANGED, 0, DDB_PLAYLIST_CHANGE_CONTENT, 0);
-    plt_replace_meta (plt, "autosort_mode", "random");
+    deadbeef->plt_replace_meta (plt, "autosort_mode", "random");
 }
 
 

--- a/plugins/gtkui/callbacks.c
+++ b/plugins/gtkui/callbacks.c
@@ -667,6 +667,7 @@ on_sort_by_title_activate              (GtkMenuItem     *menuitem,
     deadbeef->plt_unref (plt);
 
     deadbeef->sendmessage (DB_EV_PLAYLISTCHANGED, 0, DDB_PLAYLIST_CHANGE_CONTENT, 0);
+    deadbeef->conf_set_str ("gtkui.last_used_sortby_format", "%title%");
 }
 
 
@@ -680,6 +681,7 @@ on_sort_by_track_nr_activate           (GtkMenuItem     *menuitem,
     deadbeef->plt_unref (plt);
 
     deadbeef->sendmessage (DB_EV_PLAYLISTCHANGED, 0, DDB_PLAYLIST_CHANGE_CONTENT, 0);
+    deadbeef->conf_set_str ("gtkui.last_used_sortby_format", "%tracknumber%");
 }
 
 
@@ -693,6 +695,7 @@ on_sort_by_album_activate              (GtkMenuItem     *menuitem,
     deadbeef->plt_unref (plt);
 
     deadbeef->sendmessage (DB_EV_PLAYLISTCHANGED, 0, DDB_PLAYLIST_CHANGE_CONTENT, 0);
+    deadbeef->conf_set_str ("gtkui.last_used_sortby_format", "%album%");
 }
 
 
@@ -706,6 +709,7 @@ on_sort_by_artist_activate             (GtkMenuItem     *menuitem,
     deadbeef->plt_unref (plt);
 
     deadbeef->sendmessage (DB_EV_PLAYLISTCHANGED, 0, DDB_PLAYLIST_CHANGE_CONTENT, 0);
+    deadbeef->conf_set_str ("gtkui.last_used_sortby_format", "%artist%");
 }
 
 
@@ -718,6 +722,7 @@ on_sort_by_date_activate               (GtkMenuItem     *menuitem,
     deadbeef->plt_save_config (plt);
     deadbeef->plt_unref (plt);
     deadbeef->sendmessage (DB_EV_PLAYLISTCHANGED, 0, DDB_PLAYLIST_CHANGE_CONTENT, 0);
+    deadbeef->conf_set_str ("gtkui.last_used_sortby_format", "%year%");
 }
 
 
@@ -731,6 +736,7 @@ on_sort_by_random_activate               (GtkMenuItem     *menuitem,
     deadbeef->plt_unref (plt);
 
     deadbeef->sendmessage (DB_EV_PLAYLISTCHANGED, 0, DDB_PLAYLIST_CHANGE_CONTENT, 0);
+    deadbeef->conf_set_str ("gtkui.last_used_sortby_format", "%random%");
 }
 
 

--- a/plugins/gtkui/callbacks.c
+++ b/plugins/gtkui/callbacks.c
@@ -667,7 +667,7 @@ on_sort_by_title_activate              (GtkMenuItem     *menuitem,
     deadbeef->plt_unref (plt);
 
     deadbeef->sendmessage (DB_EV_PLAYLISTCHANGED, 0, DDB_PLAYLIST_CHANGE_CONTENT, 0);
-    deadbeef->plt_replace_meta (plt, "last_used_sortby_format", "%title%");
+    deadbeef->plt_set_meta_int (plt, "autosort_mode", 0);
 }
 
 
@@ -681,7 +681,7 @@ on_sort_by_track_nr_activate           (GtkMenuItem     *menuitem,
     deadbeef->plt_unref (plt);
 
     deadbeef->sendmessage (DB_EV_PLAYLISTCHANGED, 0, DDB_PLAYLIST_CHANGE_CONTENT, 0);
-    deadbeef->plt_replace_meta (plt, "last_used_sortby_format", "%tracknumber%");
+    deadbeef->plt_set_meta_int (plt, "autosort_mode", 1);
 }
 
 
@@ -695,7 +695,7 @@ on_sort_by_album_activate              (GtkMenuItem     *menuitem,
     deadbeef->plt_unref (plt);
 
     deadbeef->sendmessage (DB_EV_PLAYLISTCHANGED, 0, DDB_PLAYLIST_CHANGE_CONTENT, 0);
-    deadbeef->plt_replace_meta (plt, "last_used_sortby_format", "%album%");
+    deadbeef->plt_set_meta_int (plt, "autosort_mode", 2);
 }
 
 
@@ -709,7 +709,7 @@ on_sort_by_artist_activate             (GtkMenuItem     *menuitem,
     deadbeef->plt_unref (plt);
 
     deadbeef->sendmessage (DB_EV_PLAYLISTCHANGED, 0, DDB_PLAYLIST_CHANGE_CONTENT, 0);
-    deadbeef->plt_replace_meta (plt, "last_used_sortby_format", "%artist%");
+    deadbeef->plt_set_meta_int (plt, "autosort_mode", 3);
 }
 
 
@@ -722,7 +722,7 @@ on_sort_by_date_activate               (GtkMenuItem     *menuitem,
     deadbeef->plt_save_config (plt);
     deadbeef->plt_unref (plt);
     deadbeef->sendmessage (DB_EV_PLAYLISTCHANGED, 0, DDB_PLAYLIST_CHANGE_CONTENT, 0);
-    deadbeef->plt_replace_meta (plt, "last_used_sortby_format", "%year%");
+    deadbeef->plt_set_meta_int (plt, "autosort_mode", 4);
 }
 
 
@@ -736,7 +736,7 @@ on_sort_by_random_activate               (GtkMenuItem     *menuitem,
     deadbeef->plt_unref (plt);
 
     deadbeef->sendmessage (DB_EV_PLAYLISTCHANGED, 0, DDB_PLAYLIST_CHANGE_CONTENT, 0);
-    deadbeef->plt_replace_meta (plt, "last_used_sortby_format", "%random%");
+    deadbeef->plt_set_meta_int (plt, "autosort_mode", 5);
 }
 
 

--- a/plugins/gtkui/callbacks.c
+++ b/plugins/gtkui/callbacks.c
@@ -667,7 +667,7 @@ on_sort_by_title_activate              (GtkMenuItem     *menuitem,
     deadbeef->plt_unref (plt);
 
     deadbeef->sendmessage (DB_EV_PLAYLISTCHANGED, 0, DDB_PLAYLIST_CHANGE_CONTENT, 0);
-    deadbeef->conf_set_str ("gtkui.last_used_sortby_format", "%title%");
+    deadbeef->plt_replace_meta (plt, "last_used_sortby_format", "%title%");
 }
 
 
@@ -681,7 +681,7 @@ on_sort_by_track_nr_activate           (GtkMenuItem     *menuitem,
     deadbeef->plt_unref (plt);
 
     deadbeef->sendmessage (DB_EV_PLAYLISTCHANGED, 0, DDB_PLAYLIST_CHANGE_CONTENT, 0);
-    deadbeef->conf_set_str ("gtkui.last_used_sortby_format", "%tracknumber%");
+    deadbeef->plt_replace_meta (plt, "last_used_sortby_format", "%tracknumber%");
 }
 
 
@@ -695,7 +695,7 @@ on_sort_by_album_activate              (GtkMenuItem     *menuitem,
     deadbeef->plt_unref (plt);
 
     deadbeef->sendmessage (DB_EV_PLAYLISTCHANGED, 0, DDB_PLAYLIST_CHANGE_CONTENT, 0);
-    deadbeef->conf_set_str ("gtkui.last_used_sortby_format", "%album%");
+    deadbeef->plt_replace_meta (plt, "last_used_sortby_format", "%album%");
 }
 
 
@@ -709,7 +709,7 @@ on_sort_by_artist_activate             (GtkMenuItem     *menuitem,
     deadbeef->plt_unref (plt);
 
     deadbeef->sendmessage (DB_EV_PLAYLISTCHANGED, 0, DDB_PLAYLIST_CHANGE_CONTENT, 0);
-    deadbeef->conf_set_str ("gtkui.last_used_sortby_format", "%artist%");
+    deadbeef->plt_replace_meta (plt, "last_used_sortby_format", "%artist%");
 }
 
 
@@ -722,7 +722,7 @@ on_sort_by_date_activate               (GtkMenuItem     *menuitem,
     deadbeef->plt_save_config (plt);
     deadbeef->plt_unref (plt);
     deadbeef->sendmessage (DB_EV_PLAYLISTCHANGED, 0, DDB_PLAYLIST_CHANGE_CONTENT, 0);
-    deadbeef->conf_set_str ("gtkui.last_used_sortby_format", "%year%");
+    deadbeef->plt_replace_meta (plt, "last_used_sortby_format", "%year%");
 }
 
 
@@ -736,7 +736,7 @@ on_sort_by_random_activate               (GtkMenuItem     *menuitem,
     deadbeef->plt_unref (plt);
 
     deadbeef->sendmessage (DB_EV_PLAYLISTCHANGED, 0, DDB_PLAYLIST_CHANGE_CONTENT, 0);
-    deadbeef->conf_set_str ("gtkui.last_used_sortby_format", "%random%");
+    deadbeef->plt_replace_meta (plt, "last_used_sortby_format", "%random%");
 }
 
 

--- a/plugins/gtkui/pltmenu.c
+++ b/plugins/gtkui/pltmenu.c
@@ -411,7 +411,7 @@ gtkui_create_pltmenu (int plt_idx) {
     gtk_widget_show (copy_playlist1);
     gtk_container_add (GTK_CONTAINER (plmenu), copy_playlist1);
 
-    int autosort_enabled = deadbeef->plt_find_meta_int (deadbeef->plt_get_curr (), "autosort_enabled", 0);
+    int autosort_enabled = deadbeef->plt_find_meta_int (deadbeef->plt_get_for_idx (pltmenu_idx), "autosort_enabled", 0);
     autosort = gtk_check_menu_item_new_with_label ("Sort playlist");
     gtk_check_menu_item_set_active (autosort, autosort_enabled);
     gtk_widget_show (autosort);

--- a/plugins/gtkui/pltmenu.c
+++ b/plugins/gtkui/pltmenu.c
@@ -115,6 +115,21 @@ on_copy_playlist1_activate        (GtkMenuItem     *menuitem,
 }
 
 static void
+on_autosort_toggled (GtkMenuItem     *menuitem,
+                    gpointer         user_data)
+{
+    if (pltmenu_idx < 0) {
+        return;
+    }
+    ddb_playlist_t *plt = deadbeef->plt_get_for_idx (pltmenu_idx);
+    if (plt) {
+        int value = deadbeef->plt_find_meta_int (plt, "autosort_enabled", 0);
+        deadbeef->plt_set_meta_int (plt, "autosort_enabled", value == 0 ? 1 : 0);
+        deadbeef->plt_unref (plt);
+    }
+}
+
+static void
 on_actionitem_activate (GtkMenuItem     *menuitem,
                            DB_plugin_action_t *action)
 {
@@ -355,6 +370,7 @@ gtkui_create_pltmenu (int plt_idx) {
     GtkWidget *remove_playlist1;
     GtkWidget *add_new_playlist1;
     GtkWidget *copy_playlist1;
+    GtkWidget *autosort;
     GtkWidget *separator11;
     GtkWidget *cut;
     GtkWidget *cut_image;
@@ -395,6 +411,12 @@ gtkui_create_pltmenu (int plt_idx) {
     gtk_widget_show (copy_playlist1);
     gtk_container_add (GTK_CONTAINER (plmenu), copy_playlist1);
 
+    int autosort_enabled = deadbeef->plt_find_meta_int (deadbeef->plt_get_curr (), "autosort_enabled", 0);
+    autosort = gtk_check_menu_item_new_with_label ("Sort playlist");
+    gtk_check_menu_item_set_active (autosort, autosort_enabled);
+    gtk_widget_show (autosort);
+    gtk_container_add (GTK_CONTAINER (plmenu), autosort);
+    
     separator11 = gtk_separator_menu_item_new ();
     gtk_widget_show (separator11);
     gtk_container_add (GTK_CONTAINER (plmenu), separator11);
@@ -453,6 +475,9 @@ gtkui_create_pltmenu (int plt_idx) {
             NULL);
     g_signal_connect ((gpointer) add_new_playlist1, "activate",
             G_CALLBACK (on_add_new_playlist1_activate),
+            NULL);
+    g_signal_connect ((gpointer) autosort, "toggled",
+            G_CALLBACK (on_autosort_toggled),
             NULL);
     g_signal_connect ((gpointer) copy_playlist1, "activate",
             G_CALLBACK (on_copy_playlist1_activate),

--- a/sort.h
+++ b/sort.h
@@ -32,4 +32,7 @@ plt_sort_v2 (playlist_t *plt, int iter, int id, const char *format, int order);
 void
 sort_track_array (playlist_t *playlist, playItem_t **tracks, int num_tracks, const char *format, int order);
 
+void
+plt_autosort (playlist_t *plt);
+
 #endif /* defined(__deadbeef__sort__) */


### PR DESCRIPTION
This patch automatically sorts the current playlist when new files are added. It is then no longer necessary to manually sort the playlist because the playlist is messed up.

How does it work?
The feature must be enabled first using `gtkui.autosort_enabled 1`
After that you choose the way how the playlist should be sorted via Sort by -> Title, Track ...
The selection is stored in the config under the key `gtkui.last_used_sortby_format`.

Each time new files are added, the current playlist is sorted by the stored value. There is no need for manual sorting any more.