### PR TITLE
windows: is_relative_path fix for windows

### DIFF
--- a/playlist.c
+++ b/playlist.c
@@ -967,18 +967,6 @@ plt_insert_file_int (int visibility, playlist_t *playlist, playItem_t *after, co
         fname += 7;
     }
 
-    // now that it's known we're not dealing with URL, check if it's a relative path
-    if (is_relative_path (fname)) {
-        return NULL;
-    }
-
-    // detect decoder
-    const char *eol = strrchr (fname, '.');
-    if (!eol) {
-        return NULL;
-    }
-    eol++;
-
     #ifdef __MINGW32__
     // replace backslashes with normal slashes
     char fname_conv[strlen(fname)+1];
@@ -997,6 +985,18 @@ plt_insert_file_int (int visibility, playlist_t *playlist, playItem_t *after, co
         fname++;
     }
     #endif
+
+    // now that it's known we're not dealing with URL, check if it's a relative path
+    if (is_relative_path (fname)) {
+        return NULL;
+    }
+
+    // detect decoder
+    const char *eol = strrchr (fname, '.');
+    if (!eol) {
+        return NULL;
+    }
+    eol++;
 
     // handle cue files
     if (!strcasecmp (eol, "cue")) {
@@ -1170,10 +1170,6 @@ plt_insert_dir_int (int visibility, playlist_t *playlist, DB_vfs_t *vfs, playIte
         dirname += 7;
     }
 
-    if (is_relative_path (dirname)) {
-        return NULL;
-    }
-
     #ifdef __MINGW32__
     // replace backslashes with normal slashes
     char dirname_conv[strlen(dirname)+1];
@@ -1192,6 +1188,10 @@ plt_insert_dir_int (int visibility, playlist_t *playlist, DB_vfs_t *vfs, playIte
         dirname++;
     }
     #endif
+
+    if (is_relative_path (dirname)) {
+        return NULL;
+    }
 
     if (!playlist->follow_symlinks && !vfs) {
         struct stat buf;

--- a/plugins.c
+++ b/plugins.c
@@ -1538,12 +1538,18 @@ is_relative_path_win32 (const char *path_or_url) {
         }
     }
 
-    // path starts with a disk drive?
-    return (strlen (path_or_url) < 3
-            || !isalpha(path_or_url[0])
-            || path_or_url[1] != ':'
-            || !(path_or_url[2] == '\\' || path_or_url[2] == '/')
-            || !(path_or_url[3] != '\\' && path_or_url[3] != '/'));
+    // absolute paths start with "C:\" (or any other letter)
+    // UNC paths can also be absolute (starting with "\\")
+    // NOTE: this test won't cover \\? relative path and absolute path starting with "\"
+    if (strlen (path_or_url) >= 3) {
+        if (isalpha(path_or_url[0]) && path_or_url[1] == ':' && (path_or_url[2] == '\\' || path_or_url[2] == '/')) {
+            return 0;
+        }
+        else if (path_or_url[0] == '\\' && path_or_url[1] == '\\') {
+            return 0;
+        }
+    }
+    return 1;
 }
 
 #ifndef _WIN32


### PR DESCRIPTION
- Fixed order so that `is_relative_path` is called after conversion
- More structured approach of detection. It is not covering all the cases but I guess it will be fine. We could also consider using [`PathIsRelative()`](https://docs.microsoft.com/en-us/windows/win32/api/shlwapi/nf-shlwapi-pathisrelativea) from windows api