### PR TITLE
Two new play modes

### DIFF
--- a/deadbeef.h
+++ b/deadbeef.h
@@ -328,6 +328,8 @@ enum playback_order_t {
     PLAYBACK_ORDER_SHUFFLE_TRACKS = 1,
     PLAYBACK_ORDER_RANDOM = 2,
     PLAYBACK_ORDER_SHUFFLE_ALBUMS = 3,
+    PLAYBACK_ORDER_ARTIST = 4,
+    PLAYBACK_ORDER_TOP_RATED = 5,
 };
 
 // playback modes

--- a/plugins/gtkui/actionhandlers.c
+++ b/plugins/gtkui/actionhandlers.c
@@ -783,6 +783,30 @@ action_playback_loop_all_handler(DB_plugin_action_t *act, int ctx) {
 }
 
 gboolean
+action_playback_order_top_rated_handler_cb (void *data) {
+    gtk_check_menu_item_set_active (GTK_CHECK_MENU_ITEM (lookup_widget (mainwin, "order_top_rated")), 1);
+    return FALSE;
+}
+
+int
+action_playback_order_top_rated_handler(DB_plugin_action_t *act, int ctx) {
+    g_idle_add (action_playback_order_top_rated_handler_cb, NULL);
+    return 0;
+}
+
+gboolean
+action_playback_order_artist_handler_cb (void *data) {
+    gtk_check_menu_item_set_active (GTK_CHECK_MENU_ITEM (lookup_widget (mainwin, "order_artist")), 1);
+    return FALSE;
+}
+
+int
+action_playback_order_artist_handler(DB_plugin_action_t *act, int ctx) {
+    g_idle_add (action_playback_order_artist_handler_cb, NULL);
+    return 0;
+}
+
+gboolean
 action_playback_order_random_handler_cb (void *data) {
     gtk_check_menu_item_set_active (GTK_CHECK_MENU_ITEM (lookup_widget (mainwin, "order_random")), 1);
     return FALSE;
@@ -845,6 +869,12 @@ action_playback_order_cycle_handler_cb (void *data) {
         break;
     case PLAYBACK_ORDER_RANDOM:
         gtk_check_menu_item_set_active (GTK_CHECK_MENU_ITEM (lookup_widget (mainwin, "order_linear")), 1);
+        break;
+    case PLAYBACK_ORDER_ARTIST:
+        gtk_check_menu_item_set_active (GTK_CHECK_MENU_ITEM (lookup_widget (mainwin, "order_artist")), 1);
+        break;
+    case PLAYBACK_ORDER_TOP_RATED:
+        gtk_check_menu_item_set_active (GTK_CHECK_MENU_ITEM (lookup_widget (mainwin, "order_top_rated")), 1);
         break;
     }
     return FALSE;

--- a/plugins/gtkui/actionhandlers.h
+++ b/plugins/gtkui/actionhandlers.h
@@ -193,6 +193,12 @@ int
 action_playback_loop_all_handler(DB_plugin_action_t *act, int ctx);
 
 int
+action_playback_order_top_rated_handler(DB_plugin_action_t *act, int ctx);
+
+int
+action_playback_order_artist_handler(DB_plugin_action_t *act, int ctx);
+
+int
 action_playback_order_random_handler(DB_plugin_action_t *act, int ctx);
 
 int

--- a/plugins/gtkui/callbacks.c
+++ b/plugins/gtkui/callbacks.c
@@ -266,6 +266,22 @@ on_order_random_activate               (GtkMenuItem     *menuitem,
     deadbeef->sendmessage (DB_EV_CONFIGCHANGED, 0, 0, 0);
 }
 
+void
+on_order_artist_activate               (GtkMenuItem     *menuitem,
+                                        gpointer         user_data)
+{
+    deadbeef->conf_set_int ("playback.order", PLAYBACK_ORDER_ARTIST);
+    deadbeef->sendmessage (DB_EV_CONFIGCHANGED, 0, 0, 0);
+}
+
+void
+on_order_top_rated_activate             (GtkMenuItem     *menuitem,
+                                        gpointer         user_data)
+{
+    deadbeef->conf_set_int ("playback.order", PLAYBACK_ORDER_TOP_RATED);
+    deadbeef->sendmessage (DB_EV_CONFIGCHANGED, 0, 0, 0);
+}
+
 
 void
 on_loop_all_activate                   (GtkMenuItem     *menuitem,

--- a/plugins/gtkui/callbacks.h
+++ b/plugins/gtkui/callbacks.h
@@ -1415,3 +1415,11 @@ on_checkbutton_dependent_sr_toggled    (GtkToggleButton *togglebutton,
 void
 on_minimize_on_startup_clicked         (GtkButton       *button,
                                         gpointer         user_data);
+
+void
+on_order_artist_activate               (GtkMenuItem     *menuitem,
+                                        gpointer         user_data);
+
+void
+on_order_top_rated_activate            (GtkMenuItem     *menuitem,
+                                        gpointer         user_data);

--- a/plugins/gtkui/deadbeef.glade
+++ b/plugins/gtkui/deadbeef.glade
@@ -509,6 +509,28 @@
 			      <signal name="activate" handler="on_order_random_activate" last_modification_time="Sat, 08 Aug 2009 12:26:33 GMT"/>
 			    </widget>
 			  </child>
+
+			  <child>
+			    <widget class="GtkRadioMenuItem" id="order_artist">
+			      <property name="visible">True</property>
+			      <property name="label" translatable="yes">Keep Artist</property>
+			      <property name="use_underline">True</property>
+			      <property name="active">True</property>
+			      <property name="group">order_linear</property>
+			      <signal name="activate" handler="on_order_artist_activate" last_modification_time="Sat, 21 Sep 2019 13:52:01 GMT"/>
+			    </widget>
+			  </child>
+
+			  <child>
+			    <widget class="GtkRadioMenuItem" id="order_top_rated">
+			      <property name="visible">True</property>
+			      <property name="label" translatable="yes">Top Rated Tracks</property>
+			      <property name="use_underline">True</property>
+			      <property name="active">True</property>
+			      <property name="group">order_linear</property>
+			      <signal name="activate" handler="on_order_top_rated_activate" last_modification_time="Sat, 21 Sep 2019 13:52:01 GMT"/>
+			    </widget>
+			  </child>
 			</widget>
 		      </child>
 		    </widget>

--- a/plugins/gtkui/gtkui.c
+++ b/plugins/gtkui/gtkui.c
@@ -583,7 +583,7 @@ gtkui_on_configchanged (void *data) {
     const char *w;
 
     // order
-    const char *orderwidgets[4] = { "order_linear", "order_shuffle", "order_random", "order_shuffle_albums" };
+    const char *orderwidgets[6] = { "order_linear", "order_shuffle", "order_random", "order_shuffle_albums", "order_artist", "order_top_rated" };
     w = orderwidgets[deadbeef->conf_get_int ("playback.order", PLAYBACK_ORDER_LINEAR)];
     gtk_check_menu_item_set_active (GTK_CHECK_MENU_ITEM (lookup_widget (mainwin, w)), TRUE);
 
@@ -1711,6 +1711,22 @@ static DB_plugin_action_t action_playback_order_cycle = {
     .flags = DB_ACTION_COMMON,
     .callback2 = action_playback_order_cycle_handler,
     .next = &action_playback_loop_all
+};
+
+static DB_plugin_action_t action_playback_order_top_rated = {
+    .title = "Playback/Shuffle - Top Rated Tracks",
+    .name = "order_top_rated",
+    .flags = DB_ACTION_COMMON,
+    .callback2 = action_playback_order_top_rated_handler,
+    .next = &action_playback_order_cycle
+};
+
+static DB_plugin_action_t action_playback_order_artist = {
+    .title = "Playback/Shuffle - Keep Artist",
+    .name = "order_artist",
+    .flags = DB_ACTION_COMMON,
+    .callback2 = action_playback_order_artist_handler,
+    .next = &action_playback_order_cycle
 };
 
 static DB_plugin_action_t action_playback_order_random = {

--- a/plugins/gtkui/interface.c
+++ b/plugins/gtkui/interface.c
@@ -88,6 +88,8 @@ create_mainwin (void)
   GtkWidget *order_shuffle;
   GtkWidget *order_shuffle_albums;
   GtkWidget *order_random;
+  GtkWidget *order_artist;
+  GtkWidget *order_top_rated;
   GtkWidget *Looping;
   GtkWidget *Looping_menu;
   GSList *loop_all_group = NULL;
@@ -354,6 +356,18 @@ create_mainwin (void)
   gtk_container_add (GTK_CONTAINER (Order_menu), order_random);
   gtk_check_menu_item_set_active (GTK_CHECK_MENU_ITEM (order_random), TRUE);
 
+  order_artist = gtk_radio_menu_item_new_with_mnemonic (order_linear_group, _("Keep Artist"));
+  order_linear_group = gtk_radio_menu_item_get_group (GTK_RADIO_MENU_ITEM (order_artist));
+  gtk_widget_show (order_artist);
+  gtk_container_add (GTK_CONTAINER (Order_menu), order_artist);
+  gtk_check_menu_item_set_active (GTK_CHECK_MENU_ITEM (order_artist), TRUE);
+
+  order_top_rated = gtk_radio_menu_item_new_with_mnemonic (order_linear_group, _("Top Rated Tracks"));
+  order_linear_group = gtk_radio_menu_item_get_group (GTK_RADIO_MENU_ITEM (order_top_rated));
+  gtk_widget_show (order_top_rated);
+  gtk_container_add (GTK_CONTAINER (Order_menu), order_top_rated);
+  gtk_check_menu_item_set_active (GTK_CHECK_MENU_ITEM (order_top_rated), TRUE);
+
   Looping = gtk_menu_item_new_with_mnemonic (_("Repeat"));
   gtk_widget_show (Looping);
   gtk_container_add (GTK_CONTAINER (Playback_menu), Looping);
@@ -577,6 +591,12 @@ create_mainwin (void)
   g_signal_connect ((gpointer) order_random, "activate",
                     G_CALLBACK (on_order_random_activate),
                     NULL);
+  g_signal_connect ((gpointer) order_artist, "activate",
+                    G_CALLBACK (on_order_artist_activate),
+                    NULL);
+  g_signal_connect ((gpointer) order_top_rated, "activate",
+                    G_CALLBACK (on_order_top_rated_activate),
+                    NULL);
   g_signal_connect ((gpointer) loop_all, "activate",
                     G_CALLBACK (on_loop_all_activate),
                     NULL);
@@ -679,6 +699,8 @@ create_mainwin (void)
   GLADE_HOOKUP_OBJECT (mainwin, order_shuffle, "order_shuffle");
   GLADE_HOOKUP_OBJECT (mainwin, order_shuffle_albums, "order_shuffle_albums");
   GLADE_HOOKUP_OBJECT (mainwin, order_random, "order_random");
+  GLADE_HOOKUP_OBJECT (mainwin, order_artist, "order_artist");
+  GLADE_HOOKUP_OBJECT (mainwin, order_top_rated, "order_top_rated");
   GLADE_HOOKUP_OBJECT (mainwin, Looping, "Looping");
   GLADE_HOOKUP_OBJECT (mainwin, Looping_menu, "Looping_menu");
   GLADE_HOOKUP_OBJECT (mainwin, loop_all, "loop_all");


### PR DESCRIPTION
This pull request adds two new play modes:

**Keep Artist**
Retains the artist of the current song and automatically searches the playlist sequentially for the next one with identical artist. When the end is reached, the search begins from top of the playlist.

**Top Rated Tracks**
Randomly selects a song from the playlist, from this starting point the next song will be selected with a rating of at least 3 stars. Songs can be rated with the Song Rating plugin.

![pic](https://user-images.githubusercontent.com/39984895/66148767-f1f97200-e611-11e9-92eb-67b234943767.png)
