### PR TITLE
Path raw fix

### DIFF
--- a/osx/Tests/TitleFormattingTests.m
+++ b/osx/Tests/TitleFormattingTests.m
@@ -1341,6 +1341,30 @@ static DB_output_t fake_out = {
     XCTAssert(!strcmp (buffer, "file:///home/user/filename.mp3"), @"The actual output is: %s", buffer);
 }
 
+- (void)test_RawPathWithHttpUriScheme_ReturnUnStripped {
+    pl_replace_meta (it, ":URI", "http://example.com/filename.mp3");
+    char *bc = tf_compile("%_path_raw%");
+    tf_eval (&ctx, bc, buffer, 1000);
+    tf_free (bc);
+    XCTAssert(!strcmp (buffer, "http://example.com/filename.mp3"), @"The actual output is: %s", buffer);
+}
+
+- (void)test_RawPathAbsolutePath_ReturnsExpected {
+    pl_replace_meta (it, ":URI", "/path/to/filename.mp3");
+    char *bc = tf_compile("%_path_raw%");
+    tf_eval (&ctx, bc, buffer, 1000);
+    tf_free (bc);
+    XCTAssert(!strcmp (buffer, "file:///path/to/filename.mp3"), @"The actual output is: %s", buffer);
+}
+
+- (void)test_RawPathRelativePath_ReturnsEmpty {
+    pl_replace_meta (it, ":URI", "relative/path/to/filename.mp3");
+    char *bc = tf_compile("%_path_raw%");
+    tf_eval (&ctx, bc, buffer, 1000);
+    tf_free (bc);
+    XCTAssert(!strcmp (buffer, ""), @"The actual output is: %s", buffer);
+}
+
 - (void)test_PlaylistName_ReturnsPlaylistName {
     char *bc = tf_compile("%_playlist_name%");
     playlist_t plt = {
@@ -1461,6 +1485,14 @@ static DB_output_t fake_out = {
 - (void)test_PathWithNullUri_ReturnsEmpty {
     pl_delete_meta (it, ":URI");
     char *bc = tf_compile("%path%");
+    tf_eval (&ctx, bc, buffer, 1000);
+    tf_free (bc);
+    XCTAssert(!strcmp (buffer, ""), @"The actual output is: %s", buffer);
+}
+
+- (void)test_RawPathWithNullUri_ReturnsEmpty {
+    pl_delete_meta (it, ":URI");
+    char *bc = tf_compile("%_path_raw%");
     tf_eval (&ctx, bc, buffer, 1000);
     tf_free (bc);
     XCTAssert(!strcmp (buffer, ""), @"The actual output is: %s", buffer);

--- a/tf.c
+++ b/tf.c
@@ -2346,9 +2346,19 @@ tf_eval_int (ddb_tf_context_t *ctx, const char *code, int size, char *out, int o
                     const char *v = pl_find_meta_raw (it, ":URI");
 
                     if (v) {
-                        if (v[0] == '/') {
+                        #ifdef _WIN32
+                        int is_absolute = (isalpha (v[0]) && v[1] == ':' && v[2] == '/');
+                        #else
+                        int is_absolute = (v[0] == '/');
+                        #endif
+
+                        if (is_absolute) {
                             // This is an absolute path, just prepend proper prefix
+                            #ifdef _WIN32
+                            const char prefix[] = "file:///";
+                            #else
                             const char prefix[] = "file://";
+                            #endif
                             tf_append_out (&out, &outlen, prefix, sizeof (prefix) - 1);
                             tf_append_out (&out, &outlen, v, strlen (v));
                         }


### PR DESCRIPTION
This is a fix for #2197.

It's pretty trivial, however, there is some difficulty with relative paths that also may be stored in :URI metadata record. I decided to format them as non-standard file URI extension, because the alternative is to call realpath() to convert relative paths to absolute, and it is bad idea to do so in tf_eval() because it should be fast.

Maybe, it is a good idea not to store relative paths inside :URI at all by explicitly resolving them inside plt_insert_file_int(). It seems that foobar2000 is doing similar thing because for relative path provided through File->Add location it outputs absolute %_path_raw%. However, this is more intrusive change and it should be made per separate PR, if at all.

Please let me know what do you think on it.

I also wanted to add new tests for this use case, but unfortunately I have no Mac to verify them.

Testing:
![screen](https://user-images.githubusercontent.com/774509/65422611-5bc39000-de4a-11e9-8f9c-3a3f8aaaec4d.png)

