### PR TITLE
Linux: Move files to trash

### DIFF
--- a/plugins/gtkui/callbacks.c
+++ b/plugins/gtkui/callbacks.c
@@ -807,3 +807,4 @@ on_log_window_key_press_event          (GtkWidget       *widget,
     }
     return FALSE;
 }
+

--- a/plugins/gtkui/callbacks.h
+++ b/plugins/gtkui/callbacks.h
@@ -1419,3 +1419,7 @@ on_checkbutton_dependent_sr_toggled    (GtkToggleButton *togglebutton,
 void
 on_minimize_on_startup_clicked         (GtkButton       *button,
                                         gpointer         user_data);
+
+void
+on_move_to_trash_clicked               (GtkButton       *button,
+                                        gpointer         user_data);

--- a/plugins/gtkui/deadbeef.glade
+++ b/plugins/gtkui/deadbeef.glade
@@ -3775,6 +3775,26 @@ Only prevent clipping</property>
 		  </child>
 
 		  <child>
+		    <widget class="GtkCheckButton" id="move_to_trash">
+		      <property name="visible">True</property>
+		      <property name="can_focus">True</property>
+		      <property name="label" translatable="yes">Delete from disk should use Trash</property>
+		      <property name="use_underline">True</property>
+		      <property name="relief">GTK_RELIEF_NORMAL</property>
+		      <property name="focus_on_click">True</property>
+		      <property name="active">False</property>
+		      <property name="inconsistent">False</property>
+		      <property name="draw_indicator">True</property>
+		      <signal name="clicked" handler="on_move_to_trash_clicked" last_modification_time="Tue, 08 Sep 2020 11:46:13 GMT"/>
+		    </widget>
+		    <packing>
+		      <property name="padding">0</property>
+		      <property name="expand">False</property>
+		      <property name="fill">False</property>
+		    </packing>
+		  </child>
+
+		  <child>
 		    <widget class="GtkCheckButton" id="enable_shift_jis_recoding">
 		      <property name="visible">True</property>
 		      <property name="can_focus">True</property>

--- a/plugins/gtkui/interface.c
+++ b/plugins/gtkui/interface.c
@@ -1605,6 +1605,7 @@ create_prefwin (void)
   GtkWidget *minimize_on_startup;
   GtkWidget *pref_close_send_to_tray;
   GtkWidget *hide_tray_icon;
+  GtkWidget *move_to_trash;
   GtkWidget *enable_shift_jis_recoding;
   GtkWidget *enable_cp1251_recoding;
   GtkWidget *enable_cp936_recoding;
@@ -2181,6 +2182,10 @@ create_prefwin (void)
   hide_tray_icon = gtk_check_button_new_with_mnemonic (_("Hide system tray icon"));
   gtk_widget_show (hide_tray_icon);
   gtk_box_pack_start (GTK_BOX (vbox9), hide_tray_icon, FALSE, FALSE, 0);
+
+  move_to_trash = gtk_check_button_new_with_mnemonic (_("Delete from disk should use Trash"));
+  gtk_widget_show (move_to_trash);
+  gtk_box_pack_start (GTK_BOX (vbox9), move_to_trash, FALSE, FALSE, 0);
 
   enable_shift_jis_recoding = gtk_check_button_new_with_mnemonic (_("Enable Japanese SHIFT-JIS detection and recoding"));
   gtk_widget_show (enable_shift_jis_recoding);
@@ -3198,6 +3203,9 @@ create_prefwin (void)
   g_signal_connect ((gpointer) hide_tray_icon, "toggled",
                     G_CALLBACK (on_hide_tray_icon_toggled),
                     NULL);
+  g_signal_connect ((gpointer) move_to_trash, "clicked",
+                    G_CALLBACK (on_move_to_trash_clicked),
+                    NULL);
   g_signal_connect ((gpointer) enable_shift_jis_recoding, "toggled",
                     G_CALLBACK (on_enable_shift_jis_recoding_toggled),
                     NULL);
@@ -3489,6 +3497,7 @@ create_prefwin (void)
   GLADE_HOOKUP_OBJECT (prefwin, minimize_on_startup, "minimize_on_startup");
   GLADE_HOOKUP_OBJECT (prefwin, pref_close_send_to_tray, "pref_close_send_to_tray");
   GLADE_HOOKUP_OBJECT (prefwin, hide_tray_icon, "hide_tray_icon");
+  GLADE_HOOKUP_OBJECT (prefwin, move_to_trash, "move_to_trash");
   GLADE_HOOKUP_OBJECT (prefwin, enable_shift_jis_recoding, "enable_shift_jis_recoding");
   GLADE_HOOKUP_OBJECT (prefwin, enable_cp1251_recoding, "enable_cp1251_recoding");
   GLADE_HOOKUP_OBJECT (prefwin, enable_cp936_recoding, "enable_cp936_recoding");

--- a/plugins/gtkui/prefwin.c
+++ b/plugins/gtkui/prefwin.c
@@ -286,6 +286,9 @@ gtkui_run_preferences_dlg (void) {
     // hide tray icon
     set_toggle_button("hide_tray_icon", deadbeef->conf_get_int ("gtkui.hide_tray_icon", 0));
 
+    // move_to_trash
+    set_toggle_button("move_to_trash", deadbeef->conf_get_int ("gtkui.move_to_trash", 1));
+
     // mmb_delete_playlist
     set_toggle_button("mmb_delete_playlist", deadbeef->conf_get_int ("gtkui.mmb_delete_playlist", 1));
 
@@ -602,6 +605,15 @@ on_minimize_on_startup_clicked     (GtkButton       *button,
         set_toggle_button("hide_tray_icon", 0);
         deadbeef->conf_set_int ("gtkui.hide_tray_icon", 0);
     }
+    deadbeef->sendmessage (DB_EV_CONFIGCHANGED, 0, 0, 0);
+}
+
+void
+on_move_to_trash_clicked               (GtkButton       *button,
+                                        gpointer         user_data)
+{
+    int active = gtk_toggle_button_get_active (GTK_TOGGLE_BUTTON (button));
+    deadbeef->conf_set_int ("gtkui.move_to_trash", active);
     deadbeef->sendmessage (DB_EV_CONFIGCHANGED, 0, 0, 0);
 }
 


### PR DESCRIPTION
Instead of deleting files directly the files are moved to the recycle bin with [GIO](https://developer.gnome.org/gio/stable/gio.html) (if available, but should be present in all GTK based distributions).