### PR TITLE
Title formatting, Part 2

### DIFF
--- a/osx/Tests/TitleFormattingTests.m
+++ b/osx/Tests/TitleFormattingTests.m
@@ -2218,5 +2218,13 @@ static DB_output_t fake_out = {
     XCTAssert(!strcmp (buffer, ""), @"The actual output is: %s", buffer);
 }
 
+- (void)test_Complex_Sane {
+    pl_replace_meta (it, "path", "/media/Icy/Music/Long/Folder/Structure/2019.01.01 [Meta1] Meta2 [Meta3] Meta4 [Meta5] Meta6 [Meta7] Meta8 [Meta9]/some_reasonably_long_path.flac");
+    char *bc = tf_compile("$substr($directory(%path%,1),1,$sub($strstr($directory(%path%,1),' ['),1))");
+    tf_eval (&ctx, bc, buffer, 1000);
+    tf_free(bc);
+    XCTAssert(!strcmp (buffer, "2019.01.01"), @"The actual output is: %s", buffer);
+}
+
 
 @end

--- a/tf.c
+++ b/tf.c
@@ -197,7 +197,7 @@ tf_eval (ddb_tf_context_t *ctx, const char *code, char *out, int outlen) {
         break;
     default:
         // tf_eval_int expects outlen to not include the terminating zero
-        l = tf_eval_int (ctx, code, codelen, out, outlen - 1, &bool_out, 0);
+        TF_EVAL_CHECK(l, ctx, code, codelen, out, outlen - 1, 0);
         break;
     }
 

--- a/tf.c
+++ b/tf.c
@@ -1181,8 +1181,11 @@ tf_func_progress_impl(ddb_tf_context_t *ctx, int argc, const uint16_t *arglens, 
 
     TF_EVAL_CHECK(len, ctx, argpos, arglens[1], out, outlen - 1, fail_on_undef);
     range = atoi(out);
-    if (range <= 0) {
+    if (range < 0) {
         return -1;
+    }
+    if (range == 0) {
+        range = 1;
     }
     argpos += arglens[1];
 


### PR DESCRIPTION
This follows on from #2190.

- When the top level function fails, produce an empty string, like it would if it was a nested call.
- Adjust `$progress` to support and match fb2k's handling of zero-range calls, such as `$progress(0,0,10,x,=)`
- Adds a test to track support of complicated function chains.