### PR TITLE
Start minimized to tray

### DIFF
--- a/plugins/converter/callbacks.h
+++ b/plugins/converter/callbacks.h
@@ -134,3 +134,7 @@ on_bypass_same_format_toggled          (GtkToggleButton *togglebutton,
 void
 on_retag_after_copy_toggled            (GtkToggleButton *togglebutton,
                                         gpointer         user_data);
+
+void
+on_minimize_on_startup_clicked         (GtkButton       *button,
+                                        gpointer         user_data);

--- a/plugins/gtkui/callbacks.c
+++ b/plugins/gtkui/callbacks.c
@@ -800,3 +800,5 @@ on_log_window_key_press_event          (GtkWidget       *widget,
     }
     return FALSE;
 }
+
+

--- a/plugins/gtkui/callbacks.h
+++ b/plugins/gtkui/callbacks.h
@@ -1411,3 +1411,7 @@ on_checkbutton_sr_override_toggled     (GtkToggleButton *togglebutton,
 void
 on_checkbutton_dependent_sr_toggled    (GtkToggleButton *togglebutton,
                                         gpointer         user_data);
+
+void
+on_minimize_on_startup_clicked         (GtkButton       *button,
+                                        gpointer         user_data);

--- a/plugins/gtkui/deadbeef.glade
+++ b/plugins/gtkui/deadbeef.glade
@@ -3715,6 +3715,26 @@ Only prevent clipping</property>
 		  <property name="spacing">8</property>
 
 		  <child>
+		    <widget class="GtkCheckButton" id="minimize_on_startup">
+		      <property name="visible">True</property>
+		      <property name="can_focus">True</property>
+		      <property name="label" translatable="yes">Minimize to tray on startup</property>
+		      <property name="use_underline">True</property>
+		      <property name="relief">GTK_RELIEF_NORMAL</property>
+		      <property name="focus_on_click">True</property>
+		      <property name="active">False</property>
+		      <property name="inconsistent">False</property>
+		      <property name="draw_indicator">True</property>
+		      <signal name="clicked" handler="on_minimize_on_startup_clicked" last_modification_time="Sun, 11 Aug 2019 13:06:16 GMT"/>
+		    </widget>
+		    <packing>
+		      <property name="padding">0</property>
+		      <property name="expand">False</property>
+		      <property name="fill">False</property>
+		    </packing>
+		  </child>
+
+		  <child>
 		    <widget class="GtkCheckButton" id="pref_close_send_to_tray">
 		      <property name="visible">True</property>
 		      <property name="can_focus">True</property>
@@ -10542,7 +10562,7 @@ Descending</property>
 </widget>
 
 <widget class="GtkWindow" id="rg_scan_progress">
-  <property name="width_request">440</property>
+  <property name="width_request">650</property>
   <property name="visible">True</property>
   <property name="title" translatable="yes">ReplayGain Scan Progress</property>
   <property name="type">GTK_WINDOW_TOPLEVEL</property>
@@ -10695,7 +10715,7 @@ Descending</property>
 </widget>
 
 <widget class="GtkWindow" id="rg_scan_results">
-  <property name="width_request">550</property>
+  <property name="width_request">1000</property>
   <property name="height_request">350</property>
   <property name="visible">True</property>
   <property name="title" translatable="yes">ReplayGain Scan Results</property>

--- a/plugins/gtkui/gtkui.c
+++ b/plugins/gtkui/gtkui.c
@@ -169,6 +169,8 @@ format_timestr (char *buf, int sz, float time) {
 
 static gboolean
 update_songinfo (gpointer unused) {
+    if (w_get_rootwidget() == NULL) return FALSE;
+ 
     int iconified = gdk_window_get_state(gtk_widget_get_window(mainwin)) & GDK_WINDOW_STATE_ICONIFIED;
     if (!gtk_widget_get_visible (mainwin) || iconified) {
         return FALSE;
@@ -302,11 +304,6 @@ show_traymenu (void) {
     g_idle_add (show_traymenu_cb, NULL);
 }
 
-static gboolean
-mainwin_hide_cb (gpointer data) {
-    gtk_widget_hide (mainwin);
-    return FALSE;
-}
 
 void
 mainwin_toggle_visible (void) {
@@ -315,6 +312,8 @@ mainwin_toggle_visible (void) {
         gtk_widget_hide (mainwin);
     }
     else {
+        if (w_get_rootwidget() == NULL) init_widget_layout ();
+      
         wingeom_restore (mainwin, "mainwin", 40, 40, 500, 300, 0);
         if (iconified) {
             gtk_window_deiconify (GTK_WINDOW(mainwin));
@@ -1327,10 +1326,12 @@ gtkui_mainwin_init(void) {
         window_init_hooks[i].callback (window_init_hooks[i].userdata);
     }
     wingeom_restore (mainwin, "mainwin", 40, 40, 500, 300, 0);
-    gtk_widget_show (mainwin);
 
-    init_widget_layout ();
-
+    if (!deadbeef->conf_get_int ("gtkui.start_hidden", 0)) {
+        gtk_widget_show (mainwin);
+        init_widget_layout ();
+    }
+    
     gtkui_set_titlebar (NULL);
 
     fileadded_listener_id = deadbeef->listen_file_added (gtkui_add_file_info_cb, NULL);
@@ -1346,10 +1347,6 @@ gtkui_mainwin_init(void) {
 #ifdef __APPLE__
     gtkui_is_retina = is_retina (mainwin);
 #endif
-
-    if (deadbeef->conf_get_int ("gtkui.start_hidden", 0)) {
-        g_idle_add (mainwin_hide_cb, NULL);
-    }
 }
 
 void

--- a/plugins/gtkui/gtkui.c
+++ b/plugins/gtkui/gtkui.c
@@ -362,6 +362,7 @@ on_trayicon_popup_menu (GtkWidget       *widget,
 
 static gboolean
 activate_cb (gpointer nothing) {
+    if (w_get_rootwidget () == NULL) init_widget_layout ();
     gtk_widget_show (mainwin);
     gtk_window_present (GTK_WINDOW (mainwin));
     return FALSE;

--- a/plugins/gtkui/gtkui.h
+++ b/plugins/gtkui/gtkui.h
@@ -183,6 +183,9 @@ gtkui_mainwin_init(void);
 void
 gtkui_mainwin_free(void);
 
+static void
+init_widget_layout (void);
+
 enum GtkuiFileChooserType {
     GTKUI_FILECHOOSER_OPENFILE,
     GTKUI_FILECHOOSER_OPENFOLDER,

--- a/plugins/gtkui/interface.c
+++ b/plugins/gtkui/interface.c
@@ -147,6 +147,7 @@ create_mainwin (void)
   separator2 = gtk_separator_menu_item_new ();
   gtk_widget_show (separator2);
   gtk_container_add (GTK_CONTAINER (File_menu), separator2);
+  gtk_widget_set_sensitive (separator2, FALSE);
 
   add_files = gtk_image_menu_item_new_with_mnemonic (_("Add file(s)"));
   gtk_widget_show (add_files);
@@ -171,6 +172,7 @@ create_mainwin (void)
   separatormenuitem1 = gtk_separator_menu_item_new ();
   gtk_widget_show (separatormenuitem1);
   gtk_container_add (GTK_CONTAINER (File_menu), separatormenuitem1);
+  gtk_widget_set_sensitive (separatormenuitem1, FALSE);
 
   new_playlist1 = gtk_menu_item_new_with_mnemonic (_("New playlist"));
   gtk_widget_show (new_playlist1);
@@ -187,6 +189,7 @@ create_mainwin (void)
   separator8 = gtk_separator_menu_item_new ();
   gtk_widget_show (separator8);
   gtk_container_add (GTK_CONTAINER (File_menu), separator8);
+  gtk_widget_set_sensitive (separator8, FALSE);
 
   quit = gtk_image_menu_item_new_with_mnemonic (_("_Quit"));
   gtk_widget_show (quit);
@@ -284,6 +287,7 @@ create_mainwin (void)
   separator5 = gtk_separator_menu_item_new ();
   gtk_widget_show (separator5);
   gtk_container_add (GTK_CONTAINER (Edit_menu), separator5);
+  gtk_widget_set_sensitive (separator5, FALSE);
 
   preferences = gtk_menu_item_new_with_mnemonic (_("Preferences"));
   gtk_widget_show (preferences);
@@ -395,6 +399,7 @@ create_mainwin (void)
   separator11 = gtk_separator_menu_item_new ();
   gtk_widget_show (separator11);
   gtk_container_add (GTK_CONTAINER (Playback_menu), separator11);
+  gtk_widget_set_sensitive (separator11, FALSE);
 
   jump_to_current_track1 = gtk_menu_item_new_with_mnemonic (_("Jump to current track"));
   gtk_widget_show (jump_to_current_track1);
@@ -422,6 +427,7 @@ create_mainwin (void)
   separator10 = gtk_separator_menu_item_new ();
   gtk_widget_show (separator10);
   gtk_container_add (GTK_CONTAINER (Help_menu), separator10);
+  gtk_widget_set_sensitive (separator10, FALSE);
 
   gpl1 = gtk_menu_item_new_with_mnemonic (_("_GPLv2"));
   gtk_widget_show (gpl1);
@@ -434,6 +440,7 @@ create_mainwin (void)
   separator9 = gtk_separator_menu_item_new ();
   gtk_widget_show (separator9);
   gtk_container_add (GTK_CONTAINER (Help_menu), separator9);
+  gtk_widget_set_sensitive (separator9, FALSE);
 
   about1 = gtk_image_menu_item_new_with_mnemonic (_("_About"));
   gtk_widget_show (about1);
@@ -1595,6 +1602,7 @@ create_prefwin (void)
   GtkWidget *label110;
   GtkWidget *notebook5;
   GtkWidget *vbox9;
+  GtkWidget *minimize_on_startup;
   GtkWidget *pref_close_send_to_tray;
   GtkWidget *hide_tray_icon;
   GtkWidget *enable_shift_jis_recoding;
@@ -2160,6 +2168,10 @@ create_prefwin (void)
   gtk_widget_show (vbox9);
   gtk_container_add (GTK_CONTAINER (notebook5), vbox9);
   gtk_container_set_border_width (GTK_CONTAINER (vbox9), 12);
+
+  minimize_on_startup = gtk_check_button_new_with_mnemonic (_("Minimize to tray on startup"));
+  gtk_widget_show (minimize_on_startup);
+  gtk_box_pack_start (GTK_BOX (vbox9), minimize_on_startup, FALSE, FALSE, 0);
 
   pref_close_send_to_tray = gtk_check_button_new_with_mnemonic (_("Close minimizes to tray"));
   gtk_widget_show (pref_close_send_to_tray);
@@ -3172,6 +3184,9 @@ create_prefwin (void)
   g_signal_connect ((gpointer) dsp_preset_load, "clicked",
                     G_CALLBACK (on_dsp_preset_load_clicked),
                     NULL);
+  g_signal_connect ((gpointer) minimize_on_startup, "clicked",
+                    G_CALLBACK (on_minimize_on_startup_clicked),
+                    NULL);
   g_signal_connect ((gpointer) pref_close_send_to_tray, "clicked",
                     G_CALLBACK (on_pref_close_send_to_tray_clicked),
                     NULL);
@@ -3463,6 +3478,7 @@ create_prefwin (void)
   GLADE_HOOKUP_OBJECT (prefwin, label110, "label110");
   GLADE_HOOKUP_OBJECT (prefwin, notebook5, "notebook5");
   GLADE_HOOKUP_OBJECT (prefwin, vbox9, "vbox9");
+  GLADE_HOOKUP_OBJECT (prefwin, minimize_on_startup, "minimize_on_startup");
   GLADE_HOOKUP_OBJECT (prefwin, pref_close_send_to_tray, "pref_close_send_to_tray");
   GLADE_HOOKUP_OBJECT (prefwin, hide_tray_icon, "hide_tray_icon");
   GLADE_HOOKUP_OBJECT (prefwin, enable_shift_jis_recoding, "enable_shift_jis_recoding");
@@ -5293,7 +5309,7 @@ create_rg_scan_progress (void)
   GtkWidget *rg_scan_progress_cancel;
 
   rg_scan_progress = gtk_window_new (GTK_WINDOW_TOPLEVEL);
-  gtk_widget_set_size_request (rg_scan_progress, 440, -1);
+  gtk_widget_set_size_request (rg_scan_progress, 650, -1);
   gtk_window_set_title (GTK_WINDOW (rg_scan_progress), _("ReplayGain Scan Progress"));
 
   vbox50 = gtk_vbox_new (FALSE, 8);
@@ -5361,7 +5377,7 @@ create_rg_scan_results (void)
   GtkWidget *rg_scan_results_cancel;
 
   rg_scan_results = gtk_window_new (GTK_WINDOW_TOPLEVEL);
-  gtk_widget_set_size_request (rg_scan_results, 550, 350);
+  gtk_widget_set_size_request (rg_scan_results, 1000, 350);
   gtk_window_set_title (GTK_WINDOW (rg_scan_results), _("ReplayGain Scan Results"));
 
   vbox51 = gtk_vbox_new (FALSE, 8);

--- a/plugins/gtkui/prefwin.c
+++ b/plugins/gtkui/prefwin.c
@@ -276,6 +276,9 @@ gtkui_run_preferences_dlg (void) {
     // dsp
     dsp_setup_init (prefwin);
 
+    // minimize_on_startup
+    set_toggle_button("minimize_on_startup", deadbeef->conf_get_int ("gtkui.start_hidden", 0));
+    
     // close_send_to_tray
     set_toggle_button("pref_close_send_to_tray", deadbeef->conf_get_int ("close_send_to_tray", 0));
 
@@ -586,6 +589,19 @@ on_global_preamp_value_changed     (GtkRange        *range,
 }
 
 void
+on_minimize_on_startup_clicked     (GtkButton       *button,
+                                   gpointer         user_data)
+{
+    int active = gtk_toggle_button_get_active (GTK_TOGGLE_BUTTON (button));
+    deadbeef->conf_set_int ("gtkui.start_hidden", active);
+    if (active == 1) {
+        set_toggle_button("hide_tray_icon", 0);
+        deadbeef->conf_set_int ("gtkui.hide_tray_icon", 0);
+    }
+    deadbeef->sendmessage (DB_EV_CONFIGCHANGED, 0, 0, 0);
+}
+
+void
 on_pref_close_send_to_tray_clicked     (GtkButton       *button,
                                         gpointer         user_data)
 {
@@ -600,6 +616,10 @@ on_hide_tray_icon_toggled              (GtkToggleButton *togglebutton,
 {
     int active = gtk_toggle_button_get_active (togglebutton);
     deadbeef->conf_set_int ("gtkui.hide_tray_icon", active);
+    if (active == 1) {
+        set_toggle_button("minimize_on_startup", 0);
+        deadbeef->conf_set_int ("gtkui.start_hidden", 0);
+    }
     deadbeef->sendmessage (DB_EV_CONFIGCHANGED, 0, 0, 0);
 }
 

--- a/plugins/gtkui/widgets.c
+++ b/plugins/gtkui/widgets.c
@@ -264,9 +264,11 @@ w_free (void) {
     }
     w_creators = NULL;
 
-    w_remove (NULL, rootwidget);
-    w_destroy (rootwidget);
-    rootwidget = NULL;
+    if (rootwidget != NULL) {
+        w_remove (NULL, rootwidget);
+        w_destroy (rootwidget);
+        rootwidget = NULL;
+    }
 }
 
 ddb_gtkui_widget_t *
@@ -666,6 +668,8 @@ save_widget_to_string (char *str, int sz, ddb_gtkui_widget_t *w) {
 
 void
 w_save (void) {
+    if (rootwidget == NULL) return;
+    
     char buf[20000] = "";
     save_widget_to_string (buf, sizeof (buf), rootwidget->children);
     deadbeef->conf_set_str (DDB_GTKUI_CONF_LAYOUT, buf);


### PR DESCRIPTION
This is a pull request for a better start minimized to tray.
The following things have been improved:
* the main window is no longer displayed and then hidden
* no more high CPU load if the main window was not switched to visible before (caused by init_widget_layout ();)
* no endless error messages GDK_IS_WINDOW (window)' failed errors (caused by update_songinfo (gpointer unused))
* shutdown of the application has also been reviewed and modified
* start minimized to tray can now be configured in the settings
* a check has been added that "minimized to tray" and "trayicon invisible" cannot be enabled both

![pic](https://user-images.githubusercontent.com/39984895/64632308-2013d980-d3f9-11e9-9610-fc410dc6fabc.png)
