### PR TITLE
fix potential buffer overflow in on_group_by_custom_activate

### DIFF
--- a/plugins/gtkui/plcommon.c
+++ b/plugins/gtkui/plcommon.c
@@ -1548,9 +1548,9 @@ on_group_by_custom_activate            (GtkMenuItem     *menuitem,
     DdbListviewGroupFormat *fmt = listview->group_formats;
     while (fmt) {
         if (format[0] != 0) {
-            strncat(format, SUBGROUP_DELIMITER, sizeof(format) - 1);
+            strncat(format, SUBGROUP_DELIMITER, sizeof(format) - strlen(format) - 1);
         }
-        strncat(format, fmt->format, sizeof(format) - 1);
+        strncat(format, fmt->format, sizeof(format) - strlen(format) - 1);
         fmt = fmt->next;
     }
     gtk_entry_set_text (GTK_ENTRY (entry), format);


### PR DESCRIPTION
Repeated strncat calls may overflow the buffer, which is what gcc
complains about.  While in practice the buffer might be large enough,
the compiler can not possibly know that.

Rearrange the code to fill the buffer with its size in mind.

Signed-off-by: Olaf Hering <olaf@aepfle.de>