### PR TITLE
alac: fix for no decoder config

### DIFF
--- a/plugins/libmp4ff/mp4ff.c
+++ b/plugins/libmp4ff/mp4ff.c
@@ -336,6 +336,7 @@ int32_t mp4ff_get_decoder_config(const mp4ff_t *f, const int32_t track,
     {
         *ppBuf = NULL;
         *pBufSize = 0;
+        return 1;
     } else {
         *ppBuf = malloc(f->track[track]->decoderConfigLen);
         if (*ppBuf == NULL)


### PR DESCRIPTION
Some mp4 files cause Segmentation Fault without this check. Turns out that `mp4ff_get_decoder_config()` succeeds every time request is valid, but only sets buff and buff_size if these values are known.