### PR TITLE
psf: fix getting a relative directory error on windows

### DIFF
--- a/plugins/psf/eng_psf/eng_psf.c
+++ b/plugins/psf/eng_psf/eng_psf.c
@@ -62,23 +62,6 @@ static void spu_update (unsigned char* pSound,long lBytes,void *data)
 	memcpy(s->spu_pOutput, pSound, lBytes);
 }
 
-void
-ao_getlibpath (const char *path, const char *libname, char *libpath, int size) {
-    const char *e = strrchr (path, ':');
-    if (!e) {
-        e = strrchr (path, '/');
-    }
-    if (e) {
-        e++;
-        memcpy (libpath, path, e-path);
-        libpath[e-path] = 0;
-        strcat (libpath, libname);
-    }
-    else {
-        strcpy (libpath, libname);
-    }
-}
-
 void *psf_start(const char *path, uint8 *buffer, uint32 length)
 {
     psf_synth_t *s = malloc (sizeof (psf_synth_t));

--- a/plugins/psf/eng_psf/psx_hw.c
+++ b/plugins/psf/eng_psf/psx_hw.c
@@ -765,7 +765,7 @@ void psx_hw_frame(mips_cpu_context *cpu)
 {
 	if (cpu->psf_refresh == 50)
 	{
-		cpu->fcnt++;;
+		cpu->fcnt++;
 
 		if (cpu->fcnt < 6)
 		{

--- a/plugins/psf/psfmain.c
+++ b/plugins/psf/psfmain.c
@@ -260,3 +260,20 @@ int
 ao_command (uint32 type, void *handle, int32 command, int32 param) {
 	return (*types[type].command)(handle, command, param);
 }
+
+void
+ao_getlibpath (const char *path, const char *libname, char *libpath, int size) {
+    const char *e = strrchr (path, '\\');
+    if (!e) {
+        e = strrchr (path, '/');
+    }
+    if (e) {
+        e++;
+        memcpy (libpath, path, e-path);
+        libpath[e-path] = 0;
+        strcat (libpath, libname);
+    }
+    else {
+        strcpy (libpath, libname);
+    }
+}


### PR DESCRIPTION
Fix getting a relative directory error on windows, which causes the file(such as .minidsf .minipsf .miniqsf .minissf) not to be imported