### PR TITLE
main: Make socket path use XDG_RUNTIME_DIR if set again

### DIFF
--- a/main.c
+++ b/main.c
@@ -523,7 +523,7 @@ int db_socket_set_unix (struct sockaddr_un *remote, int *len) {
     *len = offsetof(struct sockaddr_un, sun_path) + sizeof (server_id)-1;
 #else
     char *socketdirenv = getenv ("DDB_SOCKET_DIR");
-    snprintf (remote->sun_path, sizeof (remote->sun_path), "%s/socket", socketdirenv ? socketdirenv : dbconfdir);
+    snprintf (remote->sun_path, sizeof (remote->sun_path), "%s/socket", socketdirenv ? socketdirenv : dbruntimedir);
     *len = offsetof(struct sockaddr_un, sun_path) + (int)strlen (remote->sun_path);
 #endif
     return s;


### PR DESCRIPTION
This was accidentally reverted by commit 61c3bc88732ff1dd21a3e8fef706dede0d01df17
On Windows XDG_RUNTIME_DIR is unset so it will simply use the dbconfdir path.