### PR TITLE
medialib: get medialib building and running on Linux

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -827,7 +827,7 @@ AS_IF([test "${enable_soundtouch}" != "no"], [
     HAVE_SOUNDTOUCH=yes
 ])
 
-PLUGINS_DIRS="plugins/liboggedit plugins/libparser plugins/lastfm plugins/mp3 plugins/vorbis plugins/opus plugins/flac plugins/wavpack plugins/sndfile plugins/vfs_curl plugins/cdda plugins/gtkui plugins/alsa plugins/ffmpeg plugins/hotkeys plugins/oss plugins/artwork-legacy plugins/adplug plugins/ffap plugins/sid plugins/nullout plugins/supereq plugins/vtx plugins/gme plugins/pulse plugins/notify plugins/musepack plugins/wildmidi plugins/tta plugins/dca plugins/aac plugins/mms plugins/shellexec plugins/shellexecui plugins/dsp_libsrc plugins/m3u plugins/vfs_zip plugins/converter plugins/dumb plugins/shn plugins/psf plugins/mono2stereo plugins/alac plugins/wma plugins/pltbrowser plugins/coreaudio plugins/sc68 plugins/rg_scanner plugins/soundtouch"
+PLUGINS_DIRS="plugins/liboggedit plugins/libparser plugins/lastfm plugins/mp3 plugins/vorbis plugins/opus plugins/flac plugins/wavpack plugins/sndfile plugins/vfs_curl plugins/cdda plugins/gtkui plugins/alsa plugins/ffmpeg plugins/hotkeys plugins/oss plugins/artwork-legacy plugins/adplug plugins/ffap plugins/sid plugins/nullout plugins/supereq plugins/vtx plugins/gme plugins/pulse plugins/notify plugins/musepack plugins/wildmidi plugins/tta plugins/dca plugins/aac plugins/mms plugins/shellexec plugins/shellexecui plugins/dsp_libsrc plugins/m3u plugins/vfs_zip plugins/converter plugins/dumb plugins/shn plugins/psf plugins/mono2stereo plugins/alac plugins/wma plugins/pltbrowser plugins/coreaudio plugins/sc68 plugins/rg_scanner plugins/soundtouch plugins/medialib"
 
 AM_CONDITIONAL(APE_USE_YASM, test "x$APE_USE_YASM" = "xyes")
 AM_CONDITIONAL(HAVE_VORBIS, test "x$HAVE_VORBISPLUGIN" = "xyes")
@@ -955,6 +955,7 @@ plugins/sc68/Makefile
 plugins/coreaudio/Makefile
 plugins/rg_scanner/Makefile
 plugins/soundtouch/Makefile
+plugins/medialib/Makefile
 po/Makefile.in
 intl/Makefile
 deadbeef.desktop

--- a/plugins/medialib/Makefile.am
+++ b/plugins/medialib/Makefile.am
@@ -3,6 +3,6 @@ pkglib_LTLIBRARIES = medialib.la
 medialib_la_SOURCES = medialib.c
 medialib_la_LDFLAGS = -module -avoid-version
 
-medialib_la_LIBADD = $(LDADD)
-AM_CFLAGS = $(CFLAGS) -std=c99 -fPIC
+medialib_la_LIBADD = $(LDADD) $(JANSSON_LIBS)
+AM_CFLAGS = $(CFLAGS) -std=c99 -fPIC $(JANSSON_CFLAGS)
 endif


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/1023440/93149299-8fcb3d00-f6bb-11ea-9d41-b55b469c08dd.png)

Some changes to the autoconf scripts needed to be made and some Jannson build flags needed to be added to the plugin Makefile.

I have to note that I have to explicitly enable the plugin with `--enable-medialib` despite it looking like it should be detected automatically in the autoconf script.