### PR TITLE
Windows branch merge

### DIFF
--- a/playlist.c
+++ b/playlist.c
@@ -2864,6 +2864,17 @@ pl_format_title_int (const char *escape_chars, playItem_t *it, int idx, char *s,
             }
             else if (*fmt == 'F') {
                 meta = pl_find_meta_raw (it, ":URI");
+                #ifdef __MINGW32__
+                int len = strlen(meta);
+                strncpy (dirname, meta, len);
+                dirname[len] = 0;
+                // Convert to backslashes on windows
+                char *str_p = dirname;
+                while (str_p = strchr(str_p,'/')) {
+                    *str_p = '\\';
+                }
+                meta = dirname;
+                #endif
             }
             else if (*fmt == 'T') {
                 char *t = tags;
@@ -2951,6 +2962,15 @@ pl_format_title_int (const char *escape_chars, playItem_t *it, int idx, char *s,
                     len = min (len, sizeof (dirname)-1);
                     strncpy (dirname, f, len);
                     dirname[len] = 0;
+                    #ifdef __MINGW32__
+                    {
+                        // Convert to backslashes on windows
+                        char *str_p = dirname;
+                        while (str_p = strchr(str_p,'/')) {
+                            *str_p = '\\';
+                        }
+                    }
+                    #endif
                     meta = dirname;
                 }
             }

--- a/premake5-tools.lua
+++ b/premake5-tools.lua
@@ -225,7 +225,17 @@ function print_options ()
 end
 
 -- Returns deadbeef version which is stored in ./PORTABLE_VERSION
+-- WINDOWS: Return current date
 function get_version ()
+	if os.host() == "windows" then
+		date = os.date("%Y-%m-%d")
+		fp = io.open ("PORTABLE_VERSION","w")
+		io.output (fp)
+		io.write(date)
+		io.close (fp)
+		print(date)
+		return date
+	end
 	fp = io.open ("PORTABLE_VERSION","r")
 	io.input (fp)
 	local ver = io.read()

--- a/premake5-win.lua
+++ b/premake5-win.lua
@@ -70,6 +70,8 @@ project "libwin"
    files {
        "shared/windows/fopen.c",
        "shared/windows/mingw32_layer.h",
+       "shared/windows/mkdir.c",
+       "shared/windows/rmdir.c",
        "shared/windows/rename.c",
        "shared/windows/scandir.c",
        "shared/windows/stat.c",
@@ -290,11 +292,11 @@ project "opus_plugin"
    defines { "HAVE_OGG_STREAM_FLUSH_FILL" }
    links { "opusfile", "opus", "m", "ogg" }
    filter "configurations:debug32 or release32"
-   
+
       includedirs { "static-deps/lib-x86-32/include/opus" }
 
    filter "configurations:debug or release"
-   
+
       includedirs { "static-deps/lib-x86-64/include/opus" }
 end
 
@@ -427,12 +429,12 @@ project "ddb_gui_GTK2"
     pkgconfig ("gtk+-2.0 jansson")
 
     filter "configurations:debug32 or release32"
-    
+
        includedirs { "static-deps/lib-x86-32/gtk-2.16.0/include/**", "static-deps/lib-x86-32/gtk-2.16.0/lib/**", "plugins/gtkui", "plugins/libparser" }
        libdirs { "static-deps/lib-x86-32/gtk-2.16.0/lib", "static-deps/lib-x86-32/gtk-2.16.0/lib/**" }
 
     filter "configurations:debug or release"
-    
+
        includedirs { "static-deps/lib-x86-64/gtk-2.16.0/include/**", "static-deps/lib-x86-64/gtk-2.16.0/lib/**", "plugins/gtkui", "plugins/libparser" }
        libdirs { "static-deps/lib-x86-64/gtk-2.16.0/lib", "static-deps/lib-x86-64/gtk-2.16.0/lib/**" }
 end

--- a/premake5-win.lua
+++ b/premake5-win.lua
@@ -910,6 +910,21 @@ project "ddb_soundtouch"
    }
 end
 
+if option ("plugin-tta") then
+project "tta"
+   kind "SharedLib"
+   language "C"
+   targetdir "bin/%{cfg.buildcfg}/plugins"
+   targetprefix ""
+
+   files {
+       "plugins/tta/ttaplug.c",
+       "plugins/tta/filter.h",
+       "plugins/tta/ttadec.c",
+       "plugins/tta/ttadec.h"
+   }
+end
+
 
 project "translations"
    kind "Utility"

--- a/premake5-win.lua
+++ b/premake5-win.lua
@@ -509,6 +509,22 @@ project "converter"
    }
 end
 
+if option ("plugin-shellexec", "jansson") then
+project "shellexec"
+   kind "SharedLib"
+   language "C"
+   targetdir "bin/%{cfg.buildcfg}/plugins"
+   targetprefix ""
+
+   files {
+       "plugins/shellexec/shellexec.c",
+       "plugins/shellexec/shellexec.h",
+       "plugins/shellexec/shellexecutil.c",
+       "plugins/shellexec/shellexecutil.h"
+   }
+   pkgconfig("jansson")
+end
+
 if option ("plugin-sndfile", "sndfile") then
 project "sndfile_plugin"
    kind "SharedLib"
@@ -741,6 +757,46 @@ project "pltbrowser_gtk3"
    }
 
    pkgconfig ("gtk+-3.0")
+end
+
+if option ("plugin-shellexecui_gtk2", "gtk+-2.0 jansson") then
+project "shellexecui_gtk2"
+   kind "SharedLib"
+   language "C"
+   targetdir "bin/%{cfg.buildcfg}/plugins"
+   targetprefix ""
+
+   files {
+       "plugins/shellexecui/shellexecui.c",
+       "plugins/shellexecui/interface.c",
+       "plugins/shellexecui/support.c",
+       "plugins/shellexecui/callbacks.c",
+       "plugins/shellexecui/interface.h",
+       "plugins/shellexecui/support.h",
+       "plugins/shellexecui/callbacks.h"
+   }
+
+   pkgconfig ("gtk+-2.0 jansson")
+end
+
+if option ("plugin-shellexecui_gtk3", "gtk+-3.0 jansson") then
+project "shellexecui_gtk3"
+   kind "SharedLib"
+   language "C"
+   targetdir "bin/%{cfg.buildcfg}/plugins"
+   targetprefix ""
+
+   files {
+       "plugins/shellexecui/shellexecui.c",
+       "plugins/shellexecui/interface.c",
+       "plugins/shellexecui/support.c",
+       "plugins/shellexecui/callbacks.c",
+       "plugins/shellexecui/interface.h",
+       "plugins/shellexecui/support.h",
+       "plugins/shellexecui/callbacks.h"
+   }
+
+   pkgconfig ("gtk+-3.0 jansson")
 end
 
 if option ("plugin-wildmidi") then

--- a/premake5.lua
+++ b/premake5.lua
@@ -650,6 +650,19 @@ project "ddb_soundtouch"
        "plugins/soundtouch/soundtouch/source/SoundTouch/sse_optimized.cpp"
    }
 
+project "tta"
+   kind "SharedLib"
+   language "C"
+   targetdir "bin/%{cfg.buildcfg}/plugins"
+   targetprefix ""
+
+   files {
+       "plugins/tta/ttaplug.c",
+       "plugins/tta/filter.h",
+       "plugins/tta/ttadec.c",
+       "plugins/tta/ttadec.h"
+   }
+
 
 project "resources"
     kind "Utility"

--- a/shared/windows/fopen.c
+++ b/shared/windows/fopen.c
@@ -1,3 +1,25 @@
+/*
+    shared/windows/fopen.c
+    Copyright (C) 2018 Jakub Wasylków
+
+    This software is provided 'as-is', without any express or implied
+    warranty.  In no event will the authors be held liable for any damages
+    arising from the use of this software.
+
+    Permission is granted to anyone to use this software for any purpose,
+    including commercial applications, and to alter it and redistribute it
+    freely, subject to the following restrictions:
+
+    1. The origin of this software must not be misrepresented; you must not
+     claim that you wrote the original software. If you use this software
+     in a product, an acknowledgment in the product documentation would be
+     appreciated but is not required.
+
+    2. Altered source versions must be plainly marked as such, and must not be
+     misrepresented as being the original software.
+
+    3. This notice may not be removed or altered from any source distribution.
+*/
 #include <stdio.h>
 #include <dlfcn.h>
 #include "utils.h"

--- a/shared/windows/mingw32_layer.h
+++ b/shared/windows/mingw32_layer.h
@@ -1,4 +1,25 @@
+/*
+    shared/windows/mingw32_layer.h
+    Copyright (C) 2016 Elio Blanca
 
+    This software is provided 'as-is', without any express or implied
+    warranty.  In no event will the authors be held liable for any damages
+    arising from the use of this software.
+
+    Permission is granted to anyone to use this software for any purpose,
+    including commercial applications, and to alter it and redistribute it
+    freely, subject to the following restrictions:
+
+    1. The origin of this software must not be misrepresented; you must not
+     claim that you wrote the original software. If you use this software
+     in a product, an acknowledgment in the product documentation would be
+     appreciated but is not required.
+
+    2. Altered source versions must be plainly marked as such, and must not be
+     misrepresented as being the original software.
+
+    3. This notice may not be removed or altered from any source distribution.
+*/
 #ifndef _MINGW32_LAYER_H_
 #define _MINGW32_LAYER_H_
 

--- a/shared/windows/mingw32_layer.h
+++ b/shared/windows/mingw32_layer.h
@@ -33,8 +33,9 @@
 #undef max
 #undef min
 
-// Ignore modes for mkdir to be comatible with windows mkdir
-#define mkdir(X,Y)    mkdir(X)
+// make mkdir and rmdir compatible with windows
+#define mkdir(X,Y) win_mkdir(X, Y)
+#define rmdir(X)   win_rmdir(X)
 
 // Most of these values come from Elio's port, these values should be checked if they are still needed
 
@@ -105,6 +106,9 @@ typedef pthread_cond_t  *db_cond_t;
 #undef rename
 #define rename(X,Y) rename_windows(X,Y)
 int rename_windows(const char *, const char *);
+
+int win_mkdir (const char *path, mode_t mode);
+int win_rmdir (const char *path);
 
 // Own scandir implementation
 int scandir (const char *__dir, struct dirent ***__namelist, int (*__selector) (const struct dirent *), int (*__cmp) (const struct dirent **, const struct dirent **));

--- a/shared/windows/mkdir.c
+++ b/shared/windows/mkdir.c
@@ -1,0 +1,43 @@
+/*
+    shared/windows/mkdir.c
+    Copyright (C) 2020 Keith Cancel <admin@keith.pro>
+
+    This software is provided 'as-is', without any express or implied
+    warranty.  In no event will the authors be held liable for any damages
+    arising from the use of this software.
+
+    Permission is granted to anyone to use this software for any purpose,
+    including commercial applications, and to alter it and redistribute it
+    freely, subject to the following restrictions:
+
+    1. The origin of this software must not be misrepresented; you must not
+     claim that you wrote the original software. If you use this software
+     in a product, an acknowledgment in the product documentation would be
+     appreciated but is not required.
+
+    2. Altered source versions must be plainly marked as such, and must not be
+     misrepresented as being the original software.
+
+    3. This notice may not be removed or altered from any source distribution.
+*/
+
+#include <windows.h>
+#include <wchar.h>
+
+typedef unsigned short mode_t;
+
+// TODO: Maybe also take into account mode.
+int
+win_mkdir (const char *path, mode_t mode) {
+    // get length includeing NULL terminater
+    int utf16_points = MultiByteToWideChar (CP_UTF8, /*Flags*/ 0, path, -1, NULL, 0);
+    if (utf16_points < 1) {
+        return -1;
+    }
+    wchar_t wPath[utf16_points];
+    memset(wPath, 0, sizeof(wchar_t) * utf16_points);
+    if(MultiByteToWideChar (CP_UTF8, /*Flags*/ 0, path, -1, wPath, utf16_points) < 1) {
+        return -1;
+    }
+    return _wmkdir (wPath);
+}

--- a/shared/windows/rename.c
+++ b/shared/windows/rename.c
@@ -1,3 +1,25 @@
+/*
+    shared/windows/rename.c
+    Copyright (C) 2018-2020 Jakub Wasylków
+
+    This software is provided 'as-is', without any express or implied
+    warranty.  In no event will the authors be held liable for any damages
+    arising from the use of this software.
+
+    Permission is granted to anyone to use this software for any purpose,
+    including commercial applications, and to alter it and redistribute it
+    freely, subject to the following restrictions:
+
+    1. The origin of this software must not be misrepresented; you must not
+     claim that you wrote the original software. If you use this software
+     in a product, an acknowledgment in the product documentation would be
+     appreciated but is not required.
+
+    2. Altered source versions must be plainly marked as such, and must not be
+     misrepresented as being the original software.
+
+    3. This notice may not be removed or altered from any source distribution.
+*/
 #include <stdio.h>
 #include <wchar.h>
 #include <windows.h>

--- a/shared/windows/rmdir.c
+++ b/shared/windows/rmdir.c
@@ -1,0 +1,41 @@
+
+/*
+    shared/windows/rmdir.c
+    Copyright (C) 2020 Keith Cancel <admin@keith.pro>
+
+    This software is provided 'as-is', without any express or implied
+    warranty.  In no event will the authors be held liable for any damages
+    arising from the use of this software.
+
+    Permission is granted to anyone to use this software for any purpose,
+    including commercial applications, and to alter it and redistribute it
+    freely, subject to the following restrictions:
+
+    1. The origin of this software must not be misrepresented; you must not
+     claim that you wrote the original software. If you use this software
+     in a product, an acknowledgment in the product documentation would be
+     appreciated but is not required.
+
+    2. Altered source versions must be plainly marked as such, and must not be
+     misrepresented as being the original software.
+
+    3. This notice may not be removed or altered from any source distribution.
+*/
+
+#include <windows.h>
+#include <wchar.h>
+
+int
+win_rmdir (const char *path) {
+    // get length includeing NULL terminater
+    int utf16_points = MultiByteToWideChar (CP_UTF8, /*Flags*/ 0, path, -1, NULL, 0);
+    if (utf16_points < 1) {
+        return -1;
+    }
+    wchar_t wPath[utf16_points];
+    memset(wPath, 0, sizeof(wchar_t) * utf16_points);
+    if(MultiByteToWideChar (CP_UTF8, /*Flags*/ 0, path, -1, wPath, utf16_points) < 1) {
+        return -1;
+    }
+    return _wrmdir (wPath);
+}

--- a/shared/windows/scandir.c
+++ b/shared/windows/scandir.c
@@ -1,3 +1,25 @@
+/*
+    shared/windows/scandir.c
+    Copyright (C) 2018-2020 Jakub Wasylków and other contributors
+
+    This software is provided 'as-is', without any express or implied
+    warranty.  In no event will the authors be held liable for any damages
+    arising from the use of this software.
+
+    Permission is granted to anyone to use this software for any purpose,
+    including commercial applications, and to alter it and redistribute it
+    freely, subject to the following restrictions:
+
+    1. The origin of this software must not be misrepresented; you must not
+     claim that you wrote the original software. If you use this software
+     in a product, an acknowledgment in the product documentation would be
+     appreciated but is not required.
+
+    2. Altered source versions must be plainly marked as such, and must not be
+     misrepresented as being the original software.
+
+    3. This notice may not be removed or altered from any source distribution.
+*/
 #include <dirent.h>
 #include <stdlib.h>
 #include <string.h>

--- a/shared/windows/stat.c
+++ b/shared/windows/stat.c
@@ -1,3 +1,25 @@
+/*
+    shared/windows/stat.c
+    Copyright (C) 2018 Jakub Wasylków
+
+    This software is provided 'as-is', without any express or implied
+    warranty.  In no event will the authors be held liable for any damages
+    arising from the use of this software.
+
+    Permission is granted to anyone to use this software for any purpose,
+    including commercial applications, and to alter it and redistribute it
+    freely, subject to the following restrictions:
+
+    1. The origin of this software must not be misrepresented; you must not
+     claim that you wrote the original software. If you use this software
+     in a product, an acknowledgment in the product documentation would be
+     appreciated but is not required.
+
+    2. Altered source versions must be plainly marked as such, and must not be
+     misrepresented as being the original software.
+
+    3. This notice may not be removed or altered from any source distribution.
+*/
 #include <wchar.h>
 #include "utils.h"
 

--- a/shared/windows/strcasestr.c
+++ b/shared/windows/strcasestr.c
@@ -1,4 +1,25 @@
+/*
+    shared/windows/strcasestr.c
+    Copyright (C) 2016 Elio Blanca
 
+    This software is provided 'as-is', without any express or implied
+    warranty.  In no event will the authors be held liable for any damages
+    arising from the use of this software.
+
+    Permission is granted to anyone to use this software for any purpose,
+    including commercial applications, and to alter it and redistribute it
+    freely, subject to the following restrictions:
+
+    1. The origin of this software must not be misrepresented; you must not
+     claim that you wrote the original software. If you use this software
+     in a product, an acknowledgment in the product documentation would be
+     appreciated but is not required.
+
+    2. Altered source versions must be plainly marked as such, and must not be
+     misrepresented as being the original software.
+
+    3. This notice may not be removed or altered from any source distribution.
+*/
 #include <stdio.h>
 #include <string.h>
 #include <ctype.h>

--- a/shared/windows/strndup.c
+++ b/shared/windows/strndup.c
@@ -1,4 +1,25 @@
+/*
+    shared/windows/strndup.c
+    Copyright (C) 2016 Elio Blanca
 
+    This software is provided 'as-is', without any express or implied
+    warranty.  In no event will the authors be held liable for any damages
+    arising from the use of this software.
+
+    Permission is granted to anyone to use this software for any purpose,
+    including commercial applications, and to alter it and redistribute it
+    freely, subject to the following restrictions:
+
+    1. The origin of this software must not be misrepresented; you must not
+     claim that you wrote the original software. If you use this software
+     in a product, an acknowledgment in the product documentation would be
+     appreciated but is not required.
+
+    2. Altered source versions must be plainly marked as such, and must not be
+     misrepresented as being the original software.
+
+    3. This notice may not be removed or altered from any source distribution.
+*/
 #include <malloc.h>
 #include <string.h>
 

--- a/shared/windows/utils.c
+++ b/shared/windows/utils.c
@@ -1,3 +1,25 @@
+/*
+    shared/windows/utils.c
+    Copyright (C) 2018-2020 Jakub Wasylków
+
+    This software is provided 'as-is', without any express or implied
+    warranty.  In no event will the authors be held liable for any damages
+    arising from the use of this software.
+
+    Permission is granted to anyone to use this software for any purpose,
+    including commercial applications, and to alter it and redistribute it
+    freely, subject to the following restrictions:
+
+    1. The origin of this software must not be misrepresented; you must not
+     claim that you wrote the original software. If you use this software
+     in a product, an acknowledgment in the product documentation would be
+     appreciated but is not required.
+
+    2. Altered source versions must be plainly marked as such, and must not be
+     misrepresented as being the original software.
+
+    3. This notice may not be removed or altered from any source distribution.
+*/
 #include <string.h>
 #include <shlwapi.h>
 

--- a/shared/windows/utils.h
+++ b/shared/windows/utils.h
@@ -1,3 +1,25 @@
+/*
+    shared/windows/utils.h
+    Copyright (C) 2018-2020 Jakub Wasylków
+
+    This software is provided 'as-is', without any express or implied
+    warranty.  In no event will the authors be held liable for any damages
+    arising from the use of this software.
+
+    Permission is granted to anyone to use this software for any purpose,
+    including commercial applications, and to alter it and redistribute it
+    freely, subject to the following restrictions:
+
+    1. The origin of this software must not be misrepresented; you must not
+     claim that you wrote the original software. If you use this software
+     in a product, an acknowledgment in the product documentation would be
+     appreciated but is not required.
+
+    2. Altered source versions must be plainly marked as such, and must not be
+     misrepresented as being the original software.
+
+    3. This notice may not be removed or altered from any source distribution.
+*/
 
 // convert from UTF-8 and UTF-16 (WCHAR_T) and vice-versa
 // works as junk_iconv() and has same argument strucutre


### PR DESCRIPTION
Summary of the changes:
- portaudio stream drain fix (v1.6)
- title formatting v1 returns windows-converted directories (tf v1 only used in shellexec)
- shellexec on windows now runs commands in background + single quotation mark fix
- premake: added tta
- premake-win: added tta, shellexec (+gtk2/3)
- premake-tools: each run of premake-win generates version based on date
- shared/windows: licence fix
- shared/windows: add mkdir and rmdir implementations
