### PR TITLE
Values from selection_playback_time are not rounded

### DIFF
--- a/playlist.c
+++ b/playlist.c
@@ -3133,17 +3133,17 @@ float
 plt_get_selection_playback_time (playlist_t *playlist) {
     LOCK;
 
-    if (!playlist->recalc_seltime) {
-        float t = playlist->seltime;
-        UNLOCK;
-        return t;
-    }
-
     float t = 0;
+    
+    if (!playlist->recalc_seltime) {
+        t = playlist->seltime;
+        UNLOCK;
+        return roundf(t);
+    }
 
     for (playItem_t *it = playlist->head[PL_MAIN]; it; it = it->next[PL_MAIN]) {
         if (it->selected){
-            t += it->_duration;
+            t += roundf(it->_duration);
         }
     }
 


### PR DESCRIPTION
The displayed duration of songs is rounded internally, but not from selected songs. This can lead to different displayed values of individual files and of course cumulated values.
![pic](https://user-images.githubusercontent.com/39984895/65960643-3986cf00-e455-11e9-989b-975f2dccd133.png)