### PR TITLE
artwork small fixes

### DIFF
--- a/main.c
+++ b/main.c
@@ -1227,6 +1227,20 @@ main (int argc, char *argv[]) {
 //    trace ("plugindir: %s\n", dbplugindir);
 //    trace ("pixmapdir: %s\n", dbpixmapdir);
 
+#ifdef __MINGW32__
+    char *directories[] = {dbconfdir, dbinstalldir, dbdocdir, dbplugindir, dbpixmapdir, dbcachedir, dbresourcedir, NULL};
+    for (int i = 0; directories[i] != NULL; i++) {
+        // replace backslashes with normal slashes
+        if (strchr(directories[i], '\\')) {
+            char *slash_p = directories[i];
+            while (slash_p = strchr(slash_p, '\\')) {
+                *slash_p = '/';
+                slash_p++;
+            }
+        }
+    }
+#endif
+
     mkdir (dbconfdir, 0755);
 
     int size = 0;

--- a/plugins/artwork-legacy/cache.c
+++ b/plugins/artwork-legacy/cache.c
@@ -79,7 +79,7 @@ int make_cache_root_path (char *path, const size_t size)
     #endif
 
     const char *cache_root = xdg_cache ? xdg_cache : getenv (HOMEDIR);
-    if (snprintf (path, size, xdg_cache ? "%s/deadbeef/" : "%s/.cache/deadbeef/", cache_root) >= size) {
+    if (snprintf (path, size, xdg_cache ? "%s" : "%s/.cache/deadbeef/", cache_root) >= size) {
         trace ("Cache root path truncated at %d bytes\n", (int)size);
         return -1;
     }

--- a/plugins/artwork-legacy/cache.c
+++ b/plugins/artwork-legacy/cache.c
@@ -61,25 +61,25 @@ void cache_unlock (void)
 
 int make_cache_root_path (char *path, const size_t size)
 {
-    const char *xdg_cache = deadbeef->get_system_dir (DDB_SYS_DIR_CACHE);
+    const char *ddb_cache = deadbeef->get_system_dir (DDB_SYS_DIR_CACHE);
 
     #ifdef __MINGW32__
     // replace backslashes with normal slashes
-    char xdg_cache_conv[strlen(xdg_cache)+1];
-    if (strchr(xdg_cache, '\\')) {
-        trace ("make_cache_root_path: backslash(es) detected: %s\n", xdg_cache);
-        strcpy (xdg_cache_conv, xdg_cache);
-        char *slash_p = xdg_cache_conv;
+    char ddb_cache_conv[strlen(xdg_cache)+1];
+    if (strchr(ddb_cache, '\\')) {
+        trace ("make_cache_root_path: backslash(es) detected: %s\n", ddb_cache);
+        strcpy (ddb_cache_conv, ddb_cache);
+        char *slash_p = ddb_cache_conv;
         while (slash_p = strchr(slash_p, '\\')) {
             *slash_p = '/';
             slash_p++;
         }
-        xdg_cache = xdg_cache_conv;
+        ddb_cache = ddb_cache_conv;
     }
     #endif
 
-    const char *cache_root = xdg_cache ? xdg_cache : getenv (HOMEDIR);
-    if (snprintf (path, size, xdg_cache ? "%s" : "%s/.cache/deadbeef/", cache_root) >= size) {
+    const char *cache_root = ddb_cache ? ddb_cache : getenv (HOMEDIR);
+    if (snprintf (path, size, ddb_cache ? "%s" : "%s/.cache/deadbeef/", cache_root) >= size) {
         trace ("Cache root path truncated at %d bytes\n", (int)size);
         return -1;
     }

--- a/plugins/artwork-legacy/cache.c
+++ b/plugins/artwork-legacy/cache.c
@@ -64,7 +64,7 @@ int make_cache_root_path (char *path, const size_t size)
     const char *ddb_cache = deadbeef->get_system_dir (DDB_SYS_DIR_CACHE);
 
     if (strlen(ddb_cache) >= size) {
-        trace ("Cache root path truncated at %d bytes\n", (int)size);
+        trace ("Cache root path is too long (>%d bytes)\n", (int)size);
         return -1;
     }
     else {

--- a/plugins/artwork-legacy/cache.c
+++ b/plugins/artwork-legacy/cache.c
@@ -78,10 +78,12 @@ int make_cache_root_path (char *path, const size_t size)
     }
     #endif
 
-    const char *cache_root = ddb_cache ? ddb_cache : getenv (HOMEDIR);
-    if (snprintf (path, size, ddb_cache ? "%s" : "%s/.cache/deadbeef/", cache_root) >= size) {
+    if (strlen(ddb_cache) >= size) {
         trace ("Cache root path truncated at %d bytes\n", (int)size);
         return -1;
+    }
+    else {
+        strcpy (path, ddb_cache);
     }
     return 0;
 }

--- a/plugins/artwork-legacy/cache.c
+++ b/plugins/artwork-legacy/cache.c
@@ -63,21 +63,6 @@ int make_cache_root_path (char *path, const size_t size)
 {
     const char *ddb_cache = deadbeef->get_system_dir (DDB_SYS_DIR_CACHE);
 
-    #ifdef __MINGW32__
-    // replace backslashes with normal slashes
-    char ddb_cache_conv[strlen(xdg_cache)+1];
-    if (strchr(ddb_cache, '\\')) {
-        trace ("make_cache_root_path: backslash(es) detected: %s\n", ddb_cache);
-        strcpy (ddb_cache_conv, ddb_cache);
-        char *slash_p = ddb_cache_conv;
-        while (slash_p = strchr(slash_p, '\\')) {
-            *slash_p = '/';
-            slash_p++;
-        }
-        ddb_cache = ddb_cache_conv;
-    }
-    #endif
-
     if (strlen(ddb_cache) >= size) {
         trace ("Cache root path truncated at %d bytes\n", (int)size);
         return -1;


### PR DESCRIPTION
- fix for double `deadbeef` in cache path
- move slash conversion to main program
- remove path generation from `HOMEDIR`, it is already done for `DDB_SYS_DIR_CACHE` in main