### PR TITLE
fix syntax error in deadbeef.h

### DIFF
--- a/deadbeef.h
+++ b/deadbeef.h
@@ -1598,7 +1598,7 @@ enum {
 #if (DDB_API_LEVEL >= 11)
 } ddb_action_context_t;
 #else
-}
+};
 #endif
 #endif
 


### PR DESCRIPTION
line 1601 ends an enum declaration but it's missing the semicolon

```
% clang -xc -DDDB_API_LEVEL=10 /usr/include/deadbeef/deadbeef.h
/usr/include/deadbeef/deadbeef.h:1601:2: error: expected ';' after enum
}
 ^
 ;
```