### PR TITLE
Add windows build to travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -36,7 +36,7 @@ before_install:
     case $TRAVIS_OS_NAME in
       windows)
         [[ ! -f C:/tools/msys64/msys2_shell.cmd ]] && rm -rf C:/tools/msys64
-        choco uninstall -y mingw
+        ## choco uninstall -y mingw
         choco upgrade --no-progress -y msys2
         export msys2='cmd //C RefreshEnv.cmd '
         export msys2+='& set MSYS=winsymlinks:nativestrict '
@@ -45,9 +45,9 @@ before_install:
         export msys2+=" -msys2 -c "\"\$@"\" --"
         $msys2 pacman --sync --noconfirm --needed mingw-w64-x86_64-toolchain
         ## Install more MSYS2 packages from https://packages.msys2.org/base here
-        $msys2 pacman --sync --noconfirm mingw-w64-x86_64-libzip mingw-w64-x86_64-pkg-config mingw-w64-x86_64-dlfcn \
+        $msys2 pacman --sync --noconfirm --needed mingw-w64-x86_64-libzip mingw-w64-x86_64-pkg-config mingw-w64-x86_64-dlfcn \
           mingw-w64-x86_64-gcc git make tar unzip xz
-        $msys2 pacman --sync --noconfirm mingw-w64-x86_64-jansson mingw-w64-x86_64-gtk3 mingw-w64-x86_64-gtk2 mingw-w64-x86_64-mpg123 \
+        $msys2 pacman --sync --noconfirm --needed mingw-w64-x86_64-jansson mingw-w64-x86_64-gtk3 mingw-w64-x86_64-gtk2 mingw-w64-x86_64-mpg123 \
           mingw-w64-x86_64-flac mingw-w64-x86_64-curl mingw-w64-x86_64-portaudio mingw-w64-x86_64-faad2 mingw-w64-x86_64-flac \
           mingw-w64-x86_64-wavpack mingw-w64-x86_64-libvorbis mingw-w64-x86_64-libogg mingw-w64-x86_64-opusfile mingw-w64-x86_64-opus \
           mingw-w64-x86_64-libsndfile mingw-w64-x86_64-libsamplerate
@@ -70,3 +70,4 @@ cache:
     directories:
     - $HOME/AppData/Local/Temp/chocolatey
     - /C/tools/msys64
+    timeout: 1200

--- a/.travis.yml
+++ b/.travis.yml
@@ -46,7 +46,7 @@ before_install:
         $msys2 pacman --sync --noconfirm --needed mingw-w64-x86_64-toolchain
         ## Install more MSYS2 packages from https://packages.msys2.org/base here
         $msys2 pacman --sync --noconfirm --needed mingw-w64-x86_64-libzip mingw-w64-x86_64-pkg-config mingw-w64-x86_64-dlfcn \
-          mingw-w64-x86_64-gcc git make tar unzip xz
+          mingw-w64-x86_64-gcc git make tar unzip xz zip
         $msys2 pacman --sync --noconfirm --needed mingw-w64-x86_64-jansson mingw-w64-x86_64-gtk3 mingw-w64-x86_64-gtk2 mingw-w64-x86_64-mpg123 \
           mingw-w64-x86_64-flac mingw-w64-x86_64-curl mingw-w64-x86_64-portaudio mingw-w64-x86_64-faad2 mingw-w64-x86_64-flac \
           mingw-w64-x86_64-wavpack mingw-w64-x86_64-libvorbis mingw-w64-x86_64-libogg mingw-w64-x86_64-opusfile mingw-w64-x86_64-opus \

--- a/.travis.yml
+++ b/.travis.yml
@@ -56,18 +56,3 @@ before_install:
         export MAKE=mingw32-make  # so that Autotools can find it
         ;;
     esac
-
-before_cache:
-- |-
-    case $TRAVIS_OS_NAME in
-      windows)
-        # https://unix.stackexchange.com/a/137322/107554
-        $msys2 pacman --sync --clean --noconfirm
-        ;;
-    esac
-
-cache:
-    directories:
-    - $HOME/AppData/Local/Temp/chocolatey
-    - /C/tools/msys64
-    timeout: 1200

--- a/.travis.yml
+++ b/.travis.yml
@@ -18,6 +18,7 @@ matrix:
           sudo: required
         - os: osx
           osx_image: xcode11.5
+        - os: windows
 
 git:
   submodules: true
@@ -27,3 +28,45 @@ script:
 
 after_success:
     - ./travis/upload.sh
+
+# Windows
+
+before_install:
+- |-
+    case $TRAVIS_OS_NAME in
+      windows)
+        [[ ! -f C:/tools/msys64/msys2_shell.cmd ]] && rm -rf C:/tools/msys64
+        choco uninstall -y mingw
+        choco upgrade --no-progress -y msys2
+        export msys2='cmd //C RefreshEnv.cmd '
+        export msys2+='& set MSYS=winsymlinks:nativestrict '
+        export msys2+='& C:\\tools\\msys64\\msys2_shell.cmd -defterm -no-start'
+        export mingw64="$msys2 -mingw64 -full-path -here -c "\"\$@"\" --"
+        export msys2+=" -msys2 -c "\"\$@"\" --"
+        $msys2 pacman --sync --noconfirm --needed mingw-w64-x86_64-toolchain
+        ## Install more MSYS2 packages from https://packages.msys2.org/base here
+        $msys2 pacman --sync --noconfirm mingw-w64-x86_64-libzip mingw-w64-x86_64-pkg-config mingw-w64-x86_64-dlfcn \
+          mingw-w64-x86_64-gcc git make tar unzip xz
+        $msys2 pacman --sync --noconfirm mingw-w64-x86_64-jansson mingw-w64-x86_64-gtk3 mingw-w64-x86_64-gtk2 mingw-w64-x86_64-mpg123 \
+          mingw-w64-x86_64-flac mingw-w64-x86_64-curl mingw-w64-x86_64-portaudio mingw-w64-x86_64-faad2 mingw-w64-x86_64-flac \
+          mingw-w64-x86_64-wavpack mingw-w64-x86_64-libvorbis mingw-w64-x86_64-libogg mingw-w64-x86_64-opusfile mingw-w64-x86_64-opus \
+          mingw-w64-x86_64-libsndfile mingw-w64-x86_64-libsamplerate
+        taskkill //IM gpg-agent.exe //F  # https://travis-ci.community/t/4967
+        export PATH=/C/tools/msys64/mingw64/bin:$PATH
+        export MAKE=mingw32-make  # so that Autotools can find it
+        ;;
+    esac
+
+before_cache:
+- |-
+    case $TRAVIS_OS_NAME in
+      windows)
+        # https://unix.stackexchange.com/a/137322/107554
+        $msys2 pacman --sync --clean --noconfirm
+        ;;
+    esac
+
+cache:
+    directories:
+    - $HOME/AppData/Local/Temp/chocolatey
+    - /C/tools/msys64

--- a/.travis.yml
+++ b/.travis.yml
@@ -37,7 +37,7 @@ before_install:
       windows)
         [[ ! -f C:/tools/msys64/msys2_shell.cmd ]] && rm -rf C:/tools/msys64
         ## choco uninstall -y mingw
-        choco upgrade --no-progress -y msys2
+        choco upgrade --no-progress -y msys2 innosetup
         export msys2='cmd //C RefreshEnv.cmd '
         export msys2+='& set MSYS=winsymlinks:nativestrict '
         export msys2+='& C:\\tools\\msys64\\msys2_shell.cmd -defterm -no-start'

--- a/premake5-tools.lua
+++ b/premake5-tools.lua
@@ -227,7 +227,7 @@ end
 -- Returns deadbeef version which is stored in ./PORTABLE_VERSION
 -- WINDOWS: Return current date
 function get_version ()
-	if os.host() == "windows" then
+	if _OPTIONS["version-override"] ~= nil then
 		date = os.date("%Y-%m-%d")
 		fp = io.open ("PORTABLE_VERSION","w")
 		io.output (fp)

--- a/premake5-win.lua
+++ b/premake5-win.lua
@@ -439,6 +439,7 @@ project "ddb_gui_GTK2"
    }
 
     pkgconfig ("gtk+-2.0 jansson")
+    defines ("GLIB_DISABLE_DEPRECATION_WARNINGS")
 
     filter "configurations:debug32 or release32"
 
@@ -477,6 +478,7 @@ project "ddb_gui_GTK3"
 
    pkgconfig("gtk+-3.0 jansson")
    -- links { "jansson", "gtk-3", "gdk-3", "pangocairo-1.0", "pango-1.0", "atk-1.0", "cairo-gobject", "cairo", "gdk_pixbuf-2.0", "gio-2.0", "gobject-2.0", "gthread-2.0", "glib-2.0" }
+   defines ("GLIB_DISABLE_DEPRECATION_WARNINGS")
 
     filter "configurations:debug32 or release32"
 

--- a/premake5-win.lua
+++ b/premake5-win.lua
@@ -4,6 +4,12 @@ workspace "deadbeef"
    configurations { "debug", "release", "debug32", "release32" }
    platforms { "Windows" }
    defaultplatform "Windows"
+
+newoption {
+  trigger = "version-override",
+  description = "override version with today's date",
+}
+
 defines {
     "VERSION=\"" .. get_version() .. "\"",
     "_GNU_SOURCE",

--- a/tools/windows-installer/deadbeef.iss
+++ b/tools/windows-installer/deadbeef.iss
@@ -1,26 +1,27 @@
-#define MyAppName "DeaDBeeF for Windows"
+#define MyAppName "DeaDBeeF"
 #define MyAppNameShort "DeaDBeeF"
 ; Version based on date
-#define MyAppVersion GetDateTimeString('yyyy-mm-dd', '', '');
+; #define MyAppVersion GetDateTimeString('yyyy-mm-dd', '', '');
 ; Version defined manually
 ;#define MyAppVersion "1.8.0"
 ; Version saved in deadbeef source ('PORTABLE' file)
-;#define VerFile FileOpen("../../PORTABLE")
-;#define MyAppVersion FileRead(VerFile)
-;#expr FileClose(VerFile)
+#define VerFile FileOpen("../../PORTABLE_VERSION")
+#define MyAppVersion FileRead(VerFile)
+#expr FileClose(VerFile)
 ;#undef VerFile
 
 ;#define DEBUG
 
-#define MyAppPublisher "kuba_160"
-#define MyAppURL "https://deadbeef-for-windows.github.io/"
+#define MyAppPublisher "DeaDBeeF"
+#define MyAppURL "https://deadbeef.sourceforge.net"
 #define MyAppExeName "deadbeef.exe"
 
 #ifdef DEBUG
 #define BuildPath "..\..\bin\debug"
-#define MyAppVersion MyAppVersion + "-DEBUG"
+#define OutputSuffix "windows-x86_64_DEBUG"
 #else
 #define BuildPath "..\..\bin\release"
+#define OutputSuffix "windows-x86_64"
 #endif
 #define IconPath "deadbeef.bmp"
 
@@ -41,7 +42,7 @@ DefaultDirName={pf}\DeaDBeeF
 DefaultGroupName={#MyAppName}
 DisableProgramGroupPage=yes
 DisableDirPage=no
-OutputBaseFilename=deadbeef-{#MyAppVersion}
+OutputBaseFilename=deadbeef-{#MyAppVersion}-{#OutputSuffix}
 Compression=lzma
 SolidCompression=yes
 WizardSmallImageFile=deadbeef.bmp

--- a/travis/build.sh
+++ b/travis/build.sh
@@ -36,18 +36,17 @@ case "$TRAVIS_OS_NAME" in
         cd ../../..
     ;;
     windows)
-        $msys2 git clone https://github.com/kuba160/Windows-10.git
-        $msys2 rm -rv Windows-10/.git
-        $msys2 git clone https://github.com/kuba160/Windows-10-Icons.git
-        $msys2 rm -rv Windows-10-Icons/.git
-        $msys2 wget https://github.com/premake/premake-core/releases/download/v5.0.0-alpha14/premake-5.0.0-alpha14-windows.zip && unzip premake-5.0.0-alpha14-windows.zip
+        git clone https://github.com/kuba160/deadbeef-windows-deps.git
+        wget https://github.com/premake/premake-core/releases/download/v5.0.0-alpha14/premake-5.0.0-alpha14-windows.zip && unzip premake-5.0.0-alpha14-windows.zip
         $mingw64 ./premake5 --os=linux --file=premake5-win.lua --standard gmake
         $mingw64 make config=release_windows
         $mingw64 make config=debug_windows
-        $msys2 cp -r Windows-10 bin/debug/share/themes/Windows-10 && cp -r Windows-10 bin/release/share/themes/Windows-10
-        $msys2 cp -r Windows-10-Icons bin/debug/share/icons/Windows-10-Icons && cp -r Windows-10-Icons bin/release/share/icons/Windows-10-Icons
-        $msys2 mv bin/release bin/deadbeef-x86_64 && (cd bin && $msys2 zip -q -r deadbeef-x86_64.zip deadbeef-x86_64/) && mv bin/deadbeef-x86_64 bin/release
-        $msys2 mv bin/debug bin/deadbeef-x86_64 && (cd bin && $msys2 zip -q -r deadbeef-x86_64_DEBUG.zip deadbeef-x86_64/) && mv bin/deadbeef-x86_64 bin/debug
+        cp -r deadbeef-windows-deps/Windows-10 bin/debug/share/themes/Windows-10
+        cp -r deadbeef-windows-deps/Windows-10 bin/release/share/themes/Windows-10
+        cp -r deadbeef-windows-deps/Windows-10-Icons bin/debug/share/icons/Windows-10-Icons
+        cp -r deadbeef-windows-deps/Windows-10-Icons bin/release/share/icons/Windows-10-Icons
+        mv bin/release bin/deadbeef-x86_64 && (cd bin && $msys2 zip -q -r deadbeef-x86_64.zip deadbeef-x86_64/) && mv bin/deadbeef-x86_64 bin/release
+        mv bin/debug bin/deadbeef-x86_64 && (cd bin && $msys2 zip -q -r deadbeef-x86_64_DEBUG.zip deadbeef-x86_64/) && mv bin/deadbeef-x86_64 bin/debug
         /C/ProgramData/chocolatey/bin/ISCC.exe "//Obin" "//Qp" tools/windows-installer/deadbeef.iss
         /C/ProgramData/chocolatey/bin/ISCC.exe "//DDEBUG" "//Obin" "//Qp" tools/windows-installer/deadbeef.iss
 esac

--- a/travis/build.sh
+++ b/travis/build.sh
@@ -41,9 +41,9 @@ case "$TRAVIS_OS_NAME" in
         $msys2 git clone https://github.com/kuba160/Windows-10-Icons.git
         $msys2 rm -rv Windows-10-Icons/.git
         $msys2 wget https://github.com/premake/premake-core/releases/download/v5.0.0-alpha14/premake-5.0.0-alpha14-windows.zip && unzip premake-5.0.0-alpha14-windows.zip
-        $msys2 ./premake5 --os=linux --file=premake5-win.lua --standard gmake
-        $msys2 make config=release_windows
-        $msys2 make config=debug_windows
+        $mingw64 ./premake5 --os=linux --file=premake5-win.lua --standard gmake
+        $mingw64 make config=release_windows
+        $mingw64 make config=debug_windows
         $msys2 cp -r Windows-10 bin/debug/share/themes/Windows-10 && cp -r Windows-10 bin/release/share/themes/Windows-10
         $msys2 cp -r Windows-10-Icons bin/debug/share/icons/Windows-10-Icons && cp -r Windows-10-Icons bin/release/share/icons/Windows-10-Icons
 esac

--- a/travis/build.sh
+++ b/travis/build.sh
@@ -46,8 +46,8 @@ case "$TRAVIS_OS_NAME" in
         $mingw64 make config=debug_windows
         $msys2 cp -r Windows-10 bin/debug/share/themes/Windows-10 && cp -r Windows-10 bin/release/share/themes/Windows-10
         $msys2 cp -r Windows-10-Icons bin/debug/share/icons/Windows-10-Icons && cp -r Windows-10-Icons bin/release/share/icons/Windows-10-Icons
-        $msys2 cd bin/ && mv release deadbeef-x86_64 && zip -r deadbeef-x86_64.zip deadbeef-x86_64/ && mv deadbeef-x86_64 release
-        $msys2 cd bin/ && mv debug deadbeef-x86_64 && zip -r deadbeef-x86_64_DEBUG.zip deadbeef-x86_64/ && mv deadbeef-x86_64 debug
+        $msys2 mv bin/release bin/deadbeef-x86_64 && (cd bin && $msys2 zip -r deadbeef-x86_64.zip deadbeef-x86_64/) && mv bin/deadbeef-x86_64 bin/release
+        $msys2 mv bin/debug bin/deadbeef-x86_64 && (cd bin && $msys2 zip -r deadbeef-x86_64_DEBUG.zip deadbeef-x86_64/) && mv bin/deadbeef-x86_64 bin/debug
         /C/ProgramData/chocolatey/bin/ISCC.exe "//Obin" "//Qp" tools/windows-installer/deadbeef.iss
         /C/ProgramData/chocolatey/bin/ISCC.exe "//DDEBUG" "//Obin" "//Qp" tools/windows-installer/deadbeef.iss
 esac

--- a/travis/build.sh
+++ b/travis/build.sh
@@ -46,4 +46,8 @@ case "$TRAVIS_OS_NAME" in
         $mingw64 make config=debug_windows
         $msys2 cp -r Windows-10 bin/debug/share/themes/Windows-10 && cp -r Windows-10 bin/release/share/themes/Windows-10
         $msys2 cp -r Windows-10-Icons bin/debug/share/icons/Windows-10-Icons && cp -r Windows-10-Icons bin/release/share/icons/Windows-10-Icons
+        $msys2 cd bin/ && mv release deadbeef-x86_64 && zip -r deadbeef-x86_64.zip deadbeef-x86_64/ && mv deadbeef-x86_64 release
+        $msys2 cd bin/ && mv debug deadbeef-x86_64 && zip -r deadbeef-x86_64_DEBUG.zip deadbeef-x86_64/ && mv deadbeef-x86_64 debug
+        /C/ProgramData/chocolatey/bin/ISCC.exe "//Obin" tools/windows-installer/deadbeef.iss
+        /C/ProgramData/chocolatey/bin/ISCC.exe "//DDEBUG" "//Obin" tools/windows-installer/deadbeef.iss
 esac

--- a/travis/build.sh
+++ b/travis/build.sh
@@ -35,4 +35,15 @@ case "$TRAVIS_OS_NAME" in
         zip -r deadbeef-$VERSION-osx-x86_64.zip DeaDBeeF.app || exit 1
         cd ../../..
     ;;
+    windows)
+        $msys2 git clone https://github.com/kuba160/Windows-10.git
+        $msys2 rm -rv Windows-10/.git
+        $msys2 git clone https://github.com/kuba160/Windows-10-Icons.git
+        $msys2 rm -rv Windows-10-Icons/.git
+        $msys2 wget https://github.com/premake/premake-core/releases/download/v5.0.0-alpha14/premake-5.0.0-alpha14-windows.zip && unzip premake-5.0.0-alpha14-windows.zip
+        $msys2 ./premake5 --os=linux --file=premake5-win.lua --standard gmake
+        $msys2 make config=release_windows
+        $msys2 make config=debug_windows
+        $msys2 cp -r Windows-10 bin/debug/share/themes/Windows-10 && cp -r Windows-10 bin/release/share/themes/Windows-10
+        $msys2 cp -r Windows-10-Icons bin/debug/share/icons/Windows-10-Icons && cp -r Windows-10-Icons bin/release/share/icons/Windows-10-Icons
 esac

--- a/travis/build.sh
+++ b/travis/build.sh
@@ -45,8 +45,11 @@ case "$TRAVIS_OS_NAME" in
         cp -r deadbeef-windows-deps/Windows-10 bin/release/share/themes/Windows-10
         cp -r deadbeef-windows-deps/Windows-10-Icons bin/debug/share/icons/Windows-10-Icons
         cp -r deadbeef-windows-deps/Windows-10-Icons bin/release/share/icons/Windows-10-Icons
-        mv bin/release bin/deadbeef-x86_64 && (cd bin && $msys2 zip -q -r deadbeef-x86_64.zip deadbeef-x86_64/) && mv bin/deadbeef-x86_64 bin/release
-        mv bin/debug bin/deadbeef-x86_64 && (cd bin && $msys2 zip -q -r deadbeef-x86_64_DEBUG.zip deadbeef-x86_64/) && mv bin/deadbeef-x86_64 bin/debug
+        echo "making zip packages"
+        mv bin/release bin/deadbeef-x86_64 && (cd bin && $msys2 zip -q -r deadbeef-$VERSION-windows-x86_64.zip deadbeef-x86_64/) && mv bin/deadbeef-x86_64 bin/release
+        mv bin/debug bin/deadbeef-x86_64 && (cd bin && $msys2 zip -q -r deadbeef-$VERSION-windows-x86_64_DEBUG.zip deadbeef-x86_64/) && mv bin/deadbeef-x86_64 bin/debug
+        echo "making installer packages"
         /C/ProgramData/chocolatey/bin/ISCC.exe "//Obin" "//Qp" tools/windows-installer/deadbeef.iss
         /C/ProgramData/chocolatey/bin/ISCC.exe "//DDEBUG" "//Obin" "//Qp" tools/windows-installer/deadbeef.iss
+    ;;
 esac

--- a/travis/build.sh
+++ b/travis/build.sh
@@ -48,6 +48,6 @@ case "$TRAVIS_OS_NAME" in
         $msys2 cp -r Windows-10-Icons bin/debug/share/icons/Windows-10-Icons && cp -r Windows-10-Icons bin/release/share/icons/Windows-10-Icons
         $msys2 cd bin/ && mv release deadbeef-x86_64 && zip -r deadbeef-x86_64.zip deadbeef-x86_64/ && mv deadbeef-x86_64 release
         $msys2 cd bin/ && mv debug deadbeef-x86_64 && zip -r deadbeef-x86_64_DEBUG.zip deadbeef-x86_64/ && mv deadbeef-x86_64 debug
-        /C/ProgramData/chocolatey/bin/ISCC.exe "//Obin" tools/windows-installer/deadbeef.iss
-        /C/ProgramData/chocolatey/bin/ISCC.exe "//DDEBUG" "//Obin" tools/windows-installer/deadbeef.iss
+        /C/ProgramData/chocolatey/bin/ISCC.exe "//Obin" "//Qp" tools/windows-installer/deadbeef.iss
+        /C/ProgramData/chocolatey/bin/ISCC.exe "//DDEBUG" "//Obin" "//Qp" tools/windows-installer/deadbeef.iss
 esac

--- a/travis/build.sh
+++ b/travis/build.sh
@@ -46,8 +46,8 @@ case "$TRAVIS_OS_NAME" in
         $mingw64 make config=debug_windows
         $msys2 cp -r Windows-10 bin/debug/share/themes/Windows-10 && cp -r Windows-10 bin/release/share/themes/Windows-10
         $msys2 cp -r Windows-10-Icons bin/debug/share/icons/Windows-10-Icons && cp -r Windows-10-Icons bin/release/share/icons/Windows-10-Icons
-        $msys2 mv bin/release bin/deadbeef-x86_64 && (cd bin && $msys2 zip -r deadbeef-x86_64.zip deadbeef-x86_64/) && mv bin/deadbeef-x86_64 bin/release
-        $msys2 mv bin/debug bin/deadbeef-x86_64 && (cd bin && $msys2 zip -r deadbeef-x86_64_DEBUG.zip deadbeef-x86_64/) && mv bin/deadbeef-x86_64 bin/debug
+        $msys2 mv bin/release bin/deadbeef-x86_64 && (cd bin && $msys2 zip -q -r deadbeef-x86_64.zip deadbeef-x86_64/) && mv bin/deadbeef-x86_64 bin/release
+        $msys2 mv bin/debug bin/deadbeef-x86_64 && (cd bin && $msys2 zip -q -r deadbeef-x86_64_DEBUG.zip deadbeef-x86_64/) && mv bin/deadbeef-x86_64 bin/debug
         /C/ProgramData/chocolatey/bin/ISCC.exe "//Obin" "//Qp" tools/windows-installer/deadbeef.iss
         /C/ProgramData/chocolatey/bin/ISCC.exe "//DDEBUG" "//Obin" "//Qp" tools/windows-installer/deadbeef.iss
 esac

--- a/travis/build.sh
+++ b/travis/build.sh
@@ -37,7 +37,7 @@ case "$TRAVIS_OS_NAME" in
     ;;
     windows)
         git clone https://github.com/kuba160/deadbeef-windows-deps.git
-        wget https://github.com/premake/premake-core/releases/download/v5.0.0-alpha14/premake-5.0.0-alpha14-windows.zip && unzip premake-5.0.0-alpha14-windows.zip
+        wget https://github.com/premake/premake-core/releases/download/v5.0.0-alpha15/premake-5.0.0-alpha15-windows.zip && unzip premake-5.0.0-alpha15-windows.zip
         $mingw64 ./premake5 --os=linux --file=premake5-win.lua --standard gmake
         $mingw64 make config=release_windows
         $mingw64 make config=debug_windows

--- a/travis/upload.sh
+++ b/travis/upload.sh
@@ -22,4 +22,10 @@ case "$TRAVIS_OS_NAME" in
         echo Uploading mac artifacts...
         rsync -e "$SSHOPTS" osx/build/Release/deadbeef-$VERSION-osx-x86_64.zip waker,deadbeef@frs.sourceforge.net:/home/frs/project/d/de/deadbeef/travis/osx/$TRAVIS_BRANCH/ || exit 1
     ;;
+    windows)
+        echo Uploading windows artifacts...
+        rsync -e "$SSHOPTS" bin/deadbeef-$VERSION-windows-x86_64.zip waker,deadbeef@frs.sourceforge.net:/home/frs/project/d/de/deadbeef/travis/windows/$TRAVIS_BRANCH/ || exit 1
+        rsync -e "$SSHOPTS" bin/deadbeef-$VERSION-windows-x86_64_DEBUG.zip waker,deadbeef@frs.sourceforge.net:/home/frs/project/d/de/deadbeef/travis/windows/$TRAVIS_BRANCH/ || exit 1
+        rsync -e "$SSHOPTS" bin/deadbeef-$VERSION-windows-x86_64.exe waker,deadbeef@frs.sourceforge.net:/home/frs/project/d/de/deadbeef/travis/windows/$TRAVIS_BRANCH/ || exit 1
+        rsync -e "$SSHOPTS" bin/deadbeef-$VERSION-windows-x86_64_DEBUG.exe waker,deadbeef@frs.sourceforge.net:/home/frs/project/d/de/deadbeef/travis/windows/$TRAVIS_BRANCH/ || exit 1
 esac


### PR DESCRIPTION
This PR adds windows build to travis, which builds same binaries as in "DeaDBeeF for Windows" project.

Build script downloads https://github.com/kuba160/deadbeef-windows-deps.git which contains GTK theme and icons used by default in "DeaDBeeF for Windows" project. I did not test travis builds yet, but I tested builds from GitHub Actions made by similar script and they were working fine. `upload.sh` was updated to support uploading windows builds to sourceforge. If there are some changes that can't be accepted please let me know.