### PR TITLE
Prevent leaking file descriptors when loading and playing ALAC files

### DIFF
--- a/plugins/aac/aac.c
+++ b/plugins/aac/aac.c
@@ -1022,6 +1022,7 @@ aac_insert (ddb_playlist_t *plt, DB_playItem_t *after, const char *fname) {
             return after;
         }
         else if (res > 0) { // mp4 but not aac
+            deadbeef->fclose (fp);
             return NULL;
         }
     }

--- a/plugins/alac/alac_plugin.c
+++ b/plugins/alac/alac_plugin.c
@@ -111,8 +111,7 @@ alacplug_init (DB_fileinfo_t *_info, DB_playItem_t *it) {
     int bps = 0;
     float duration = 0;
 
-    DB_FILE *file = deadbeef->fopen (deadbeef->pl_find_meta (it, ":URI"));
-    info->mp4reader.ptrhandle = file;
+    info->mp4reader.ptrhandle = info->file;
     mp4_init_ddb_file_callbacks (&info->mp4reader);
     info->mp4file = mp4p_open(&info->mp4reader);
 


### PR DESCRIPTION
This fixes the underlying issue causing the crash in https://github.com/DeaDBeeF-Player/deadbeef/issues/2466.

Also fixes a second leak that happened on each ALAC track playback.