### PR TITLE
medialib: windows clang support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -49,7 +49,7 @@ before_install:
         $msys2 pacman --sync --noconfirm --needed mingw-w64-x86_64-toolchain
         ## Install more MSYS2 packages from https://packages.msys2.org/base here
         $msys2 pacman --sync --noconfirm --needed mingw-w64-x86_64-libzip mingw-w64-x86_64-pkg-config mingw-w64-x86_64-dlfcn \
-          mingw-w64-x86_64-gcc git make tar unzip xz zip mingw-w64-x86_64-clang mingw-w64-x86_64-libblocksruntime
+          git make tar unzip xz zip mingw-w64-x86_64-clang mingw-w64-x86_64-libblocksruntime
         $msys2 pacman --sync --noconfirm --needed mingw-w64-x86_64-jansson mingw-w64-x86_64-gtk3 mingw-w64-x86_64-gtk2 mingw-w64-x86_64-mpg123 \
           mingw-w64-x86_64-flac mingw-w64-x86_64-curl mingw-w64-x86_64-portaudio mingw-w64-x86_64-faad2 mingw-w64-x86_64-flac \
           mingw-w64-x86_64-wavpack mingw-w64-x86_64-libvorbis mingw-w64-x86_64-libogg mingw-w64-x86_64-opusfile mingw-w64-x86_64-opus \

--- a/.travis.yml
+++ b/.travis.yml
@@ -49,7 +49,7 @@ before_install:
         $msys2 pacman --sync --noconfirm --needed mingw-w64-x86_64-toolchain
         ## Install more MSYS2 packages from https://packages.msys2.org/base here
         $msys2 pacman --sync --noconfirm --needed mingw-w64-x86_64-libzip mingw-w64-x86_64-pkg-config mingw-w64-x86_64-dlfcn \
-          mingw-w64-x86_64-gcc git make tar unzip xz zip
+          mingw-w64-x86_64-gcc git make tar unzip xz zip mingw-w64-x86_64-clang mingw-w64-x86_64-libblocksruntime
         $msys2 pacman --sync --noconfirm --needed mingw-w64-x86_64-jansson mingw-w64-x86_64-gtk3 mingw-w64-x86_64-gtk2 mingw-w64-x86_64-mpg123 \
           mingw-w64-x86_64-flac mingw-w64-x86_64-curl mingw-w64-x86_64-portaudio mingw-w64-x86_64-faad2 mingw-w64-x86_64-flac \
           mingw-w64-x86_64-wavpack mingw-w64-x86_64-libvorbis mingw-w64-x86_64-libogg mingw-w64-x86_64-opusfile mingw-w64-x86_64-opus \

--- a/premake5-win.lua
+++ b/premake5-win.lua
@@ -1167,6 +1167,20 @@ project "tta"
    }
 end
 
+if option ("plugin-medialib") then
+project "medialib"
+   kind "SharedLib"
+   language "C"
+   targetdir "bin/%{cfg.buildcfg}/plugins"
+   targetprefix ""
+
+   files {
+       "plugins/medialib/medialib.c",
+       "plugins/medialib/medialib.h"
+   }
+
+   pkgconfig ("jansson")
+end
 
 project "translations"
    kind "Utility"

--- a/premake5-win.lua
+++ b/premake5-win.lua
@@ -47,7 +47,6 @@ filter "configurations:debug or debug32"
   symbols "On"
 
 filter "configurations:debug or release"
-  buildoptions { "-fPIC" }
   includedirs { "plugins/libmp4ff", "static-deps/lib-x86-64/include/x86_64-linux-gnu", "static-deps/lib-x86-64/include"  }
   libdirs { "static-deps/lib-x86-64/lib/x86_64-linux-gnu", "static-deps/lib-x86-64/lib" }
 
@@ -63,14 +62,22 @@ filter "configurations:release32 or release"
 
 filter "system:Windows"
   buildoptions { "-include shared/windows/mingw32_layer.h", "-fno-builtin"}
-  includedirs { "shared/windows/include", "/mingw64/include/opus", "external/mp4p/include" }
-  libdirs { "static-deps/lib-x86-64/lib/x86_64-linux-gnu", "static-deps/lib-x86-64/lib" }
+  includedirs { "shared/windows/include", "/mingw64/include/opus", "external/mp4p/include", "xdispatch_ddb/include" }
+  libdirs { "static-deps/lib-x86-64/lib/x86_64-linux-gnu", "static-deps/lib-x86-64/lib", "xdispatch_ddb/lib" }
   defines { "USE_STDIO", "HAVE_ICONV", "_POSIX_C_SOURCE" }
 
   if nls() then
     links {"intl"}
   end
   links { "ws2_32", "psapi", "shlwapi", "iconv", "libwin", "dl"}
+
+-- clang preset in premake5 does not support icon compiling, define it here
+filter 'files:**.rc'
+   buildcommands {
+      'windres -O coff -o "%{cfg.objdir}/%{file.basename}.o" "%{file.relpath}"'
+   }
+   buildoutputs { '%{cfg.objdir}/%{file.basename}.o' }
+
 
 project "libwin"
    kind "StaticLib"
@@ -1111,6 +1118,7 @@ end
 if option ("plugin-lastfm", "libcurl") then
 project "lastfm"
    kind "SharedLib"
+   buildoptions {"-fblocks"}
    language "C"
    targetdir "bin/%{cfg.buildcfg}/plugins"
    targetprefix ""
@@ -1119,6 +1127,7 @@ project "lastfm"
        "plugins/lastfm/*.h",
        "plugins/lastfm/*.c"
    }
+   links {"dispatch", "BlocksRuntime"}
    pkgconfig ("libcurl")
 end
 

--- a/premake5-win.lua
+++ b/premake5-win.lua
@@ -4,6 +4,7 @@ workspace "deadbeef"
    configurations { "debug", "release", "debug32", "release32" }
    platforms { "Windows" }
    defaultplatform "Windows"
+   toolset "clang"
 
 newoption {
   trigger = "version-override",

--- a/scripts/windows_postbuild.sh
+++ b/scripts/windows_postbuild.sh
@@ -44,6 +44,9 @@ ldd "$1/plugins/"*.dll "$1/deadbeef.exe" | awk 'NF == 4 {print $3}; NF == 2 {pri
 
 cp -uv `cat .libraries.tmp` "$1/"
 
+# libdispatch
+cp -uv xdispatch_ddb/lib/* "$1/"
+
 # gdk_pixbuf libs
 for i in /mingw32 /mingw64 /usr; do
 	cp -ru $i/lib/gdk-pixbuf-2.0 "$1/lib/gdk-pixbuf-2.0" 2>>/dev/null | true

--- a/travis/build.sh
+++ b/travis/build.sh
@@ -39,6 +39,9 @@ case "$TRAVIS_OS_NAME" in
         cd ../../..
     ;;
     windows)
+        STATICDEPS_URL="http://sourceforge.net/projects/deadbeef/files/staticdeps/ddb-xdispatch-win-latest.zip/download"
+        wget -q "$STATICDEPS_URL" -O ddb-xdispatch-win-latest.zip || exit 1
+        $mingw64 unzip ddb-xdispatch-win-latest.zip || exit 1
         git clone https://github.com/kuba160/deadbeef-windows-deps.git
         wget https://github.com/premake/premake-core/releases/download/v5.0.0-alpha15/premake-5.0.0-alpha15-windows.zip && unzip premake-5.0.0-alpha15-windows.zip
         $mingw64 ./premake5 --os=linux --file=premake5-win.lua --standard gmake

--- a/travis/build.sh
+++ b/travis/build.sh
@@ -49,8 +49,8 @@ case "$TRAVIS_OS_NAME" in
         wget https://github.com/premake/premake-core/releases/download/v5.0.0-alpha15/premake-5.0.0-alpha15-windows.zip && unzip premake-5.0.0-alpha15-windows.zip
         echo "building for x86_64"
         $mingw64 ./premake5 --os=linux --file=premake5-win.lua --standard gmake
-        $mingw64 make config=release_windows || exit 1
-        $mingw64 make config=debug_windows || exit 1
+        $mingw64 make config=release_windows CC=clang CXX=clang++ || exit 1
+        $mingw64 make config=debug_windows CC=clang CXX=clang++ || exit 1
         cp -r deadbeef-windows-deps/Windows-10 bin/debug/share/themes/Windows-10
         cp -r deadbeef-windows-deps/Windows-10 bin/release/share/themes/Windows-10
         cp -r deadbeef-windows-deps/Windows-10-Icons bin/debug/share/icons/Windows-10-Icons

--- a/travis/build.sh
+++ b/travis/build.sh
@@ -40,10 +40,14 @@ case "$TRAVIS_OS_NAME" in
     ;;
     windows)
         STATICDEPS_URL="http://sourceforge.net/projects/deadbeef/files/staticdeps/ddb-xdispatch-win-latest.zip/download"
+        echo "downloading xdispatch_ddb..."
         wget -q "$STATICDEPS_URL" -O ddb-xdispatch-win-latest.zip || exit 1
+        echo "unpacking xdispatch_ddb..."
         $mingw64 unzip ddb-xdispatch-win-latest.zip || exit 1
+        echo "downloading windows deps..."
         git clone https://github.com/kuba160/deadbeef-windows-deps.git
         wget https://github.com/premake/premake-core/releases/download/v5.0.0-alpha15/premake-5.0.0-alpha15-windows.zip && unzip premake-5.0.0-alpha15-windows.zip
+        echo "building for x86_64"
         $mingw64 ./premake5 --os=linux --file=premake5-win.lua --standard gmake
         $mingw64 make config=release_windows || exit 1
         $mingw64 make config=debug_windows || exit 1


### PR DESCRIPTION
The idea is that you:
1. Fork [DeaDBeeF-for-Windows/xdispatch_ddb](https://github.com/DeaDBeeF-for-Windows/xdispatch_ddb) into DeaDBeeF-Player.
2. Travis compiles windows version of libdispatch (xdispatch)
3. Zip file with binaries and headers is being sent to deadbeef sourceforge to `staticdeps/ddb-xdispatch-win-latest.zip`
4. Deadbeef travis build script downloads that zip file, unpacks it and uses provided libdispatch with its headers for windows build.

Please let me know if there is something you would like to do differently. If not, please rerun the build after `staticdeps/ddb-xdispatch-win-latest.zip` is available on sourceforge servers.