### PR TITLE
artwork-legacy: add fallback to *.png

### DIFF
--- a/plugins/artwork-legacy/artwork.c
+++ b/plugins/artwork-legacy/artwork.c
@@ -1254,7 +1254,8 @@ local_image_file (const char *cache_path, const char *local_path, const char *ur
         }
     }
     if (!scan_local_path ("*.jpg", cache_path, local_path, uri, vfsplug) ||
-        !scan_local_path ("*.jpeg", cache_path, local_path, uri, vfsplug)) {
+        !scan_local_path ("*.jpeg", cache_path, local_path, uri, vfsplug) ||
+        !scan_local_path ("*.png", cache_path, local_path, uri, vfsplug)) {
         return 0;
     }
 


### PR DESCRIPTION
Currently, if none of the specified filenames (`*cover*.jpg`, `*cover*.png`, etc.) is found in local folder, DB falls back to any jpg/jpeg.
Add fallback to png as well.
Makes it consistent with 'artwork' plugin:
https://github.com/DeaDBeeF-Player/deadbeef/blob/master/plugins/artwork/artwork.c#L1254#L1256
