### PR TITLE
Track Gain All Unscanned Files In Playlist

### DIFF
--- a/plugins/gtkui/gtkui.c
+++ b/plugins/gtkui/gtkui.c
@@ -1592,12 +1592,20 @@ static DB_plugin_action_t action_rg_scan_per_file = {
     .next = &action_rg_scan_selection_as_album
 };
 
+static DB_plugin_action_t action_scan_all_tracks_without_Rg = {
+    .title = "ReplayGain/Track Gain All Unscanned Files In Playlist",
+    .name = "scan_all_tracks_without_Rg",
+    .flags = DB_ACTION_SINGLE_TRACK | DB_ACTION_MULTIPLE_TRACKS | DB_ACTION_ADD_MENU,
+    .callback2 = action_scan_all_tracks_without_Rg_handler ,
+    .next = &action_rg_scan_per_file
+};
+
 static DB_plugin_action_t action_deselect_all = {
     .title = "Edit/Deselect All",
     .name = "deselect_all",
     .flags = DB_ACTION_COMMON,
     .callback2 = action_deselect_all_handler,
-    .next = &action_rg_scan_per_file
+    .next = &action_scan_all_tracks_without_Rg
 };
 
 static DB_plugin_action_t action_select_all = {

--- a/plugins/gtkui/gtkui.c
+++ b/plugins/gtkui/gtkui.c
@@ -1592,11 +1592,11 @@ static DB_plugin_action_t action_rg_scan_per_file = {
     .next = &action_rg_scan_selection_as_album
 };
 
-static DB_plugin_action_t action_scan_all_tracks_without_Rg = {
-    .title = "ReplayGain/Track Gain All Unscanned Files In Playlist",
+static DB_plugin_action_t action_scan_all_tracks_without_rg = {
+    .title = "ReplayGain/Scan Per-file Track Gain If Not Scanned",
     .name = "scan_all_tracks_without_Rg",
     .flags = DB_ACTION_SINGLE_TRACK | DB_ACTION_MULTIPLE_TRACKS | DB_ACTION_ADD_MENU,
-    .callback2 = action_scan_all_tracks_without_Rg_handler ,
+    .callback2 = action_scan_all_tracks_without_rg_handler ,
     .next = &action_rg_scan_per_file
 };
 
@@ -1605,7 +1605,7 @@ static DB_plugin_action_t action_deselect_all = {
     .name = "deselect_all",
     .flags = DB_ACTION_COMMON,
     .callback2 = action_deselect_all_handler,
-    .next = &action_scan_all_tracks_without_Rg
+    .next = &action_scan_all_tracks_without_rg
 };
 
 static DB_plugin_action_t action_select_all = {

--- a/plugins/gtkui/rg.c
+++ b/plugins/gtkui/rg.c
@@ -689,9 +689,14 @@ action_scan_all_tracks_without_rg_handler (struct DB_plugin_action_s *action, in
     s._size = sizeof (ddb_replaygain_settings_t);
 
     deadbeef->pl_lock ();
-    int tc = deadbeef->plt_get_item_count (plt, PL_MAIN);
-    tracks = calloc (tc, sizeof (DB_playItem_t *));
 
+    int tc = deadbeef->plt_get_item_count (plt, PL_MAIN);
+    if (!tc) {
+        deadbeef->pl_unlock ();
+        return 0;
+    }
+    tracks = calloc (tc, sizeof (DB_playItem_t *));
+ 
     DB_playItem_t *it = deadbeef->plt_get_first (plt, PL_MAIN);
     while (it) {
         const char *uri = deadbeef->pl_find_meta (it, ":URI");

--- a/plugins/gtkui/rg.c
+++ b/plugins/gtkui/rg.c
@@ -676,8 +676,8 @@ action_rg_remove_info_handler (struct DB_plugin_action_s *action, int ctx) {
 }
 
 int
-action_scan_all_tracks_without_Rg_handler (struct DB_plugin_action_s *action, int ctx) {
-  int count = 0;
+action_scan_all_tracks_without_rg_handler (struct DB_plugin_action_s *action, int ctx) {
+    int count = 0;
     DB_playItem_t **tracks = NULL;
 
     ddb_playlist_t *plt = deadbeef->plt_get_curr ();

--- a/plugins/gtkui/rg.c
+++ b/plugins/gtkui/rg.c
@@ -489,6 +489,7 @@ _get_action_track_list (DB_plugin_action_t *action, int ctx, int *pcount, int on
         int tc = deadbeef->plt_getselcount (plt);
         if (!tc) {
             deadbeef->pl_unlock ();
+            deadbeef->plt_unref (plt);
             return NULL;
         }
         tracks = calloc (tc, sizeof (DB_playItem_t *));
@@ -521,6 +522,7 @@ _get_action_track_list (DB_plugin_action_t *action, int ctx, int *pcount, int on
         int tc = deadbeef->plt_get_item_count (plt, PL_MAIN);
         if (!tc) {
             deadbeef->pl_unlock ();
+            deadbeef->plt_unref (plt);
             return NULL;
         }
         tracks = calloc (tc, sizeof (DB_playItem_t *));
@@ -693,6 +695,7 @@ action_scan_all_tracks_without_rg_handler (struct DB_plugin_action_s *action, in
     int tc = deadbeef->plt_get_item_count (plt, PL_MAIN);
     if (!tc) {
         deadbeef->pl_unlock ();
+        deadbeef->plt_unref (plt);
         return 0;
     }
     tracks = calloc (tc, sizeof (DB_playItem_t *));

--- a/plugins/gtkui/rg.h
+++ b/plugins/gtkui/rg.h
@@ -22,7 +22,7 @@
 */
 
 int
-action_scan_all_tracks_without_Rg_handler (struct DB_plugin_action_s *action, int ctx);
+action_scan_all_tracks_without_rg_handler (struct DB_plugin_action_s *action, int ctx);
 
 int
 action_rg_scan_per_file_handler (struct DB_plugin_action_s *action, int ctx);

--- a/plugins/gtkui/rg.h
+++ b/plugins/gtkui/rg.h
@@ -21,6 +21,8 @@
     3. This notice may not be removed or altered from any source distribution.
 */
 
+int
+action_scan_all_tracks_without_Rg_handler (struct DB_plugin_action_s *action, int ctx);
 
 int
 action_rg_scan_per_file_handler (struct DB_plugin_action_s *action, int ctx);


### PR DESCRIPTION
This Pull Request adds a new entry to the ReplayGain Scanner: Track Gain All Unscanned Files In Playlist.
It is not easy to see which files are replay gained and which are not. Especially in larger collections it quickly becomes chaotic. The new routine therefore checks all files in the current playlist to see if they have been replay gained, and only processes those that are not. This is fast and efficient.