### PR TITLE
gtkui: New plugin preferences UI

### DIFF
--- a/plugins/gtkui/callbacks.h
+++ b/plugins/gtkui/callbacks.h
@@ -1419,3 +1419,22 @@ on_minimize_on_startup_clicked         (GtkButton       *button,
 void
 on_move_to_trash_clicked               (GtkButton       *button,
                                         gpointer         user_data);
+
+void
+on_plugin_conf_tab_btn_clicked         (GtkRadioButton       *button,
+                                        gpointer         user_data);
+
+void
+on_plugin_info_tab_btn_clicked         (GtkRadioButton       *button,
+                                        gpointer         user_data);
+
+void
+on_plugin_license_tab_btn_clicked      (GtkRadioButton       *button,
+                                        gpointer         user_data);
+
+
+void
+on_plugin_notebook_switch_page         (GtkNotebook     *notebook,
+                                        GtkWidget       *page,
+                                        guint            page_num,
+                                        gpointer         user_data);

--- a/plugins/gtkui/callbacks.h
+++ b/plugins/gtkui/callbacks.h
@@ -1438,3 +1438,7 @@ on_plugin_notebook_switch_page         (GtkNotebook     *notebook,
                                         GtkWidget       *page,
                                         guint            page_num,
                                         gpointer         user_data);
+
+void
+on_plugin_conf_reset_btn_clicked       (GtkButton       *button,
+                                        gpointer         user_data);

--- a/plugins/gtkui/deadbeef.glade
+++ b/plugins/gtkui/deadbeef.glade
@@ -2357,7 +2357,7 @@ Center</property>
 	</widget>
 	<packing>
 	  <property name="padding">0</property>
-	  <property name="expand">False</property>
+	  <property name="expand">True</property>
 	  <property name="fill">True</property>
 	  <property name="pack_type">GTK_PACK_END</property>
 	</packing>
@@ -6882,94 +6882,137 @@ if you don't press Apply.</property>
 	      </child>
 
 	      <child>
-		<widget class="GtkVBox" id="vbox54">
+		<widget class="GtkAlignment" id="alignment33">
 		  <property name="visible">True</property>
-		  <property name="homogeneous">False</property>
-		  <property name="spacing">0</property>
+		  <property name="xalign">0.5</property>
+		  <property name="yalign">0.5</property>
+		  <property name="xscale">1</property>
+		  <property name="yscale">1</property>
+		  <property name="top_padding">0</property>
+		  <property name="bottom_padding">0</property>
+		  <property name="left_padding">16</property>
+		  <property name="right_padding">0</property>
 
 		  <child>
-		    <widget class="GtkHBox" id="hbox149">
-		      <property name="border_width">6</property>
+		    <widget class="GtkVBox" id="vbox54">
 		      <property name="visible">True</property>
 		      <property name="homogeneous">False</property>
-		      <property name="spacing">0</property>
+		      <property name="spacing">8</property>
 
 		      <child>
-			<widget class="GtkLabel" id="fillerlabel1">
+			<widget class="GtkHBox" id="hbox149">
 			  <property name="visible">True</property>
-			  <property name="label" translatable="yes"></property>
-			  <property name="use_underline">False</property>
-			  <property name="use_markup">False</property>
-			  <property name="justify">GTK_JUSTIFY_LEFT</property>
-			  <property name="wrap">False</property>
-			  <property name="selectable">False</property>
-			  <property name="xalign">0.5</property>
-			  <property name="yalign">0.5</property>
-			  <property name="xpad">0</property>
-			  <property name="ypad">0</property>
-			  <property name="ellipsize">PANGO_ELLIPSIZE_NONE</property>
-			  <property name="width_chars">-1</property>
-			  <property name="single_line_mode">False</property>
-			  <property name="angle">0</property>
-			</widget>
-			<packing>
-			  <property name="padding">0</property>
-			  <property name="expand">True</property>
-			  <property name="fill">False</property>
-			</packing>
-		      </child>
-
-		      <child>
-			<widget class="GtkHButtonBox" id="plugin_tabbtn_hbtnbox">
-			  <property name="visible">True</property>
-			  <property name="layout_style">GTK_BUTTONBOX_DEFAULT_STYLE</property>
+			  <property name="homogeneous">False</property>
 			  <property name="spacing">0</property>
 
 			  <child>
-			    <widget class="GtkRadioButton" id="plugin_conf_tab_btn">
+			    <widget class="GtkLabel" id="fillerlabel1">
 			      <property name="visible">True</property>
-			      <property name="can_focus">True</property>
-			      <property name="label" translatable="yes">Configuration</property>
-			      <property name="use_underline">True</property>
-			      <property name="relief">GTK_RELIEF_NORMAL</property>
-			      <property name="focus_on_click">True</property>
-			      <property name="active">True</property>
-			      <property name="inconsistent">False</property>
-			      <property name="draw_indicator">False</property>
-			      <signal name="clicked" handler="on_plugin_conf_tab_btn_clicked" last_modification_time="Thu, 25 Feb 2021 11:17:56 GMT"/>
+			      <property name="label" translatable="yes"></property>
+			      <property name="use_underline">False</property>
+			      <property name="use_markup">False</property>
+			      <property name="justify">GTK_JUSTIFY_LEFT</property>
+			      <property name="wrap">False</property>
+			      <property name="selectable">False</property>
+			      <property name="xalign">0.5</property>
+			      <property name="yalign">0.5</property>
+			      <property name="xpad">0</property>
+			      <property name="ypad">0</property>
+			      <property name="ellipsize">PANGO_ELLIPSIZE_NONE</property>
+			      <property name="width_chars">-1</property>
+			      <property name="single_line_mode">False</property>
+			      <property name="angle">0</property>
 			    </widget>
+			    <packing>
+			      <property name="padding">0</property>
+			      <property name="expand">True</property>
+			      <property name="fill">False</property>
+			    </packing>
 			  </child>
 
 			  <child>
-			    <widget class="GtkRadioButton" id="plugin_info_tab_btn">
+			    <widget class="GtkHButtonBox" id="plugin_tabbtn_hbtnbox">
 			      <property name="visible">True</property>
-			      <property name="can_focus">True</property>
-			      <property name="label" translatable="yes">Info</property>
-			      <property name="use_underline">True</property>
-			      <property name="relief">GTK_RELIEF_NORMAL</property>
-			      <property name="focus_on_click">True</property>
-			      <property name="active">False</property>
-			      <property name="inconsistent">False</property>
-			      <property name="draw_indicator">False</property>
-			      <property name="group">plugin_conf_tab_btn</property>
-			      <signal name="clicked" handler="on_plugin_info_tab_btn_clicked" last_modification_time="Thu, 25 Feb 2021 11:18:04 GMT"/>
+			      <property name="layout_style">GTK_BUTTONBOX_DEFAULT_STYLE</property>
+			      <property name="spacing">0</property>
+
+			      <child>
+				<widget class="GtkRadioButton" id="plugin_conf_tab_btn">
+				  <property name="visible">True</property>
+				  <property name="can_focus">True</property>
+				  <property name="label" translatable="yes">Configuration</property>
+				  <property name="use_underline">True</property>
+				  <property name="relief">GTK_RELIEF_NORMAL</property>
+				  <property name="focus_on_click">True</property>
+				  <property name="active">True</property>
+				  <property name="inconsistent">False</property>
+				  <property name="draw_indicator">False</property>
+				  <signal name="clicked" handler="on_plugin_conf_tab_btn_clicked" last_modification_time="Thu, 25 Feb 2021 11:17:56 GMT"/>
+				</widget>
+			      </child>
+
+			      <child>
+				<widget class="GtkRadioButton" id="plugin_info_tab_btn">
+				  <property name="visible">True</property>
+				  <property name="can_focus">True</property>
+				  <property name="label" translatable="yes">Info</property>
+				  <property name="use_underline">True</property>
+				  <property name="relief">GTK_RELIEF_NORMAL</property>
+				  <property name="focus_on_click">True</property>
+				  <property name="active">False</property>
+				  <property name="inconsistent">False</property>
+				  <property name="draw_indicator">False</property>
+				  <property name="group">plugin_conf_tab_btn</property>
+				  <signal name="clicked" handler="on_plugin_info_tab_btn_clicked" last_modification_time="Thu, 25 Feb 2021 11:18:04 GMT"/>
+				</widget>
+			      </child>
+
+			      <child>
+				<widget class="GtkRadioButton" id="plugin_license_tab_btn">
+				  <property name="visible">True</property>
+				  <property name="can_focus">True</property>
+				  <property name="label" translatable="yes">License</property>
+				  <property name="use_underline">True</property>
+				  <property name="relief">GTK_RELIEF_NORMAL</property>
+				  <property name="focus_on_click">True</property>
+				  <property name="active">False</property>
+				  <property name="inconsistent">False</property>
+				  <property name="draw_indicator">False</property>
+				  <property name="group">plugin_conf_tab_btn</property>
+				  <signal name="clicked" handler="on_plugin_license_tab_btn_clicked" last_modification_time="Thu, 25 Feb 2021 11:18:08 GMT"/>
+				</widget>
+			      </child>
 			    </widget>
+			    <packing>
+			      <property name="padding">0</property>
+			      <property name="expand">False</property>
+			      <property name="fill">False</property>
+			    </packing>
 			  </child>
 
 			  <child>
-			    <widget class="GtkRadioButton" id="plugin_license_tab_btn">
+			    <widget class="GtkLabel" id="fillerlabel2">
 			      <property name="visible">True</property>
-			      <property name="can_focus">True</property>
-			      <property name="label" translatable="yes">License</property>
-			      <property name="use_underline">True</property>
-			      <property name="relief">GTK_RELIEF_NORMAL</property>
-			      <property name="focus_on_click">True</property>
-			      <property name="active">False</property>
-			      <property name="inconsistent">False</property>
-			      <property name="draw_indicator">False</property>
-			      <property name="group">plugin_conf_tab_btn</property>
-			      <signal name="clicked" handler="on_plugin_license_tab_btn_clicked" last_modification_time="Thu, 25 Feb 2021 11:18:08 GMT"/>
+			      <property name="label" translatable="yes"></property>
+			      <property name="use_underline">False</property>
+			      <property name="use_markup">False</property>
+			      <property name="justify">GTK_JUSTIFY_LEFT</property>
+			      <property name="wrap">False</property>
+			      <property name="selectable">False</property>
+			      <property name="xalign">0.5</property>
+			      <property name="yalign">0.5</property>
+			      <property name="xpad">0</property>
+			      <property name="ypad">0</property>
+			      <property name="ellipsize">PANGO_ELLIPSIZE_NONE</property>
+			      <property name="width_chars">-1</property>
+			      <property name="single_line_mode">False</property>
+			      <property name="angle">0</property>
 			    </widget>
+			    <packing>
+			      <property name="padding">0</property>
+			      <property name="expand">True</property>
+			      <property name="fill">False</property>
+			    </packing>
 			  </child>
 			</widget>
 			<packing>
@@ -6980,146 +7023,156 @@ if you don't press Apply.</property>
 		      </child>
 
 		      <child>
-			<widget class="GtkLabel" id="fillerlabel2">
-			  <property name="visible">True</property>
-			  <property name="label" translatable="yes"></property>
-			  <property name="use_underline">False</property>
-			  <property name="use_markup">False</property>
-			  <property name="justify">GTK_JUSTIFY_LEFT</property>
-			  <property name="wrap">False</property>
-			  <property name="selectable">False</property>
-			  <property name="xalign">0.5</property>
-			  <property name="yalign">0.5</property>
-			  <property name="xpad">0</property>
-			  <property name="ypad">0</property>
-			  <property name="ellipsize">PANGO_ELLIPSIZE_NONE</property>
-			  <property name="width_chars">-1</property>
-			  <property name="single_line_mode">False</property>
-			  <property name="angle">0</property>
-			</widget>
-			<packing>
-			  <property name="padding">0</property>
-			  <property name="expand">True</property>
-			  <property name="fill">False</property>
-			</packing>
-		      </child>
-		    </widget>
-		    <packing>
-		      <property name="padding">0</property>
-		      <property name="expand">False</property>
-		      <property name="fill">False</property>
-		    </packing>
-		  </child>
-
-		  <child>
-		    <widget class="GtkNotebook" id="plugin_notebook">
-		      <property name="border_width">6</property>
-		      <property name="visible">True</property>
-		      <property name="can_focus">True</property>
-		      <property name="show_tabs">True</property>
-		      <property name="show_border">False</property>
-		      <property name="tab_pos">GTK_POS_TOP</property>
-		      <property name="scrollable">False</property>
-		      <property name="enable_popup">False</property>
-		      <signal name="switch_page" handler="on_plugin_notebook_switch_page" last_modification_time="Thu, 25 Feb 2021 07:50:30 GMT"/>
-
-		      <child>
-			<widget class="GtkScrolledWindow" id="plug_conf_dlg_scrolledwindow">
+			<widget class="GtkNotebook" id="plugin_notebook">
 			  <property name="visible">True</property>
 			  <property name="can_focus">True</property>
-			  <property name="hscrollbar_policy">GTK_POLICY_AUTOMATIC</property>
-			  <property name="vscrollbar_policy">GTK_POLICY_AUTOMATIC</property>
-			  <property name="shadow_type">GTK_SHADOW_NONE</property>
-			  <property name="window_placement">GTK_CORNER_TOP_LEFT</property>
+			  <property name="show_tabs">True</property>
+			  <property name="show_border">False</property>
+			  <property name="tab_pos">GTK_POS_TOP</property>
+			  <property name="scrollable">False</property>
+			  <property name="enable_popup">False</property>
+			  <signal name="switch_page" handler="on_plugin_notebook_switch_page" last_modification_time="Thu, 25 Feb 2021 07:50:30 GMT"/>
 
 			  <child>
-			    <widget class="GtkViewport" id="plug_conf_dlg_viewport">
+			    <widget class="GtkScrolledWindow" id="plug_conf_dlg_scrolledwindow">
 			      <property name="visible">True</property>
+			      <property name="can_focus">True</property>
+			      <property name="hscrollbar_policy">GTK_POLICY_AUTOMATIC</property>
+			      <property name="vscrollbar_policy">GTK_POLICY_AUTOMATIC</property>
 			      <property name="shadow_type">GTK_SHADOW_NONE</property>
+			      <property name="window_placement">GTK_CORNER_TOP_LEFT</property>
 
 			      <child>
-				<placeholder/>
+				<widget class="GtkViewport" id="plug_conf_dlg_viewport">
+				  <property name="visible">True</property>
+				  <property name="shadow_type">GTK_SHADOW_NONE</property>
+
+				  <child>
+				    <placeholder/>
+				  </child>
+				</widget>
 			      </child>
 			    </widget>
+			    <packing>
+			      <property name="tab_expand">False</property>
+			      <property name="tab_fill">True</property>
+			    </packing>
 			  </child>
-			</widget>
-			<packing>
-			  <property name="tab_expand">False</property>
-			  <property name="tab_fill">True</property>
-			</packing>
-		      </child>
-
-		      <child>
-			<widget class="GtkLabel" id="label170">
-			  <property name="visible">True</property>
-			  <property name="label" translatable="yes">Configuration</property>
-			  <property name="use_underline">False</property>
-			  <property name="use_markup">False</property>
-			  <property name="justify">GTK_JUSTIFY_LEFT</property>
-			  <property name="wrap">False</property>
-			  <property name="selectable">False</property>
-			  <property name="xalign">0.5</property>
-			  <property name="yalign">0.5</property>
-			  <property name="xpad">0</property>
-			  <property name="ypad">0</property>
-			  <property name="ellipsize">PANGO_ELLIPSIZE_NONE</property>
-			  <property name="width_chars">-1</property>
-			  <property name="single_line_mode">False</property>
-			  <property name="angle">0</property>
-			</widget>
-			<packing>
-			  <property name="type">tab</property>
-			</packing>
-		      </child>
-
-		      <child>
-			<widget class="GtkVBox" id="vbox12">
-			  <property name="visible">True</property>
-			  <property name="homogeneous">False</property>
-			  <property name="spacing">8</property>
 
 			  <child>
-			    <widget class="GtkHBox" id="hbox103">
+			    <widget class="GtkLabel" id="label170">
+			      <property name="visible">True</property>
+			      <property name="label" translatable="yes">Configuration</property>
+			      <property name="use_underline">False</property>
+			      <property name="use_markup">False</property>
+			      <property name="justify">GTK_JUSTIFY_LEFT</property>
+			      <property name="wrap">False</property>
+			      <property name="selectable">False</property>
+			      <property name="xalign">0.5</property>
+			      <property name="yalign">0.5</property>
+			      <property name="xpad">0</property>
+			      <property name="ypad">0</property>
+			      <property name="ellipsize">PANGO_ELLIPSIZE_NONE</property>
+			      <property name="width_chars">-1</property>
+			      <property name="single_line_mode">False</property>
+			      <property name="angle">0</property>
+			    </widget>
+			    <packing>
+			      <property name="type">tab</property>
+			    </packing>
+			  </child>
+
+			  <child>
+			    <widget class="GtkVBox" id="vbox12">
 			      <property name="visible">True</property>
 			      <property name="homogeneous">False</property>
 			      <property name="spacing">8</property>
 
 			      <child>
-				<widget class="GtkLabel" id="label130">
+				<widget class="GtkHBox" id="hbox103">
 				  <property name="visible">True</property>
-				  <property name="label" translatable="yes">Version: </property>
-				  <property name="use_underline">False</property>
-				  <property name="use_markup">False</property>
-				  <property name="justify">GTK_JUSTIFY_LEFT</property>
-				  <property name="wrap">False</property>
-				  <property name="selectable">False</property>
-				  <property name="xalign">0.5</property>
-				  <property name="yalign">0.5</property>
-				  <property name="xpad">0</property>
-				  <property name="ypad">0</property>
-				  <property name="ellipsize">PANGO_ELLIPSIZE_NONE</property>
-				  <property name="width_chars">-1</property>
-				  <property name="single_line_mode">False</property>
-				  <property name="angle">0</property>
+				  <property name="homogeneous">False</property>
+				  <property name="spacing">8</property>
+
+				  <child>
+				    <widget class="GtkLabel" id="label130">
+				      <property name="visible">True</property>
+				      <property name="label" translatable="yes">Version: </property>
+				      <property name="use_underline">False</property>
+				      <property name="use_markup">False</property>
+				      <property name="justify">GTK_JUSTIFY_LEFT</property>
+				      <property name="wrap">False</property>
+				      <property name="selectable">False</property>
+				      <property name="xalign">0.5</property>
+				      <property name="yalign">0.5</property>
+				      <property name="xpad">0</property>
+				      <property name="ypad">0</property>
+				      <property name="ellipsize">PANGO_ELLIPSIZE_NONE</property>
+				      <property name="width_chars">-1</property>
+				      <property name="single_line_mode">False</property>
+				      <property name="angle">0</property>
+				    </widget>
+				    <packing>
+				      <property name="padding">0</property>
+				      <property name="expand">False</property>
+				      <property name="fill">False</property>
+				    </packing>
+				  </child>
+
+				  <child>
+				    <widget class="GtkEntry" id="plug_version">
+				      <property name="visible">True</property>
+				      <property name="can_focus">True</property>
+				      <property name="editable">False</property>
+				      <property name="visibility">True</property>
+				      <property name="max_length">0</property>
+				      <property name="text" translatable="yes"></property>
+				      <property name="has_frame">True</property>
+				      <property name="invisible_char">•</property>
+				      <property name="activates_default">False</property>
+				    </widget>
+				    <packing>
+				      <property name="padding">0</property>
+				      <property name="expand">True</property>
+				      <property name="fill">True</property>
+				    </packing>
+				  </child>
 				</widget>
 				<packing>
 				  <property name="padding">0</property>
 				  <property name="expand">False</property>
-				  <property name="fill">False</property>
+				  <property name="fill">True</property>
 				</packing>
 			      </child>
 
 			      <child>
-				<widget class="GtkEntry" id="plug_version">
+				<widget class="GtkScrolledWindow" id="scrolledwindow8">
 				  <property name="visible">True</property>
 				  <property name="can_focus">True</property>
-				  <property name="editable">False</property>
-				  <property name="visibility">True</property>
-				  <property name="max_length">0</property>
-				  <property name="text" translatable="yes"></property>
-				  <property name="has_frame">True</property>
-				  <property name="invisible_char">•</property>
-				  <property name="activates_default">False</property>
+				  <property name="hscrollbar_policy">GTK_POLICY_AUTOMATIC</property>
+				  <property name="vscrollbar_policy">GTK_POLICY_AUTOMATIC</property>
+				  <property name="shadow_type">GTK_SHADOW_IN</property>
+				  <property name="window_placement">GTK_CORNER_TOP_LEFT</property>
+
+				  <child>
+				    <widget class="GtkTextView" id="plug_description">
+				      <property name="visible">True</property>
+				      <property name="can_focus">True</property>
+				      <property name="editable">False</property>
+				      <property name="overwrite">False</property>
+				      <property name="accepts_tab">True</property>
+				      <property name="justification">GTK_JUSTIFY_LEFT</property>
+				      <property name="wrap_mode">GTK_WRAP_NONE</property>
+				      <property name="cursor_visible">False</property>
+				      <property name="pixels_above_lines">0</property>
+				      <property name="pixels_below_lines">0</property>
+				      <property name="pixels_inside_wrap">0</property>
+				      <property name="left_margin">0</property>
+				      <property name="right_margin">0</property>
+				      <property name="indent">0</property>
+				      <property name="text" translatable="yes"></property>
+				    </widget>
+				  </child>
 				</widget>
 				<packing>
 				  <property name="padding">0</property>
@@ -7127,16 +7180,66 @@ if you don't press Apply.</property>
 				  <property name="fill">True</property>
 				</packing>
 			      </child>
+
+			      <child>
+				<widget class="GtkHBox" id="hbox20">
+				  <property name="visible">True</property>
+				  <property name="homogeneous">False</property>
+				  <property name="spacing">0</property>
+
+				  <child>
+				    <widget class="Custom" id="weblink">
+				      <property name="visible">True</property>
+				      <property name="creation_function">create_plugin_weblink</property>
+				      <property name="int1">0</property>
+				      <property name="int2">0</property>
+				      <property name="last_modification_time">Sun, 27 Feb 2011 11:39:00 GMT</property>
+				    </widget>
+				    <packing>
+				      <property name="padding">0</property>
+				      <property name="expand">True</property>
+				      <property name="fill">False</property>
+				    </packing>
+				  </child>
+				</widget>
+				<packing>
+				  <property name="padding">0</property>
+				  <property name="expand">False</property>
+				  <property name="fill">False</property>
+				</packing>
+			      </child>
 			    </widget>
 			    <packing>
-			      <property name="padding">0</property>
-			      <property name="expand">False</property>
-			      <property name="fill">True</property>
+			      <property name="tab_expand">False</property>
+			      <property name="tab_fill">True</property>
 			    </packing>
 			  </child>
 
 			  <child>
-			    <widget class="GtkScrolledWindow" id="scrolledwindow8">
+			    <widget class="GtkLabel" id="label171">
+			      <property name="visible">True</property>
+			      <property name="label" translatable="yes">Info</property>
+			      <property name="use_underline">False</property>
+			      <property name="use_markup">False</property>
+			      <property name="justify">GTK_JUSTIFY_LEFT</property>
+			      <property name="wrap">False</property>
+			      <property name="selectable">False</property>
+			      <property name="xalign">0.5</property>
+			      <property name="yalign">0.5</property>
+			      <property name="xpad">0</property>
+			      <property name="ypad">0</property>
+			      <property name="ellipsize">PANGO_ELLIPSIZE_NONE</property>
+			      <property name="width_chars">-1</property>
+			      <property name="single_line_mode">False</property>
+			      <property name="angle">0</property>
+			    </widget>
+			    <packing>
+			      <property name="type">tab</property>
+			    </packing>
+			  </child>
+
+			  <child>
+			    <widget class="GtkScrolledWindow" id="scrolledwindow16">
 			      <property name="visible">True</property>
 			      <property name="can_focus">True</property>
 			      <property name="hscrollbar_policy">GTK_POLICY_AUTOMATIC</property>
@@ -7145,7 +7248,7 @@ if you don't press Apply.</property>
 			      <property name="window_placement">GTK_CORNER_TOP_LEFT</property>
 
 			      <child>
-				<widget class="GtkTextView" id="plug_description">
+				<widget class="GtkTextView" id="plug_license">
 				  <property name="visible">True</property>
 				  <property name="can_focus">True</property>
 				  <property name="editable">False</property>
@@ -7165,170 +7268,67 @@ if you don't press Apply.</property>
 			      </child>
 			    </widget>
 			    <packing>
-			      <property name="padding">0</property>
-			      <property name="expand">True</property>
-			      <property name="fill">True</property>
+			      <property name="tab_expand">False</property>
+			      <property name="tab_fill">True</property>
 			    </packing>
 			  </child>
 
 			  <child>
-			    <widget class="GtkHBox" id="hbox20">
+			    <widget class="GtkLabel" id="label172">
 			      <property name="visible">True</property>
-			      <property name="homogeneous">False</property>
-			      <property name="spacing">0</property>
-
-			      <child>
-				<widget class="Custom" id="weblink">
-				  <property name="visible">True</property>
-				  <property name="creation_function">create_plugin_weblink</property>
-				  <property name="int1">0</property>
-				  <property name="int2">0</property>
-				  <property name="last_modification_time">Sun, 27 Feb 2011 11:39:00 GMT</property>
-				</widget>
-				<packing>
-				  <property name="padding">0</property>
-				  <property name="expand">True</property>
-				  <property name="fill">False</property>
-				</packing>
-			      </child>
+			      <property name="label" translatable="yes">License</property>
+			      <property name="use_underline">False</property>
+			      <property name="use_markup">False</property>
+			      <property name="justify">GTK_JUSTIFY_LEFT</property>
+			      <property name="wrap">False</property>
+			      <property name="selectable">False</property>
+			      <property name="xalign">0.5</property>
+			      <property name="yalign">0.5</property>
+			      <property name="xpad">0</property>
+			      <property name="ypad">0</property>
+			      <property name="ellipsize">PANGO_ELLIPSIZE_NONE</property>
+			      <property name="width_chars">-1</property>
+			      <property name="single_line_mode">False</property>
+			      <property name="angle">0</property>
 			    </widget>
 			    <packing>
-			      <property name="padding">0</property>
-			      <property name="expand">False</property>
-			      <property name="fill">False</property>
+			      <property name="type">tab</property>
 			    </packing>
 			  </child>
 			</widget>
 			<packing>
-			  <property name="tab_expand">False</property>
-			  <property name="tab_fill">True</property>
+			  <property name="padding">0</property>
+			  <property name="expand">True</property>
+			  <property name="fill">True</property>
 			</packing>
 		      </child>
 
 		      <child>
-			<widget class="GtkLabel" id="label171">
+			<widget class="GtkHButtonBox" id="plugin_actions_btnbox">
 			  <property name="visible">True</property>
-			  <property name="label" translatable="yes">Info</property>
-			  <property name="use_underline">False</property>
-			  <property name="use_markup">False</property>
-			  <property name="justify">GTK_JUSTIFY_LEFT</property>
-			  <property name="wrap">False</property>
-			  <property name="selectable">False</property>
-			  <property name="xalign">0.5</property>
-			  <property name="yalign">0.5</property>
-			  <property name="xpad">0</property>
-			  <property name="ypad">0</property>
-			  <property name="ellipsize">PANGO_ELLIPSIZE_NONE</property>
-			  <property name="width_chars">-1</property>
-			  <property name="single_line_mode">False</property>
-			  <property name="angle">0</property>
-			</widget>
-			<packing>
-			  <property name="type">tab</property>
-			</packing>
-		      </child>
-
-		      <child>
-			<widget class="GtkScrolledWindow" id="scrolledwindow16">
-			  <property name="visible">True</property>
-			  <property name="can_focus">True</property>
-			  <property name="hscrollbar_policy">GTK_POLICY_AUTOMATIC</property>
-			  <property name="vscrollbar_policy">GTK_POLICY_AUTOMATIC</property>
-			  <property name="shadow_type">GTK_SHADOW_IN</property>
-			  <property name="window_placement">GTK_CORNER_TOP_LEFT</property>
+			  <property name="layout_style">GTK_BUTTONBOX_END</property>
+			  <property name="spacing">0</property>
 
 			  <child>
-			    <widget class="GtkTextView" id="plug_license">
+			    <widget class="GtkButton" id="plugin_conf_reset_btn">
 			      <property name="visible">True</property>
+			      <property name="can_default">True</property>
 			      <property name="can_focus">True</property>
-			      <property name="editable">False</property>
-			      <property name="overwrite">False</property>
-			      <property name="accepts_tab">True</property>
-			      <property name="justification">GTK_JUSTIFY_LEFT</property>
-			      <property name="wrap_mode">GTK_WRAP_NONE</property>
-			      <property name="cursor_visible">False</property>
-			      <property name="pixels_above_lines">0</property>
-			      <property name="pixels_below_lines">0</property>
-			      <property name="pixels_inside_wrap">0</property>
-			      <property name="left_margin">0</property>
-			      <property name="right_margin">0</property>
-			      <property name="indent">0</property>
-			      <property name="text" translatable="yes"></property>
+			      <property name="label" translatable="yes">Reset to defaults</property>
+			      <property name="use_underline">True</property>
+			      <property name="relief">GTK_RELIEF_NORMAL</property>
+			      <property name="focus_on_click">True</property>
+			      <signal name="clicked" handler="on_plugin_conf_reset_btn_clicked" last_modification_time="Fri, 26 Feb 2021 21:54:07 GMT"/>
 			    </widget>
 			  </child>
 			</widget>
 			<packing>
-			  <property name="tab_expand">False</property>
-			  <property name="tab_fill">True</property>
-			</packing>
-		      </child>
-
-		      <child>
-			<widget class="GtkLabel" id="label172">
-			  <property name="visible">True</property>
-			  <property name="label" translatable="yes">License</property>
-			  <property name="use_underline">False</property>
-			  <property name="use_markup">False</property>
-			  <property name="justify">GTK_JUSTIFY_LEFT</property>
-			  <property name="wrap">False</property>
-			  <property name="selectable">False</property>
-			  <property name="xalign">0.5</property>
-			  <property name="yalign">0.5</property>
-			  <property name="xpad">0</property>
-			  <property name="ypad">0</property>
-			  <property name="ellipsize">PANGO_ELLIPSIZE_NONE</property>
-			  <property name="width_chars">-1</property>
-			  <property name="single_line_mode">False</property>
-			  <property name="angle">0</property>
-			</widget>
-			<packing>
-			  <property name="type">tab</property>
+			  <property name="padding">0</property>
+			  <property name="expand">False</property>
+			  <property name="fill">True</property>
 			</packing>
 		      </child>
 		    </widget>
-		    <packing>
-		      <property name="padding">0</property>
-		      <property name="expand">True</property>
-		      <property name="fill">True</property>
-		    </packing>
-		  </child>
-
-		  <child>
-		    <widget class="GtkHSeparator" id="hseparator7">
-		      <property name="visible">True</property>
-		    </widget>
-		    <packing>
-		      <property name="padding">0</property>
-		      <property name="expand">False</property>
-		      <property name="fill">True</property>
-		    </packing>
-		  </child>
-
-		  <child>
-		    <widget class="GtkHButtonBox" id="plugin_actions_btnbox">
-		      <property name="visible">True</property>
-		      <property name="layout_style">GTK_BUTTONBOX_END</property>
-		      <property name="spacing">0</property>
-
-		      <child>
-			<widget class="GtkButton" id="plugin_conf_reset_btn">
-			  <property name="visible">True</property>
-			  <property name="sensitive">False</property>
-			  <property name="can_default">True</property>
-			  <property name="can_focus">True</property>
-			  <property name="label" translatable="yes">Reset to defaults</property>
-			  <property name="use_underline">True</property>
-			  <property name="relief">GTK_RELIEF_NORMAL</property>
-			  <property name="focus_on_click">True</property>
-			  <signal name="clicked" handler="on_plugin_conf_reset_btn_clicked" last_modification_time="Fri, 26 Feb 2021 21:54:07 GMT"/>
-			</widget>
-		      </child>
-		    </widget>
-		    <packing>
-		      <property name="padding">0</property>
-		      <property name="expand">False</property>
-		      <property name="fill">True</property>
-		    </packing>
 		  </child>
 		</widget>
 		<packing>

--- a/plugins/gtkui/deadbeef.glade
+++ b/plugins/gtkui/deadbeef.glade
@@ -6847,6 +6847,7 @@ if you don't press Apply.</property>
 	      <property name="border_width">12</property>
 	      <property name="visible">True</property>
 	      <property name="can_focus">True</property>
+	      <property name="position">0</property>
 
 	      <child>
 		<widget class="GtkScrolledWindow" id="scrolledwindow2">
@@ -6895,7 +6896,7 @@ if you don't press Apply.</property>
 		      <property name="spacing">0</property>
 
 		      <child>
-			<widget class="GtkLabel" id="label169">
+			<widget class="GtkLabel" id="fillerlabel1">
 			  <property name="visible">True</property>
 			  <property name="label" translatable="yes"></property>
 			  <property name="use_underline">False</property>
@@ -6915,15 +6916,15 @@ if you don't press Apply.</property>
 			<packing>
 			  <property name="padding">0</property>
 			  <property name="expand">True</property>
-			  <property name="fill">True</property>
+			  <property name="fill">False</property>
 			</packing>
 		      </child>
 
 		      <child>
-			<widget class="GtkHBox" id="plugin_tabbtn_hbox">
+			<widget class="GtkHButtonBox" id="plugin_tabbtn_hbtnbox">
 			  <property name="visible">True</property>
-			  <property name="homogeneous">True</property>
-			  <property name="spacing">5</property>
+			  <property name="layout_style">GTK_BUTTONBOX_DEFAULT_STYLE</property>
+			  <property name="spacing">0</property>
 
 			  <child>
 			    <widget class="GtkRadioButton" id="plugin_conf_tab_btn">
@@ -6938,11 +6939,6 @@ if you don't press Apply.</property>
 			      <property name="draw_indicator">False</property>
 			      <signal name="clicked" handler="on_plugin_conf_tab_btn_clicked" last_modification_time="Thu, 25 Feb 2021 11:17:56 GMT"/>
 			    </widget>
-			    <packing>
-			      <property name="padding">0</property>
-			      <property name="expand">True</property>
-			      <property name="fill">True</property>
-			    </packing>
 			  </child>
 
 			  <child>
@@ -6959,11 +6955,6 @@ if you don't press Apply.</property>
 			      <property name="group">plugin_conf_tab_btn</property>
 			      <signal name="clicked" handler="on_plugin_info_tab_btn_clicked" last_modification_time="Thu, 25 Feb 2021 11:18:04 GMT"/>
 			    </widget>
-			    <packing>
-			      <property name="padding">0</property>
-			      <property name="expand">True</property>
-			      <property name="fill">True</property>
-			    </packing>
 			  </child>
 
 			  <child>
@@ -6980,22 +6971,17 @@ if you don't press Apply.</property>
 			      <property name="group">plugin_conf_tab_btn</property>
 			      <signal name="clicked" handler="on_plugin_license_tab_btn_clicked" last_modification_time="Thu, 25 Feb 2021 11:18:08 GMT"/>
 			    </widget>
-			    <packing>
-			      <property name="padding">0</property>
-			      <property name="expand">True</property>
-			      <property name="fill">True</property>
-			    </packing>
 			  </child>
 			</widget>
 			<packing>
 			  <property name="padding">0</property>
 			  <property name="expand">False</property>
-			  <property name="fill">True</property>
+			  <property name="fill">False</property>
 			</packing>
 		      </child>
 
 		      <child>
-			<widget class="GtkLabel" id="label168">
+			<widget class="GtkLabel" id="fillerlabel2">
 			  <property name="visible">True</property>
 			  <property name="label" translatable="yes"></property>
 			  <property name="use_underline">False</property>
@@ -7015,7 +7001,7 @@ if you don't press Apply.</property>
 			<packing>
 			  <property name="padding">0</property>
 			  <property name="expand">True</property>
-			  <property name="fill">True</property>
+			  <property name="fill">False</property>
 			</packing>
 		      </child>
 		    </widget>
@@ -7048,7 +7034,14 @@ if you don't press Apply.</property>
 			  <property name="window_placement">GTK_CORNER_TOP_LEFT</property>
 
 			  <child>
-			    <placeholder/>
+			    <widget class="GtkViewport" id="plug_conf_dlg_viewport">
+			      <property name="visible">True</property>
+			      <property name="shadow_type">GTK_SHADOW_NONE</property>
+
+			      <child>
+				<placeholder/>
+			      </child>
+			    </widget>
 			  </child>
 			</widget>
 			<packing>
@@ -7302,7 +7295,7 @@ if you don't press Apply.</property>
 		  </child>
 		</widget>
 		<packing>
-		  <property name="shrink">True</property>
+		  <property name="shrink">False</property>
 		  <property name="resize">True</property>
 		</packing>
 	      </child>

--- a/plugins/gtkui/deadbeef.glade
+++ b/plugins/gtkui/deadbeef.glade
@@ -6882,22 +6882,22 @@ if you don't press Apply.</property>
 	      </child>
 
 	      <child>
-		<widget class="GtkVBox" id="vbox12">
-		  <property name="border_width">12</property>
+		<widget class="GtkVBox" id="vbox54">
 		  <property name="visible">True</property>
 		  <property name="homogeneous">False</property>
-		  <property name="spacing">8</property>
+		  <property name="spacing">0</property>
 
 		  <child>
-		    <widget class="GtkHBox" id="hbox103">
+		    <widget class="GtkHBox" id="hbox149">
+		      <property name="border_width">6</property>
 		      <property name="visible">True</property>
 		      <property name="homogeneous">False</property>
-		      <property name="spacing">8</property>
+		      <property name="spacing">0</property>
 
 		      <child>
-			<widget class="GtkLabel" id="label130">
+			<widget class="GtkLabel" id="label169">
 			  <property name="visible">True</property>
-			  <property name="label" translatable="yes">Version: </property>
+			  <property name="label" translatable="yes"></property>
 			  <property name="use_underline">False</property>
 			  <property name="use_markup">False</property>
 			  <property name="justify">GTK_JUSTIFY_LEFT</property>
@@ -6914,22 +6914,103 @@ if you don't press Apply.</property>
 			</widget>
 			<packing>
 			  <property name="padding">0</property>
-			  <property name="expand">False</property>
-			  <property name="fill">False</property>
+			  <property name="expand">True</property>
+			  <property name="fill">True</property>
 			</packing>
 		      </child>
 
 		      <child>
-			<widget class="GtkEntry" id="plug_version">
+			<widget class="GtkHBox" id="plugin_tabbtn_hbox">
 			  <property name="visible">True</property>
-			  <property name="can_focus">True</property>
-			  <property name="editable">False</property>
-			  <property name="visibility">True</property>
-			  <property name="max_length">0</property>
-			  <property name="text" translatable="yes"></property>
-			  <property name="has_frame">True</property>
-			  <property name="invisible_char">•</property>
-			  <property name="activates_default">False</property>
+			  <property name="homogeneous">True</property>
+			  <property name="spacing">5</property>
+
+			  <child>
+			    <widget class="GtkRadioButton" id="plugin_conf_tab_btn">
+			      <property name="visible">True</property>
+			      <property name="can_focus">True</property>
+			      <property name="label" translatable="yes">Configuration</property>
+			      <property name="use_underline">True</property>
+			      <property name="relief">GTK_RELIEF_NORMAL</property>
+			      <property name="focus_on_click">True</property>
+			      <property name="active">True</property>
+			      <property name="inconsistent">False</property>
+			      <property name="draw_indicator">False</property>
+			      <signal name="clicked" handler="on_plugin_conf_tab_btn_clicked" last_modification_time="Thu, 25 Feb 2021 11:17:56 GMT"/>
+			    </widget>
+			    <packing>
+			      <property name="padding">0</property>
+			      <property name="expand">True</property>
+			      <property name="fill">True</property>
+			    </packing>
+			  </child>
+
+			  <child>
+			    <widget class="GtkRadioButton" id="plugin_info_tab_btn">
+			      <property name="visible">True</property>
+			      <property name="can_focus">True</property>
+			      <property name="label" translatable="yes">Info</property>
+			      <property name="use_underline">True</property>
+			      <property name="relief">GTK_RELIEF_NORMAL</property>
+			      <property name="focus_on_click">True</property>
+			      <property name="active">False</property>
+			      <property name="inconsistent">False</property>
+			      <property name="draw_indicator">False</property>
+			      <property name="group">plugin_conf_tab_btn</property>
+			      <signal name="clicked" handler="on_plugin_info_tab_btn_clicked" last_modification_time="Thu, 25 Feb 2021 11:18:04 GMT"/>
+			    </widget>
+			    <packing>
+			      <property name="padding">0</property>
+			      <property name="expand">True</property>
+			      <property name="fill">True</property>
+			    </packing>
+			  </child>
+
+			  <child>
+			    <widget class="GtkRadioButton" id="plugin_license_tab_btn">
+			      <property name="visible">True</property>
+			      <property name="can_focus">True</property>
+			      <property name="label" translatable="yes">License</property>
+			      <property name="use_underline">True</property>
+			      <property name="relief">GTK_RELIEF_NORMAL</property>
+			      <property name="focus_on_click">True</property>
+			      <property name="active">False</property>
+			      <property name="inconsistent">False</property>
+			      <property name="draw_indicator">False</property>
+			      <property name="group">plugin_conf_tab_btn</property>
+			      <signal name="clicked" handler="on_plugin_license_tab_btn_clicked" last_modification_time="Thu, 25 Feb 2021 11:18:08 GMT"/>
+			    </widget>
+			    <packing>
+			      <property name="padding">0</property>
+			      <property name="expand">True</property>
+			      <property name="fill">True</property>
+			    </packing>
+			  </child>
+			</widget>
+			<packing>
+			  <property name="padding">0</property>
+			  <property name="expand">False</property>
+			  <property name="fill">True</property>
+			</packing>
+		      </child>
+
+		      <child>
+			<widget class="GtkLabel" id="label168">
+			  <property name="visible">True</property>
+			  <property name="label" translatable="yes"></property>
+			  <property name="use_underline">False</property>
+			  <property name="use_markup">False</property>
+			  <property name="justify">GTK_JUSTIFY_LEFT</property>
+			  <property name="wrap">False</property>
+			  <property name="selectable">False</property>
+			  <property name="xalign">0.5</property>
+			  <property name="yalign">0.5</property>
+			  <property name="xpad">0</property>
+			  <property name="ypad">0</property>
+			  <property name="ellipsize">PANGO_ELLIPSIZE_NONE</property>
+			  <property name="width_chars">-1</property>
+			  <property name="single_line_mode">False</property>
+			  <property name="angle">0</property>
 			</widget>
 			<packing>
 			  <property name="padding">0</property>
@@ -6941,231 +7022,282 @@ if you don't press Apply.</property>
 		    <packing>
 		      <property name="padding">0</property>
 		      <property name="expand">False</property>
-		      <property name="fill">True</property>
+		      <property name="fill">False</property>
 		    </packing>
 		  </child>
 
 		  <child>
-		    <widget class="GtkScrolledWindow" id="scrolledwindow8">
+		    <widget class="GtkNotebook" id="plugin_notebook">
+		      <property name="border_width">6</property>
 		      <property name="visible">True</property>
 		      <property name="can_focus">True</property>
-		      <property name="hscrollbar_policy">GTK_POLICY_AUTOMATIC</property>
-		      <property name="vscrollbar_policy">GTK_POLICY_AUTOMATIC</property>
-		      <property name="shadow_type">GTK_SHADOW_IN</property>
-		      <property name="window_placement">GTK_CORNER_TOP_LEFT</property>
+		      <property name="show_tabs">True</property>
+		      <property name="show_border">False</property>
+		      <property name="tab_pos">GTK_POS_TOP</property>
+		      <property name="scrollable">False</property>
+		      <property name="enable_popup">False</property>
+		      <signal name="switch_page" handler="on_plugin_notebook_switch_page" last_modification_time="Thu, 25 Feb 2021 07:50:30 GMT"/>
 
 		      <child>
-			<widget class="GtkTextView" id="plug_description">
+			<widget class="GtkScrolledWindow" id="plug_conf_dlg_scrolledwindow">
 			  <property name="visible">True</property>
 			  <property name="can_focus">True</property>
-			  <property name="editable">False</property>
-			  <property name="overwrite">False</property>
-			  <property name="accepts_tab">True</property>
-			  <property name="justification">GTK_JUSTIFY_LEFT</property>
-			  <property name="wrap_mode">GTK_WRAP_NONE</property>
-			  <property name="cursor_visible">False</property>
-			  <property name="pixels_above_lines">0</property>
-			  <property name="pixels_below_lines">0</property>
-			  <property name="pixels_inside_wrap">0</property>
-			  <property name="left_margin">0</property>
-			  <property name="right_margin">0</property>
-			  <property name="indent">0</property>
-			  <property name="text" translatable="yes"></property>
+			  <property name="hscrollbar_policy">GTK_POLICY_AUTOMATIC</property>
+			  <property name="vscrollbar_policy">GTK_POLICY_AUTOMATIC</property>
+			  <property name="shadow_type">GTK_SHADOW_NONE</property>
+			  <property name="window_placement">GTK_CORNER_TOP_LEFT</property>
+
+			  <child>
+			    <placeholder/>
+			  </child>
 			</widget>
+			<packing>
+			  <property name="tab_expand">False</property>
+			  <property name="tab_fill">True</property>
+			</packing>
+		      </child>
+
+		      <child>
+			<widget class="GtkLabel" id="label170">
+			  <property name="visible">True</property>
+			  <property name="label" translatable="yes">Configuration</property>
+			  <property name="use_underline">False</property>
+			  <property name="use_markup">False</property>
+			  <property name="justify">GTK_JUSTIFY_LEFT</property>
+			  <property name="wrap">False</property>
+			  <property name="selectable">False</property>
+			  <property name="xalign">0.5</property>
+			  <property name="yalign">0.5</property>
+			  <property name="xpad">0</property>
+			  <property name="ypad">0</property>
+			  <property name="ellipsize">PANGO_ELLIPSIZE_NONE</property>
+			  <property name="width_chars">-1</property>
+			  <property name="single_line_mode">False</property>
+			  <property name="angle">0</property>
+			</widget>
+			<packing>
+			  <property name="type">tab</property>
+			</packing>
+		      </child>
+
+		      <child>
+			<widget class="GtkVBox" id="vbox12">
+			  <property name="visible">True</property>
+			  <property name="homogeneous">False</property>
+			  <property name="spacing">8</property>
+
+			  <child>
+			    <widget class="GtkHBox" id="hbox103">
+			      <property name="visible">True</property>
+			      <property name="homogeneous">False</property>
+			      <property name="spacing">8</property>
+
+			      <child>
+				<widget class="GtkLabel" id="label130">
+				  <property name="visible">True</property>
+				  <property name="label" translatable="yes">Version: </property>
+				  <property name="use_underline">False</property>
+				  <property name="use_markup">False</property>
+				  <property name="justify">GTK_JUSTIFY_LEFT</property>
+				  <property name="wrap">False</property>
+				  <property name="selectable">False</property>
+				  <property name="xalign">0.5</property>
+				  <property name="yalign">0.5</property>
+				  <property name="xpad">0</property>
+				  <property name="ypad">0</property>
+				  <property name="ellipsize">PANGO_ELLIPSIZE_NONE</property>
+				  <property name="width_chars">-1</property>
+				  <property name="single_line_mode">False</property>
+				  <property name="angle">0</property>
+				</widget>
+				<packing>
+				  <property name="padding">0</property>
+				  <property name="expand">False</property>
+				  <property name="fill">False</property>
+				</packing>
+			      </child>
+
+			      <child>
+				<widget class="GtkEntry" id="plug_version">
+				  <property name="visible">True</property>
+				  <property name="can_focus">True</property>
+				  <property name="editable">False</property>
+				  <property name="visibility">True</property>
+				  <property name="max_length">0</property>
+				  <property name="text" translatable="yes"></property>
+				  <property name="has_frame">True</property>
+				  <property name="invisible_char">•</property>
+				  <property name="activates_default">False</property>
+				</widget>
+				<packing>
+				  <property name="padding">0</property>
+				  <property name="expand">True</property>
+				  <property name="fill">True</property>
+				</packing>
+			      </child>
+			    </widget>
+			    <packing>
+			      <property name="padding">0</property>
+			      <property name="expand">False</property>
+			      <property name="fill">True</property>
+			    </packing>
+			  </child>
+
+			  <child>
+			    <widget class="GtkScrolledWindow" id="scrolledwindow8">
+			      <property name="visible">True</property>
+			      <property name="can_focus">True</property>
+			      <property name="hscrollbar_policy">GTK_POLICY_AUTOMATIC</property>
+			      <property name="vscrollbar_policy">GTK_POLICY_AUTOMATIC</property>
+			      <property name="shadow_type">GTK_SHADOW_IN</property>
+			      <property name="window_placement">GTK_CORNER_TOP_LEFT</property>
+
+			      <child>
+				<widget class="GtkTextView" id="plug_description">
+				  <property name="visible">True</property>
+				  <property name="can_focus">True</property>
+				  <property name="editable">False</property>
+				  <property name="overwrite">False</property>
+				  <property name="accepts_tab">True</property>
+				  <property name="justification">GTK_JUSTIFY_LEFT</property>
+				  <property name="wrap_mode">GTK_WRAP_NONE</property>
+				  <property name="cursor_visible">False</property>
+				  <property name="pixels_above_lines">0</property>
+				  <property name="pixels_below_lines">0</property>
+				  <property name="pixels_inside_wrap">0</property>
+				  <property name="left_margin">0</property>
+				  <property name="right_margin">0</property>
+				  <property name="indent">0</property>
+				  <property name="text" translatable="yes"></property>
+				</widget>
+			      </child>
+			    </widget>
+			    <packing>
+			      <property name="padding">0</property>
+			      <property name="expand">True</property>
+			      <property name="fill">True</property>
+			    </packing>
+			  </child>
+
+			  <child>
+			    <widget class="GtkHBox" id="hbox20">
+			      <property name="visible">True</property>
+			      <property name="homogeneous">False</property>
+			      <property name="spacing">0</property>
+
+			      <child>
+				<widget class="Custom" id="weblink">
+				  <property name="visible">True</property>
+				  <property name="creation_function">create_plugin_weblink</property>
+				  <property name="int1">0</property>
+				  <property name="int2">0</property>
+				  <property name="last_modification_time">Sun, 27 Feb 2011 11:39:00 GMT</property>
+				</widget>
+				<packing>
+				  <property name="padding">0</property>
+				  <property name="expand">True</property>
+				  <property name="fill">False</property>
+				</packing>
+			      </child>
+			    </widget>
+			    <packing>
+			      <property name="padding">0</property>
+			      <property name="expand">False</property>
+			      <property name="fill">False</property>
+			    </packing>
+			  </child>
+			</widget>
+			<packing>
+			  <property name="tab_expand">False</property>
+			  <property name="tab_fill">True</property>
+			</packing>
+		      </child>
+
+		      <child>
+			<widget class="GtkLabel" id="label171">
+			  <property name="visible">True</property>
+			  <property name="label" translatable="yes">Info</property>
+			  <property name="use_underline">False</property>
+			  <property name="use_markup">False</property>
+			  <property name="justify">GTK_JUSTIFY_LEFT</property>
+			  <property name="wrap">False</property>
+			  <property name="selectable">False</property>
+			  <property name="xalign">0.5</property>
+			  <property name="yalign">0.5</property>
+			  <property name="xpad">0</property>
+			  <property name="ypad">0</property>
+			  <property name="ellipsize">PANGO_ELLIPSIZE_NONE</property>
+			  <property name="width_chars">-1</property>
+			  <property name="single_line_mode">False</property>
+			  <property name="angle">0</property>
+			</widget>
+			<packing>
+			  <property name="type">tab</property>
+			</packing>
+		      </child>
+
+		      <child>
+			<widget class="GtkScrolledWindow" id="scrolledwindow16">
+			  <property name="visible">True</property>
+			  <property name="can_focus">True</property>
+			  <property name="hscrollbar_policy">GTK_POLICY_AUTOMATIC</property>
+			  <property name="vscrollbar_policy">GTK_POLICY_AUTOMATIC</property>
+			  <property name="shadow_type">GTK_SHADOW_IN</property>
+			  <property name="window_placement">GTK_CORNER_TOP_LEFT</property>
+
+			  <child>
+			    <widget class="GtkTextView" id="plug_license">
+			      <property name="visible">True</property>
+			      <property name="can_focus">True</property>
+			      <property name="editable">False</property>
+			      <property name="overwrite">False</property>
+			      <property name="accepts_tab">True</property>
+			      <property name="justification">GTK_JUSTIFY_LEFT</property>
+			      <property name="wrap_mode">GTK_WRAP_NONE</property>
+			      <property name="cursor_visible">False</property>
+			      <property name="pixels_above_lines">0</property>
+			      <property name="pixels_below_lines">0</property>
+			      <property name="pixels_inside_wrap">0</property>
+			      <property name="left_margin">0</property>
+			      <property name="right_margin">0</property>
+			      <property name="indent">0</property>
+			      <property name="text" translatable="yes"></property>
+			    </widget>
+			  </child>
+			</widget>
+			<packing>
+			  <property name="tab_expand">False</property>
+			  <property name="tab_fill">True</property>
+			</packing>
+		      </child>
+
+		      <child>
+			<widget class="GtkLabel" id="label172">
+			  <property name="visible">True</property>
+			  <property name="label" translatable="yes">License</property>
+			  <property name="use_underline">False</property>
+			  <property name="use_markup">False</property>
+			  <property name="justify">GTK_JUSTIFY_LEFT</property>
+			  <property name="wrap">False</property>
+			  <property name="selectable">False</property>
+			  <property name="xalign">0.5</property>
+			  <property name="yalign">0.5</property>
+			  <property name="xpad">0</property>
+			  <property name="ypad">0</property>
+			  <property name="ellipsize">PANGO_ELLIPSIZE_NONE</property>
+			  <property name="width_chars">-1</property>
+			  <property name="single_line_mode">False</property>
+			  <property name="angle">0</property>
+			</widget>
+			<packing>
+			  <property name="type">tab</property>
+			</packing>
 		      </child>
 		    </widget>
 		    <packing>
 		      <property name="padding">0</property>
 		      <property name="expand">True</property>
 		      <property name="fill">True</property>
-		    </packing>
-		  </child>
-
-		  <child>
-		    <widget class="GtkHBox" id="hbox20">
-		      <property name="visible">True</property>
-		      <property name="homogeneous">False</property>
-		      <property name="spacing">0</property>
-
-		      <child>
-			<widget class="GtkButton" id="configure_plugin">
-			  <property name="visible">True</property>
-			  <property name="sensitive">False</property>
-			  <property name="can_focus">True</property>
-			  <property name="relief">GTK_RELIEF_NORMAL</property>
-			  <property name="focus_on_click">True</property>
-			  <signal name="clicked" handler="on_configure_plugin_clicked" last_modification_time="Tue, 01 Dec 2009 16:54:36 GMT"/>
-
-			  <child>
-			    <widget class="GtkAlignment" id="alignment15">
-			      <property name="visible">True</property>
-			      <property name="xalign">0.5</property>
-			      <property name="yalign">0.5</property>
-			      <property name="xscale">0</property>
-			      <property name="yscale">0</property>
-			      <property name="top_padding">0</property>
-			      <property name="bottom_padding">0</property>
-			      <property name="left_padding">0</property>
-			      <property name="right_padding">0</property>
-
-			      <child>
-				<widget class="GtkHBox" id="hbox56">
-				  <property name="visible">True</property>
-				  <property name="homogeneous">False</property>
-				  <property name="spacing">2</property>
-
-				  <child>
-				    <widget class="GtkImage" id="image394">
-				      <property name="visible">True</property>
-				      <property name="stock">gtk-preferences</property>
-				      <property name="icon_size">4</property>
-				      <property name="xalign">0.5</property>
-				      <property name="yalign">0.5</property>
-				      <property name="xpad">0</property>
-				      <property name="ypad">0</property>
-				    </widget>
-				    <packing>
-				      <property name="padding">0</property>
-				      <property name="expand">False</property>
-				      <property name="fill">False</property>
-				    </packing>
-				  </child>
-
-				  <child>
-				    <widget class="GtkLabel" id="label92">
-				      <property name="visible">True</property>
-				      <property name="label" translatable="yes">Configure</property>
-				      <property name="use_underline">True</property>
-				      <property name="use_markup">False</property>
-				      <property name="justify">GTK_JUSTIFY_LEFT</property>
-				      <property name="wrap">False</property>
-				      <property name="selectable">False</property>
-				      <property name="xalign">0.5</property>
-				      <property name="yalign">0.5</property>
-				      <property name="xpad">0</property>
-				      <property name="ypad">0</property>
-				      <property name="ellipsize">PANGO_ELLIPSIZE_NONE</property>
-				      <property name="width_chars">-1</property>
-				      <property name="single_line_mode">False</property>
-				      <property name="angle">0</property>
-				    </widget>
-				    <packing>
-				      <property name="padding">0</property>
-				      <property name="expand">False</property>
-				      <property name="fill">False</property>
-				    </packing>
-				  </child>
-				</widget>
-			      </child>
-			    </widget>
-			  </child>
-			</widget>
-			<packing>
-			  <property name="padding">0</property>
-			  <property name="expand">True</property>
-			  <property name="fill">False</property>
-			</packing>
-		      </child>
-
-		      <child>
-			<widget class="GtkButton" id="plug_copyright">
-			  <property name="visible">True</property>
-			  <property name="sensitive">False</property>
-			  <property name="can_focus">True</property>
-			  <property name="relief">GTK_RELIEF_NORMAL</property>
-			  <property name="focus_on_click">True</property>
-			  <signal name="clicked" handler="on_plug_copyright_clicked" last_modification_time="Sun, 27 Feb 2011 10:24:22 GMT"/>
-
-			  <child>
-			    <widget class="GtkAlignment" id="alignment20">
-			      <property name="visible">True</property>
-			      <property name="xalign">0.5</property>
-			      <property name="yalign">0.5</property>
-			      <property name="xscale">0</property>
-			      <property name="yscale">0</property>
-			      <property name="top_padding">0</property>
-			      <property name="bottom_padding">0</property>
-			      <property name="left_padding">0</property>
-			      <property name="right_padding">0</property>
-
-			      <child>
-				<widget class="GtkHBox" id="hbox88">
-				  <property name="visible">True</property>
-				  <property name="homogeneous">False</property>
-				  <property name="spacing">2</property>
-
-				  <child>
-				    <widget class="GtkImage" id="image521">
-				      <property name="visible">True</property>
-				      <property name="stock">gtk-about</property>
-				      <property name="icon_size">4</property>
-				      <property name="xalign">0.5</property>
-				      <property name="yalign">0.5</property>
-				      <property name="xpad">0</property>
-				      <property name="ypad">0</property>
-				    </widget>
-				    <packing>
-				      <property name="padding">0</property>
-				      <property name="expand">False</property>
-				      <property name="fill">False</property>
-				    </packing>
-				  </child>
-
-				  <child>
-				    <widget class="GtkLabel" id="label117">
-				      <property name="visible">True</property>
-				      <property name="label" translatable="yes">Copyright</property>
-				      <property name="use_underline">True</property>
-				      <property name="use_markup">False</property>
-				      <property name="justify">GTK_JUSTIFY_LEFT</property>
-				      <property name="wrap">False</property>
-				      <property name="selectable">False</property>
-				      <property name="xalign">0.5</property>
-				      <property name="yalign">0.5</property>
-				      <property name="xpad">0</property>
-				      <property name="ypad">0</property>
-				      <property name="ellipsize">PANGO_ELLIPSIZE_NONE</property>
-				      <property name="width_chars">-1</property>
-				      <property name="single_line_mode">False</property>
-				      <property name="angle">0</property>
-				    </widget>
-				    <packing>
-				      <property name="padding">0</property>
-				      <property name="expand">False</property>
-				      <property name="fill">False</property>
-				    </packing>
-				  </child>
-				</widget>
-			      </child>
-			    </widget>
-			  </child>
-			</widget>
-			<packing>
-			  <property name="padding">0</property>
-			  <property name="expand">True</property>
-			  <property name="fill">False</property>
-			</packing>
-		      </child>
-
-		      <child>
-			<widget class="Custom" id="weblink">
-			  <property name="visible">True</property>
-			  <property name="creation_function">create_plugin_weblink</property>
-			  <property name="int1">0</property>
-			  <property name="int2">0</property>
-			  <property name="last_modification_time">Sun, 27 Feb 2011 11:39:00 GMT</property>
-			</widget>
-			<packing>
-			  <property name="padding">0</property>
-			  <property name="expand">True</property>
-			  <property name="fill">False</property>
-			</packing>
-		      </child>
-		    </widget>
-		    <packing>
-		      <property name="padding">0</property>
-		      <property name="expand">False</property>
-		      <property name="fill">False</property>
 		    </packing>
 		  </child>
 		</widget>

--- a/plugins/gtkui/deadbeef.glade
+++ b/plugins/gtkui/deadbeef.glade
@@ -6847,7 +6847,6 @@ if you don't press Apply.</property>
 	      <property name="border_width">12</property>
 	      <property name="visible">True</property>
 	      <property name="can_focus">True</property>
-	      <property name="position">0</property>
 
 	      <child>
 		<widget class="GtkScrolledWindow" id="scrolledwindow2">
@@ -7290,6 +7289,44 @@ if you don't press Apply.</property>
 		    <packing>
 		      <property name="padding">0</property>
 		      <property name="expand">True</property>
+		      <property name="fill">True</property>
+		    </packing>
+		  </child>
+
+		  <child>
+		    <widget class="GtkHSeparator" id="hseparator7">
+		      <property name="visible">True</property>
+		    </widget>
+		    <packing>
+		      <property name="padding">0</property>
+		      <property name="expand">False</property>
+		      <property name="fill">True</property>
+		    </packing>
+		  </child>
+
+		  <child>
+		    <widget class="GtkHButtonBox" id="plugin_actions_btnbox">
+		      <property name="visible">True</property>
+		      <property name="layout_style">GTK_BUTTONBOX_END</property>
+		      <property name="spacing">0</property>
+
+		      <child>
+			<widget class="GtkButton" id="plugin_conf_reset_btn">
+			  <property name="visible">True</property>
+			  <property name="sensitive">False</property>
+			  <property name="can_default">True</property>
+			  <property name="can_focus">True</property>
+			  <property name="label" translatable="yes">Reset to defaults</property>
+			  <property name="use_underline">True</property>
+			  <property name="relief">GTK_RELIEF_NORMAL</property>
+			  <property name="focus_on_click">True</property>
+			  <signal name="clicked" handler="on_plugin_conf_reset_btn_clicked" last_modification_time="Fri, 26 Feb 2021 21:54:07 GMT"/>
+			</widget>
+		      </child>
+		    </widget>
+		    <packing>
+		      <property name="padding">0</property>
+		      <property name="expand">False</property>
 		      <property name="fill">True</property>
 		    </packing>
 		  </child>

--- a/plugins/gtkui/deadbeef.glade
+++ b/plugins/gtkui/deadbeef.glade
@@ -7034,23 +7034,61 @@ if you don't press Apply.</property>
 			  <signal name="switch_page" handler="on_plugin_notebook_switch_page" last_modification_time="Thu, 25 Feb 2021 07:50:30 GMT"/>
 
 			  <child>
-			    <widget class="GtkScrolledWindow" id="plug_conf_dlg_scrolledwindow">
+			    <widget class="GtkVBox" id="plugin_conf_tab_vbox">
 			      <property name="visible">True</property>
-			      <property name="can_focus">True</property>
-			      <property name="hscrollbar_policy">GTK_POLICY_AUTOMATIC</property>
-			      <property name="vscrollbar_policy">GTK_POLICY_AUTOMATIC</property>
-			      <property name="shadow_type">GTK_SHADOW_NONE</property>
-			      <property name="window_placement">GTK_CORNER_TOP_LEFT</property>
+			      <property name="homogeneous">False</property>
+			      <property name="spacing">8</property>
 
 			      <child>
-				<widget class="GtkViewport" id="plug_conf_dlg_viewport">
+				<widget class="GtkScrolledWindow" id="plug_conf_dlg_scrolledwindow">
 				  <property name="visible">True</property>
+				  <property name="can_focus">True</property>
+				  <property name="hscrollbar_policy">GTK_POLICY_AUTOMATIC</property>
+				  <property name="vscrollbar_policy">GTK_POLICY_AUTOMATIC</property>
 				  <property name="shadow_type">GTK_SHADOW_NONE</property>
+				  <property name="window_placement">GTK_CORNER_TOP_LEFT</property>
 
 				  <child>
-				    <placeholder/>
+				    <widget class="GtkViewport" id="plug_conf_dlg_viewport">
+				      <property name="visible">True</property>
+				      <property name="shadow_type">GTK_SHADOW_NONE</property>
+
+				      <child>
+					<placeholder/>
+				      </child>
+				    </widget>
 				  </child>
 				</widget>
+				<packing>
+				  <property name="padding">0</property>
+				  <property name="expand">True</property>
+				  <property name="fill">True</property>
+				</packing>
+			      </child>
+
+			      <child>
+				<widget class="GtkHButtonBox" id="plugin_actions_btnbox">
+				  <property name="layout_style">GTK_BUTTONBOX_END</property>
+				  <property name="spacing">0</property>
+
+				  <child>
+				    <widget class="GtkButton" id="plugin_conf_reset_btn">
+				      <property name="visible">True</property>
+				      <property name="can_default">True</property>
+				      <property name="can_focus">True</property>
+				      <property name="label" translatable="yes">Reset to defaults</property>
+				      <property name="use_underline">True</property>
+				      <property name="relief">GTK_RELIEF_NORMAL</property>
+				      <property name="focus_on_click">True</property>
+				      <signal name="clicked" handler="on_plugin_conf_reset_btn_clicked" last_modification_time="Fri, 26 Feb 2021 21:54:07 GMT"/>
+				    </widget>
+				  </child>
+				</widget>
+				<packing>
+				  <property name="padding">0</property>
+				  <property name="expand">False</property>
+				  <property name="fill">True</property>
+				</packing>
 			      </child>
 			    </widget>
 			    <packing>
@@ -7299,32 +7337,6 @@ if you don't press Apply.</property>
 			<packing>
 			  <property name="padding">0</property>
 			  <property name="expand">True</property>
-			  <property name="fill">True</property>
-			</packing>
-		      </child>
-
-		      <child>
-			<widget class="GtkHButtonBox" id="plugin_actions_btnbox">
-			  <property name="visible">True</property>
-			  <property name="layout_style">GTK_BUTTONBOX_END</property>
-			  <property name="spacing">0</property>
-
-			  <child>
-			    <widget class="GtkButton" id="plugin_conf_reset_btn">
-			      <property name="visible">True</property>
-			      <property name="can_default">True</property>
-			      <property name="can_focus">True</property>
-			      <property name="label" translatable="yes">Reset to defaults</property>
-			      <property name="use_underline">True</property>
-			      <property name="relief">GTK_RELIEF_NORMAL</property>
-			      <property name="focus_on_click">True</property>
-			      <signal name="clicked" handler="on_plugin_conf_reset_btn_clicked" last_modification_time="Fri, 26 Feb 2021 21:54:07 GMT"/>
-			    </widget>
-			  </child>
-			</widget>
-			<packing>
-			  <property name="padding">0</property>
-			  <property name="expand">False</property>
 			  <property name="fill">True</property>
 			</packing>
 		      </child>

--- a/plugins/gtkui/deadbeef.glade
+++ b/plugins/gtkui/deadbeef.glade
@@ -2310,7 +2310,7 @@ Center</property>
 </widget>
 
 <widget class="GtkDialog" id="prefwin">
-  <property name="border_width">12</property>
+  <property name="border_width">6</property>
   <property name="visible">True</property>
   <property name="title" translatable="yes">Preferences</property>
   <property name="type">GTK_WINDOW_TOPLEVEL</property>
@@ -2357,7 +2357,7 @@ Center</property>
 	</widget>
 	<packing>
 	  <property name="padding">0</property>
-	  <property name="expand">True</property>
+	  <property name="expand">False</property>
 	  <property name="fill">True</property>
 	  <property name="pack_type">GTK_PACK_END</property>
 	</packing>
@@ -2365,6 +2365,7 @@ Center</property>
 
       <child>
 	<widget class="GtkNotebook" id="notebook">
+	  <property name="border_width">6</property>
 	  <property name="visible">True</property>
 	  <property name="can_focus">True</property>
 	  <property name="show_tabs">True</property>

--- a/plugins/gtkui/interface.c
+++ b/plugins/gtkui/interface.c
@@ -1778,8 +1778,11 @@ create_prefwin (void)
   GtkWidget *plugin_license_tab_btn;
   GtkWidget *fillerlabel2;
   GtkWidget *plugin_notebook;
+  GtkWidget *plugin_conf_tab_vbox;
   GtkWidget *plug_conf_dlg_scrolledwindow;
   GtkWidget *plug_conf_dlg_viewport;
+  GtkWidget *plugin_actions_btnbox;
+  GtkWidget *plugin_conf_reset_btn;
   GtkWidget *label170;
   GtkWidget *vbox12;
   GtkWidget *hbox103;
@@ -1793,8 +1796,6 @@ create_prefwin (void)
   GtkWidget *scrolledwindow16;
   GtkWidget *plug_license;
   GtkWidget *label172;
-  GtkWidget *plugin_actions_btnbox;
-  GtkWidget *plugin_conf_reset_btn;
   GtkWidget *label3;
   GtkWidget *dialog_action_area2;
   GtkWidget *closebutton1;
@@ -3072,15 +3073,28 @@ create_prefwin (void)
   gtk_box_pack_start (GTK_BOX (vbox54), plugin_notebook, TRUE, TRUE, 0);
   gtk_notebook_set_show_border (GTK_NOTEBOOK (plugin_notebook), FALSE);
 
+  plugin_conf_tab_vbox = gtk_vbox_new (FALSE, 8);
+  gtk_widget_show (plugin_conf_tab_vbox);
+  gtk_container_add (GTK_CONTAINER (plugin_notebook), plugin_conf_tab_vbox);
+
   plug_conf_dlg_scrolledwindow = gtk_scrolled_window_new (NULL, NULL);
   gtk_widget_show (plug_conf_dlg_scrolledwindow);
-  gtk_container_add (GTK_CONTAINER (plugin_notebook), plug_conf_dlg_scrolledwindow);
+  gtk_box_pack_start (GTK_BOX (plugin_conf_tab_vbox), plug_conf_dlg_scrolledwindow, TRUE, TRUE, 0);
   gtk_scrolled_window_set_policy (GTK_SCROLLED_WINDOW (plug_conf_dlg_scrolledwindow), GTK_POLICY_AUTOMATIC, GTK_POLICY_AUTOMATIC);
 
   plug_conf_dlg_viewport = gtk_viewport_new (NULL, NULL);
   gtk_widget_show (plug_conf_dlg_viewport);
   gtk_container_add (GTK_CONTAINER (plug_conf_dlg_scrolledwindow), plug_conf_dlg_viewport);
   gtk_viewport_set_shadow_type (GTK_VIEWPORT (plug_conf_dlg_viewport), GTK_SHADOW_NONE);
+
+  plugin_actions_btnbox = gtk_hbutton_box_new ();
+  gtk_box_pack_start (GTK_BOX (plugin_conf_tab_vbox), plugin_actions_btnbox, FALSE, TRUE, 0);
+  gtk_button_box_set_layout (GTK_BUTTON_BOX (plugin_actions_btnbox), GTK_BUTTONBOX_END);
+
+  plugin_conf_reset_btn = gtk_button_new_with_mnemonic (_("Reset to defaults"));
+  gtk_widget_show (plugin_conf_reset_btn);
+  gtk_container_add (GTK_CONTAINER (plugin_actions_btnbox), plugin_conf_reset_btn);
+  gtk_widget_set_can_default(plugin_conf_reset_btn, TRUE);
 
   label170 = gtk_label_new (_("Configuration"));
   gtk_widget_show (label170);
@@ -3145,16 +3159,6 @@ create_prefwin (void)
   label172 = gtk_label_new (_("License"));
   gtk_widget_show (label172);
   gtk_notebook_set_tab_label (GTK_NOTEBOOK (plugin_notebook), gtk_notebook_get_nth_page (GTK_NOTEBOOK (plugin_notebook), 2), label172);
-
-  plugin_actions_btnbox = gtk_hbutton_box_new ();
-  gtk_widget_show (plugin_actions_btnbox);
-  gtk_box_pack_start (GTK_BOX (vbox54), plugin_actions_btnbox, FALSE, TRUE, 0);
-  gtk_button_box_set_layout (GTK_BUTTON_BOX (plugin_actions_btnbox), GTK_BUTTONBOX_END);
-
-  plugin_conf_reset_btn = gtk_button_new_with_mnemonic (_("Reset to defaults"));
-  gtk_widget_show (plugin_conf_reset_btn);
-  gtk_container_add (GTK_CONTAINER (plugin_actions_btnbox), plugin_conf_reset_btn);
-  gtk_widget_set_can_default(plugin_conf_reset_btn, TRUE);
 
   label3 = gtk_label_new (_("Plugins"));
   gtk_widget_show (label3);
@@ -3740,8 +3744,11 @@ create_prefwin (void)
   GLADE_HOOKUP_OBJECT (prefwin, plugin_license_tab_btn, "plugin_license_tab_btn");
   GLADE_HOOKUP_OBJECT (prefwin, fillerlabel2, "fillerlabel2");
   GLADE_HOOKUP_OBJECT (prefwin, plugin_notebook, "plugin_notebook");
+  GLADE_HOOKUP_OBJECT (prefwin, plugin_conf_tab_vbox, "plugin_conf_tab_vbox");
   GLADE_HOOKUP_OBJECT (prefwin, plug_conf_dlg_scrolledwindow, "plug_conf_dlg_scrolledwindow");
   GLADE_HOOKUP_OBJECT (prefwin, plug_conf_dlg_viewport, "plug_conf_dlg_viewport");
+  GLADE_HOOKUP_OBJECT (prefwin, plugin_actions_btnbox, "plugin_actions_btnbox");
+  GLADE_HOOKUP_OBJECT (prefwin, plugin_conf_reset_btn, "plugin_conf_reset_btn");
   GLADE_HOOKUP_OBJECT (prefwin, label170, "label170");
   GLADE_HOOKUP_OBJECT (prefwin, vbox12, "vbox12");
   GLADE_HOOKUP_OBJECT (prefwin, hbox103, "hbox103");
@@ -3755,8 +3762,6 @@ create_prefwin (void)
   GLADE_HOOKUP_OBJECT (prefwin, scrolledwindow16, "scrolledwindow16");
   GLADE_HOOKUP_OBJECT (prefwin, plug_license, "plug_license");
   GLADE_HOOKUP_OBJECT (prefwin, label172, "label172");
-  GLADE_HOOKUP_OBJECT (prefwin, plugin_actions_btnbox, "plugin_actions_btnbox");
-  GLADE_HOOKUP_OBJECT (prefwin, plugin_conf_reset_btn, "plugin_conf_reset_btn");
   GLADE_HOOKUP_OBJECT (prefwin, label3, "label3");
   GLADE_HOOKUP_OBJECT_NO_REF (prefwin, dialog_action_area2, "dialog_action_area2");
   GLADE_HOOKUP_OBJECT (prefwin, closebutton1, "closebutton1");

--- a/plugins/gtkui/interface.c
+++ b/plugins/gtkui/interface.c
@@ -1792,6 +1792,9 @@ create_prefwin (void)
   GtkWidget *scrolledwindow16;
   GtkWidget *plug_license;
   GtkWidget *label172;
+  GtkWidget *hseparator7;
+  GtkWidget *plugin_actions_btnbox;
+  GtkWidget *plugin_conf_reset_btn;
   GtkWidget *label3;
   GtkWidget *dialog_action_area2;
   GtkWidget *closebutton1;
@@ -3003,7 +3006,6 @@ create_prefwin (void)
   gtk_widget_show (hpaned1);
   gtk_container_add (GTK_CONTAINER (notebook), hpaned1);
   gtk_container_set_border_width (GTK_CONTAINER (hpaned1), 12);
-  gtk_paned_set_position (GTK_PANED (hpaned1), 0);
 
   scrolledwindow2 = gtk_scrolled_window_new (NULL, NULL);
   gtk_widget_show (scrolledwindow2);
@@ -3140,6 +3142,21 @@ create_prefwin (void)
   label172 = gtk_label_new (_("License"));
   gtk_widget_show (label172);
   gtk_notebook_set_tab_label (GTK_NOTEBOOK (plugin_notebook), gtk_notebook_get_nth_page (GTK_NOTEBOOK (plugin_notebook), 2), label172);
+
+  hseparator7 = gtk_hseparator_new ();
+  gtk_widget_show (hseparator7);
+  gtk_box_pack_start (GTK_BOX (vbox54), hseparator7, FALSE, TRUE, 0);
+
+  plugin_actions_btnbox = gtk_hbutton_box_new ();
+  gtk_widget_show (plugin_actions_btnbox);
+  gtk_box_pack_start (GTK_BOX (vbox54), plugin_actions_btnbox, FALSE, TRUE, 0);
+  gtk_button_box_set_layout (GTK_BUTTON_BOX (plugin_actions_btnbox), GTK_BUTTONBOX_END);
+
+  plugin_conf_reset_btn = gtk_button_new_with_mnemonic (_("Reset to defaults"));
+  gtk_widget_show (plugin_conf_reset_btn);
+  gtk_container_add (GTK_CONTAINER (plugin_actions_btnbox), plugin_conf_reset_btn);
+  gtk_widget_set_sensitive (plugin_conf_reset_btn, FALSE);
+  gtk_widget_set_can_default(plugin_conf_reset_btn, TRUE);
 
   label3 = gtk_label_new (_("Plugins"));
   gtk_widget_show (label3);
@@ -3467,6 +3484,9 @@ create_prefwin (void)
   g_signal_connect ((gpointer) plugin_notebook, "switch_page",
                     G_CALLBACK (on_plugin_notebook_switch_page),
                     NULL);
+  g_signal_connect ((gpointer) plugin_conf_reset_btn, "clicked",
+                    G_CALLBACK (on_plugin_conf_reset_btn_clicked),
+                    NULL);
 
   /* Store pointers to all widgets, for use by lookup_widget(). */
   GLADE_HOOKUP_OBJECT_NO_REF (prefwin, prefwin, "prefwin");
@@ -3736,6 +3756,9 @@ create_prefwin (void)
   GLADE_HOOKUP_OBJECT (prefwin, scrolledwindow16, "scrolledwindow16");
   GLADE_HOOKUP_OBJECT (prefwin, plug_license, "plug_license");
   GLADE_HOOKUP_OBJECT (prefwin, label172, "label172");
+  GLADE_HOOKUP_OBJECT (prefwin, hseparator7, "hseparator7");
+  GLADE_HOOKUP_OBJECT (prefwin, plugin_actions_btnbox, "plugin_actions_btnbox");
+  GLADE_HOOKUP_OBJECT (prefwin, plugin_conf_reset_btn, "plugin_conf_reset_btn");
   GLADE_HOOKUP_OBJECT (prefwin, label3, "label3");
   GLADE_HOOKUP_OBJECT_NO_REF (prefwin, dialog_action_area2, "dialog_action_area2");
   GLADE_HOOKUP_OBJECT (prefwin, closebutton1, "closebutton1");

--- a/plugins/gtkui/interface.c
+++ b/plugins/gtkui/interface.c
@@ -1767,6 +1767,7 @@ create_prefwin (void)
   GtkWidget *hpaned1;
   GtkWidget *scrolledwindow2;
   GtkWidget *pref_pluginlist;
+  GtkWidget *alignment33;
   GtkWidget *vbox54;
   GtkWidget *hbox149;
   GtkWidget *fillerlabel1;
@@ -1792,7 +1793,6 @@ create_prefwin (void)
   GtkWidget *scrolledwindow16;
   GtkWidget *plug_license;
   GtkWidget *label172;
-  GtkWidget *hseparator7;
   GtkWidget *plugin_actions_btnbox;
   GtkWidget *plugin_conf_reset_btn;
   GtkWidget *label3;
@@ -3020,14 +3020,18 @@ create_prefwin (void)
   gtk_container_add (GTK_CONTAINER (scrolledwindow2), pref_pluginlist);
   gtk_tree_view_set_rules_hint (GTK_TREE_VIEW (pref_pluginlist), TRUE);
 
-  vbox54 = gtk_vbox_new (FALSE, 0);
+  alignment33 = gtk_alignment_new (0.5, 0.5, 1, 1);
+  gtk_widget_show (alignment33);
+  gtk_paned_pack2 (GTK_PANED (hpaned1), alignment33, TRUE, FALSE);
+  gtk_alignment_set_padding (GTK_ALIGNMENT (alignment33), 0, 0, 16, 0);
+
+  vbox54 = gtk_vbox_new (FALSE, 8);
   gtk_widget_show (vbox54);
-  gtk_paned_pack2 (GTK_PANED (hpaned1), vbox54, TRUE, FALSE);
+  gtk_container_add (GTK_CONTAINER (alignment33), vbox54);
 
   hbox149 = gtk_hbox_new (FALSE, 0);
   gtk_widget_show (hbox149);
   gtk_box_pack_start (GTK_BOX (vbox54), hbox149, FALSE, FALSE, 0);
-  gtk_container_set_border_width (GTK_CONTAINER (hbox149), 6);
 
   fillerlabel1 = gtk_label_new ("");
   gtk_widget_show (fillerlabel1);
@@ -3066,7 +3070,6 @@ create_prefwin (void)
   plugin_notebook = gtk_notebook_new ();
   gtk_widget_show (plugin_notebook);
   gtk_box_pack_start (GTK_BOX (vbox54), plugin_notebook, TRUE, TRUE, 0);
-  gtk_container_set_border_width (GTK_CONTAINER (plugin_notebook), 6);
   gtk_notebook_set_show_border (GTK_NOTEBOOK (plugin_notebook), FALSE);
 
   plug_conf_dlg_scrolledwindow = gtk_scrolled_window_new (NULL, NULL);
@@ -3143,10 +3146,6 @@ create_prefwin (void)
   gtk_widget_show (label172);
   gtk_notebook_set_tab_label (GTK_NOTEBOOK (plugin_notebook), gtk_notebook_get_nth_page (GTK_NOTEBOOK (plugin_notebook), 2), label172);
 
-  hseparator7 = gtk_hseparator_new ();
-  gtk_widget_show (hseparator7);
-  gtk_box_pack_start (GTK_BOX (vbox54), hseparator7, FALSE, TRUE, 0);
-
   plugin_actions_btnbox = gtk_hbutton_box_new ();
   gtk_widget_show (plugin_actions_btnbox);
   gtk_box_pack_start (GTK_BOX (vbox54), plugin_actions_btnbox, FALSE, TRUE, 0);
@@ -3155,7 +3154,6 @@ create_prefwin (void)
   plugin_conf_reset_btn = gtk_button_new_with_mnemonic (_("Reset to defaults"));
   gtk_widget_show (plugin_conf_reset_btn);
   gtk_container_add (GTK_CONTAINER (plugin_actions_btnbox), plugin_conf_reset_btn);
-  gtk_widget_set_sensitive (plugin_conf_reset_btn, FALSE);
   gtk_widget_set_can_default(plugin_conf_reset_btn, TRUE);
 
   label3 = gtk_label_new (_("Plugins"));
@@ -3732,6 +3730,7 @@ create_prefwin (void)
   GLADE_HOOKUP_OBJECT (prefwin, hpaned1, "hpaned1");
   GLADE_HOOKUP_OBJECT (prefwin, scrolledwindow2, "scrolledwindow2");
   GLADE_HOOKUP_OBJECT (prefwin, pref_pluginlist, "pref_pluginlist");
+  GLADE_HOOKUP_OBJECT (prefwin, alignment33, "alignment33");
   GLADE_HOOKUP_OBJECT (prefwin, vbox54, "vbox54");
   GLADE_HOOKUP_OBJECT (prefwin, hbox149, "hbox149");
   GLADE_HOOKUP_OBJECT (prefwin, fillerlabel1, "fillerlabel1");
@@ -3756,7 +3755,6 @@ create_prefwin (void)
   GLADE_HOOKUP_OBJECT (prefwin, scrolledwindow16, "scrolledwindow16");
   GLADE_HOOKUP_OBJECT (prefwin, plug_license, "plug_license");
   GLADE_HOOKUP_OBJECT (prefwin, label172, "label172");
-  GLADE_HOOKUP_OBJECT (prefwin, hseparator7, "hseparator7");
   GLADE_HOOKUP_OBJECT (prefwin, plugin_actions_btnbox, "plugin_actions_btnbox");
   GLADE_HOOKUP_OBJECT (prefwin, plugin_conf_reset_btn, "plugin_conf_reset_btn");
   GLADE_HOOKUP_OBJECT (prefwin, label3, "label3");

--- a/plugins/gtkui/interface.c
+++ b/plugins/gtkui/interface.c
@@ -1801,7 +1801,7 @@ create_prefwin (void)
   GtkWidget *closebutton1;
 
   prefwin = gtk_dialog_new ();
-  gtk_container_set_border_width (GTK_CONTAINER (prefwin), 12);
+  gtk_container_set_border_width (GTK_CONTAINER (prefwin), 6);
   gtk_window_set_title (GTK_WINDOW (prefwin), _("Preferences"));
   gtk_window_set_position (GTK_WINDOW (prefwin), GTK_WIN_POS_CENTER);
   gtk_window_set_type_hint (GTK_WINDOW (prefwin), GDK_WINDOW_TYPE_HINT_DIALOG);
@@ -1812,6 +1812,7 @@ create_prefwin (void)
   notebook = gtk_notebook_new ();
   gtk_widget_show (notebook);
   gtk_box_pack_start (GTK_BOX (dialog_vbox2), notebook, TRUE, TRUE, 0);
+  gtk_container_set_border_width (GTK_CONTAINER (notebook), 6);
   gtk_notebook_set_scrollable (GTK_NOTEBOOK (notebook), TRUE);
 
   vbox10 = gtk_vbox_new (FALSE, 8);

--- a/plugins/gtkui/interface.c
+++ b/plugins/gtkui/interface.c
@@ -1769,15 +1769,16 @@ create_prefwin (void)
   GtkWidget *pref_pluginlist;
   GtkWidget *vbox54;
   GtkWidget *hbox149;
-  GtkWidget *label169;
-  GtkWidget *plugin_tabbtn_hbox;
+  GtkWidget *fillerlabel1;
+  GtkWidget *plugin_tabbtn_hbtnbox;
   GtkWidget *plugin_conf_tab_btn;
   GSList *plugin_conf_tab_btn_group = NULL;
   GtkWidget *plugin_info_tab_btn;
   GtkWidget *plugin_license_tab_btn;
-  GtkWidget *label168;
+  GtkWidget *fillerlabel2;
   GtkWidget *plugin_notebook;
   GtkWidget *plug_conf_dlg_scrolledwindow;
+  GtkWidget *plug_conf_dlg_viewport;
   GtkWidget *label170;
   GtkWidget *vbox12;
   GtkWidget *hbox103;
@@ -3002,6 +3003,7 @@ create_prefwin (void)
   gtk_widget_show (hpaned1);
   gtk_container_add (GTK_CONTAINER (notebook), hpaned1);
   gtk_container_set_border_width (GTK_CONTAINER (hpaned1), 12);
+  gtk_paned_set_position (GTK_PANED (hpaned1), 0);
 
   scrolledwindow2 = gtk_scrolled_window_new (NULL, NULL);
   gtk_widget_show (scrolledwindow2);
@@ -3018,24 +3020,24 @@ create_prefwin (void)
 
   vbox54 = gtk_vbox_new (FALSE, 0);
   gtk_widget_show (vbox54);
-  gtk_paned_pack2 (GTK_PANED (hpaned1), vbox54, TRUE, TRUE);
+  gtk_paned_pack2 (GTK_PANED (hpaned1), vbox54, TRUE, FALSE);
 
   hbox149 = gtk_hbox_new (FALSE, 0);
   gtk_widget_show (hbox149);
   gtk_box_pack_start (GTK_BOX (vbox54), hbox149, FALSE, FALSE, 0);
   gtk_container_set_border_width (GTK_CONTAINER (hbox149), 6);
 
-  label169 = gtk_label_new ("");
-  gtk_widget_show (label169);
-  gtk_box_pack_start (GTK_BOX (hbox149), label169, TRUE, TRUE, 0);
+  fillerlabel1 = gtk_label_new ("");
+  gtk_widget_show (fillerlabel1);
+  gtk_box_pack_start (GTK_BOX (hbox149), fillerlabel1, TRUE, FALSE, 0);
 
-  plugin_tabbtn_hbox = gtk_hbox_new (TRUE, 5);
-  gtk_widget_show (plugin_tabbtn_hbox);
-  gtk_box_pack_start (GTK_BOX (hbox149), plugin_tabbtn_hbox, FALSE, TRUE, 0);
+  plugin_tabbtn_hbtnbox = gtk_hbutton_box_new ();
+  gtk_widget_show (plugin_tabbtn_hbtnbox);
+  gtk_box_pack_start (GTK_BOX (hbox149), plugin_tabbtn_hbtnbox, FALSE, FALSE, 0);
 
   plugin_conf_tab_btn = gtk_radio_button_new_with_mnemonic (NULL, _("Configuration"));
   gtk_widget_show (plugin_conf_tab_btn);
-  gtk_box_pack_start (GTK_BOX (plugin_tabbtn_hbox), plugin_conf_tab_btn, TRUE, TRUE, 0);
+  gtk_container_add (GTK_CONTAINER (plugin_tabbtn_hbtnbox), plugin_conf_tab_btn);
   gtk_radio_button_set_group (GTK_RADIO_BUTTON (plugin_conf_tab_btn), plugin_conf_tab_btn_group);
   plugin_conf_tab_btn_group = gtk_radio_button_get_group (GTK_RADIO_BUTTON (plugin_conf_tab_btn));
   gtk_toggle_button_set_active (GTK_TOGGLE_BUTTON (plugin_conf_tab_btn), TRUE);
@@ -3043,21 +3045,21 @@ create_prefwin (void)
 
   plugin_info_tab_btn = gtk_radio_button_new_with_mnemonic (NULL, _("Info"));
   gtk_widget_show (plugin_info_tab_btn);
-  gtk_box_pack_start (GTK_BOX (plugin_tabbtn_hbox), plugin_info_tab_btn, TRUE, TRUE, 0);
+  gtk_container_add (GTK_CONTAINER (plugin_tabbtn_hbtnbox), plugin_info_tab_btn);
   gtk_radio_button_set_group (GTK_RADIO_BUTTON (plugin_info_tab_btn), plugin_conf_tab_btn_group);
   plugin_conf_tab_btn_group = gtk_radio_button_get_group (GTK_RADIO_BUTTON (plugin_info_tab_btn));
   gtk_toggle_button_set_mode (GTK_TOGGLE_BUTTON (plugin_info_tab_btn), FALSE);
 
   plugin_license_tab_btn = gtk_radio_button_new_with_mnemonic (NULL, _("License"));
   gtk_widget_show (plugin_license_tab_btn);
-  gtk_box_pack_start (GTK_BOX (plugin_tabbtn_hbox), plugin_license_tab_btn, TRUE, TRUE, 0);
+  gtk_container_add (GTK_CONTAINER (plugin_tabbtn_hbtnbox), plugin_license_tab_btn);
   gtk_radio_button_set_group (GTK_RADIO_BUTTON (plugin_license_tab_btn), plugin_conf_tab_btn_group);
   plugin_conf_tab_btn_group = gtk_radio_button_get_group (GTK_RADIO_BUTTON (plugin_license_tab_btn));
   gtk_toggle_button_set_mode (GTK_TOGGLE_BUTTON (plugin_license_tab_btn), FALSE);
 
-  label168 = gtk_label_new ("");
-  gtk_widget_show (label168);
-  gtk_box_pack_start (GTK_BOX (hbox149), label168, TRUE, TRUE, 0);
+  fillerlabel2 = gtk_label_new ("");
+  gtk_widget_show (fillerlabel2);
+  gtk_box_pack_start (GTK_BOX (hbox149), fillerlabel2, TRUE, FALSE, 0);
 
   plugin_notebook = gtk_notebook_new ();
   gtk_widget_show (plugin_notebook);
@@ -3069,6 +3071,11 @@ create_prefwin (void)
   gtk_widget_show (plug_conf_dlg_scrolledwindow);
   gtk_container_add (GTK_CONTAINER (plugin_notebook), plug_conf_dlg_scrolledwindow);
   gtk_scrolled_window_set_policy (GTK_SCROLLED_WINDOW (plug_conf_dlg_scrolledwindow), GTK_POLICY_AUTOMATIC, GTK_POLICY_AUTOMATIC);
+
+  plug_conf_dlg_viewport = gtk_viewport_new (NULL, NULL);
+  gtk_widget_show (plug_conf_dlg_viewport);
+  gtk_container_add (GTK_CONTAINER (plug_conf_dlg_scrolledwindow), plug_conf_dlg_viewport);
+  gtk_viewport_set_shadow_type (GTK_VIEWPORT (plug_conf_dlg_viewport), GTK_SHADOW_NONE);
 
   label170 = gtk_label_new (_("Configuration"));
   gtk_widget_show (label170);
@@ -3707,14 +3714,15 @@ create_prefwin (void)
   GLADE_HOOKUP_OBJECT (prefwin, pref_pluginlist, "pref_pluginlist");
   GLADE_HOOKUP_OBJECT (prefwin, vbox54, "vbox54");
   GLADE_HOOKUP_OBJECT (prefwin, hbox149, "hbox149");
-  GLADE_HOOKUP_OBJECT (prefwin, label169, "label169");
-  GLADE_HOOKUP_OBJECT (prefwin, plugin_tabbtn_hbox, "plugin_tabbtn_hbox");
+  GLADE_HOOKUP_OBJECT (prefwin, fillerlabel1, "fillerlabel1");
+  GLADE_HOOKUP_OBJECT (prefwin, plugin_tabbtn_hbtnbox, "plugin_tabbtn_hbtnbox");
   GLADE_HOOKUP_OBJECT (prefwin, plugin_conf_tab_btn, "plugin_conf_tab_btn");
   GLADE_HOOKUP_OBJECT (prefwin, plugin_info_tab_btn, "plugin_info_tab_btn");
   GLADE_HOOKUP_OBJECT (prefwin, plugin_license_tab_btn, "plugin_license_tab_btn");
-  GLADE_HOOKUP_OBJECT (prefwin, label168, "label168");
+  GLADE_HOOKUP_OBJECT (prefwin, fillerlabel2, "fillerlabel2");
   GLADE_HOOKUP_OBJECT (prefwin, plugin_notebook, "plugin_notebook");
   GLADE_HOOKUP_OBJECT (prefwin, plug_conf_dlg_scrolledwindow, "plug_conf_dlg_scrolledwindow");
+  GLADE_HOOKUP_OBJECT (prefwin, plug_conf_dlg_viewport, "plug_conf_dlg_viewport");
   GLADE_HOOKUP_OBJECT (prefwin, label170, "label170");
   GLADE_HOOKUP_OBJECT (prefwin, vbox12, "vbox12");
   GLADE_HOOKUP_OBJECT (prefwin, hbox103, "hbox103");

--- a/plugins/gtkui/interface.c
+++ b/plugins/gtkui/interface.c
@@ -1767,6 +1767,18 @@ create_prefwin (void)
   GtkWidget *hpaned1;
   GtkWidget *scrolledwindow2;
   GtkWidget *pref_pluginlist;
+  GtkWidget *vbox54;
+  GtkWidget *hbox149;
+  GtkWidget *label169;
+  GtkWidget *plugin_tabbtn_hbox;
+  GtkWidget *plugin_conf_tab_btn;
+  GSList *plugin_conf_tab_btn_group = NULL;
+  GtkWidget *plugin_info_tab_btn;
+  GtkWidget *plugin_license_tab_btn;
+  GtkWidget *label168;
+  GtkWidget *plugin_notebook;
+  GtkWidget *plug_conf_dlg_scrolledwindow;
+  GtkWidget *label170;
   GtkWidget *vbox12;
   GtkWidget *hbox103;
   GtkWidget *label130;
@@ -1774,17 +1786,11 @@ create_prefwin (void)
   GtkWidget *scrolledwindow8;
   GtkWidget *plug_description;
   GtkWidget *hbox20;
-  GtkWidget *configure_plugin;
-  GtkWidget *alignment15;
-  GtkWidget *hbox56;
-  GtkWidget *image394;
-  GtkWidget *label92;
-  GtkWidget *plug_copyright;
-  GtkWidget *alignment20;
-  GtkWidget *hbox88;
-  GtkWidget *image521;
-  GtkWidget *label117;
   GtkWidget *weblink;
+  GtkWidget *label171;
+  GtkWidget *scrolledwindow16;
+  GtkWidget *plug_license;
+  GtkWidget *label172;
   GtkWidget *label3;
   GtkWidget *dialog_action_area2;
   GtkWidget *closebutton1;
@@ -3010,10 +3016,67 @@ create_prefwin (void)
   gtk_container_add (GTK_CONTAINER (scrolledwindow2), pref_pluginlist);
   gtk_tree_view_set_rules_hint (GTK_TREE_VIEW (pref_pluginlist), TRUE);
 
+  vbox54 = gtk_vbox_new (FALSE, 0);
+  gtk_widget_show (vbox54);
+  gtk_paned_pack2 (GTK_PANED (hpaned1), vbox54, TRUE, TRUE);
+
+  hbox149 = gtk_hbox_new (FALSE, 0);
+  gtk_widget_show (hbox149);
+  gtk_box_pack_start (GTK_BOX (vbox54), hbox149, FALSE, FALSE, 0);
+  gtk_container_set_border_width (GTK_CONTAINER (hbox149), 6);
+
+  label169 = gtk_label_new ("");
+  gtk_widget_show (label169);
+  gtk_box_pack_start (GTK_BOX (hbox149), label169, TRUE, TRUE, 0);
+
+  plugin_tabbtn_hbox = gtk_hbox_new (TRUE, 5);
+  gtk_widget_show (plugin_tabbtn_hbox);
+  gtk_box_pack_start (GTK_BOX (hbox149), plugin_tabbtn_hbox, FALSE, TRUE, 0);
+
+  plugin_conf_tab_btn = gtk_radio_button_new_with_mnemonic (NULL, _("Configuration"));
+  gtk_widget_show (plugin_conf_tab_btn);
+  gtk_box_pack_start (GTK_BOX (plugin_tabbtn_hbox), plugin_conf_tab_btn, TRUE, TRUE, 0);
+  gtk_radio_button_set_group (GTK_RADIO_BUTTON (plugin_conf_tab_btn), plugin_conf_tab_btn_group);
+  plugin_conf_tab_btn_group = gtk_radio_button_get_group (GTK_RADIO_BUTTON (plugin_conf_tab_btn));
+  gtk_toggle_button_set_active (GTK_TOGGLE_BUTTON (plugin_conf_tab_btn), TRUE);
+  gtk_toggle_button_set_mode (GTK_TOGGLE_BUTTON (plugin_conf_tab_btn), FALSE);
+
+  plugin_info_tab_btn = gtk_radio_button_new_with_mnemonic (NULL, _("Info"));
+  gtk_widget_show (plugin_info_tab_btn);
+  gtk_box_pack_start (GTK_BOX (plugin_tabbtn_hbox), plugin_info_tab_btn, TRUE, TRUE, 0);
+  gtk_radio_button_set_group (GTK_RADIO_BUTTON (plugin_info_tab_btn), plugin_conf_tab_btn_group);
+  plugin_conf_tab_btn_group = gtk_radio_button_get_group (GTK_RADIO_BUTTON (plugin_info_tab_btn));
+  gtk_toggle_button_set_mode (GTK_TOGGLE_BUTTON (plugin_info_tab_btn), FALSE);
+
+  plugin_license_tab_btn = gtk_radio_button_new_with_mnemonic (NULL, _("License"));
+  gtk_widget_show (plugin_license_tab_btn);
+  gtk_box_pack_start (GTK_BOX (plugin_tabbtn_hbox), plugin_license_tab_btn, TRUE, TRUE, 0);
+  gtk_radio_button_set_group (GTK_RADIO_BUTTON (plugin_license_tab_btn), plugin_conf_tab_btn_group);
+  plugin_conf_tab_btn_group = gtk_radio_button_get_group (GTK_RADIO_BUTTON (plugin_license_tab_btn));
+  gtk_toggle_button_set_mode (GTK_TOGGLE_BUTTON (plugin_license_tab_btn), FALSE);
+
+  label168 = gtk_label_new ("");
+  gtk_widget_show (label168);
+  gtk_box_pack_start (GTK_BOX (hbox149), label168, TRUE, TRUE, 0);
+
+  plugin_notebook = gtk_notebook_new ();
+  gtk_widget_show (plugin_notebook);
+  gtk_box_pack_start (GTK_BOX (vbox54), plugin_notebook, TRUE, TRUE, 0);
+  gtk_container_set_border_width (GTK_CONTAINER (plugin_notebook), 6);
+  gtk_notebook_set_show_border (GTK_NOTEBOOK (plugin_notebook), FALSE);
+
+  plug_conf_dlg_scrolledwindow = gtk_scrolled_window_new (NULL, NULL);
+  gtk_widget_show (plug_conf_dlg_scrolledwindow);
+  gtk_container_add (GTK_CONTAINER (plugin_notebook), plug_conf_dlg_scrolledwindow);
+  gtk_scrolled_window_set_policy (GTK_SCROLLED_WINDOW (plug_conf_dlg_scrolledwindow), GTK_POLICY_AUTOMATIC, GTK_POLICY_AUTOMATIC);
+
+  label170 = gtk_label_new (_("Configuration"));
+  gtk_widget_show (label170);
+  gtk_notebook_set_tab_label (GTK_NOTEBOOK (plugin_notebook), gtk_notebook_get_nth_page (GTK_NOTEBOOK (plugin_notebook), 0), label170);
+
   vbox12 = gtk_vbox_new (FALSE, 8);
   gtk_widget_show (vbox12);
-  gtk_paned_pack2 (GTK_PANED (hpaned1), vbox12, TRUE, TRUE);
-  gtk_container_set_border_width (GTK_CONTAINER (vbox12), 12);
+  gtk_container_add (GTK_CONTAINER (plugin_notebook), vbox12);
 
   hbox103 = gtk_hbox_new (FALSE, 8);
   gtk_widget_show (hbox103);
@@ -3045,53 +3108,31 @@ create_prefwin (void)
   gtk_widget_show (hbox20);
   gtk_box_pack_start (GTK_BOX (vbox12), hbox20, FALSE, FALSE, 0);
 
-  configure_plugin = gtk_button_new ();
-  gtk_widget_show (configure_plugin);
-  gtk_box_pack_start (GTK_BOX (hbox20), configure_plugin, TRUE, FALSE, 0);
-  gtk_widget_set_sensitive (configure_plugin, FALSE);
-
-  alignment15 = gtk_alignment_new (0.5, 0.5, 0, 0);
-  gtk_widget_show (alignment15);
-  gtk_container_add (GTK_CONTAINER (configure_plugin), alignment15);
-
-  hbox56 = gtk_hbox_new (FALSE, 2);
-  gtk_widget_show (hbox56);
-  gtk_container_add (GTK_CONTAINER (alignment15), hbox56);
-
-  image394 = gtk_image_new_from_stock ("gtk-preferences", GTK_ICON_SIZE_BUTTON);
-  gtk_widget_show (image394);
-  gtk_box_pack_start (GTK_BOX (hbox56), image394, FALSE, FALSE, 0);
-
-  label92 = gtk_label_new_with_mnemonic (_("Configure"));
-  gtk_widget_show (label92);
-  gtk_box_pack_start (GTK_BOX (hbox56), label92, FALSE, FALSE, 0);
-
-  plug_copyright = gtk_button_new ();
-  gtk_widget_show (plug_copyright);
-  gtk_box_pack_start (GTK_BOX (hbox20), plug_copyright, TRUE, FALSE, 0);
-  gtk_widget_set_sensitive (plug_copyright, FALSE);
-
-  alignment20 = gtk_alignment_new (0.5, 0.5, 0, 0);
-  gtk_widget_show (alignment20);
-  gtk_container_add (GTK_CONTAINER (plug_copyright), alignment20);
-
-  hbox88 = gtk_hbox_new (FALSE, 2);
-  gtk_widget_show (hbox88);
-  gtk_container_add (GTK_CONTAINER (alignment20), hbox88);
-
-  image521 = gtk_image_new_from_stock ("gtk-about", GTK_ICON_SIZE_BUTTON);
-  gtk_widget_show (image521);
-  gtk_box_pack_start (GTK_BOX (hbox88), image521, FALSE, FALSE, 0);
-
-  label117 = gtk_label_new_with_mnemonic (_("Copyright"));
-  gtk_widget_show (label117);
-  gtk_box_pack_start (GTK_BOX (hbox88), label117, FALSE, FALSE, 0);
-
   weblink = create_plugin_weblink ("weblink", "", "", 0, 0);
   gtk_widget_show (weblink);
   gtk_box_pack_start (GTK_BOX (hbox20), weblink, TRUE, FALSE, 0);
   gtk_widget_set_can_focus(weblink, FALSE);
   gtk_widget_set_can_default(weblink, FALSE);
+
+  label171 = gtk_label_new (_("Info"));
+  gtk_widget_show (label171);
+  gtk_notebook_set_tab_label (GTK_NOTEBOOK (plugin_notebook), gtk_notebook_get_nth_page (GTK_NOTEBOOK (plugin_notebook), 1), label171);
+
+  scrolledwindow16 = gtk_scrolled_window_new (NULL, NULL);
+  gtk_widget_show (scrolledwindow16);
+  gtk_container_add (GTK_CONTAINER (plugin_notebook), scrolledwindow16);
+  gtk_scrolled_window_set_policy (GTK_SCROLLED_WINDOW (scrolledwindow16), GTK_POLICY_AUTOMATIC, GTK_POLICY_AUTOMATIC);
+  gtk_scrolled_window_set_shadow_type (GTK_SCROLLED_WINDOW (scrolledwindow16), GTK_SHADOW_IN);
+
+  plug_license = gtk_text_view_new ();
+  gtk_widget_show (plug_license);
+  gtk_container_add (GTK_CONTAINER (scrolledwindow16), plug_license);
+  gtk_text_view_set_editable (GTK_TEXT_VIEW (plug_license), FALSE);
+  gtk_text_view_set_cursor_visible (GTK_TEXT_VIEW (plug_license), FALSE);
+
+  label172 = gtk_label_new (_("License"));
+  gtk_widget_show (label172);
+  gtk_notebook_set_tab_label (GTK_NOTEBOOK (plugin_notebook), gtk_notebook_get_nth_page (GTK_NOTEBOOK (plugin_notebook), 2), label172);
 
   label3 = gtk_label_new (_("Plugins"));
   gtk_widget_show (label3);
@@ -3407,11 +3448,17 @@ create_prefwin (void)
   g_signal_connect ((gpointer) pref_pluginlist, "row_activated",
                     G_CALLBACK (on_pref_pluginlist_row_activated),
                     NULL);
-  g_signal_connect ((gpointer) configure_plugin, "clicked",
-                    G_CALLBACK (on_configure_plugin_clicked),
+  g_signal_connect ((gpointer) plugin_conf_tab_btn, "clicked",
+                    G_CALLBACK (on_plugin_conf_tab_btn_clicked),
                     NULL);
-  g_signal_connect ((gpointer) plug_copyright, "clicked",
-                    G_CALLBACK (on_plug_copyright_clicked),
+  g_signal_connect ((gpointer) plugin_info_tab_btn, "clicked",
+                    G_CALLBACK (on_plugin_info_tab_btn_clicked),
+                    NULL);
+  g_signal_connect ((gpointer) plugin_license_tab_btn, "clicked",
+                    G_CALLBACK (on_plugin_license_tab_btn_clicked),
+                    NULL);
+  g_signal_connect ((gpointer) plugin_notebook, "switch_page",
+                    G_CALLBACK (on_plugin_notebook_switch_page),
                     NULL);
 
   /* Store pointers to all widgets, for use by lookup_widget(). */
@@ -3658,6 +3705,17 @@ create_prefwin (void)
   GLADE_HOOKUP_OBJECT (prefwin, hpaned1, "hpaned1");
   GLADE_HOOKUP_OBJECT (prefwin, scrolledwindow2, "scrolledwindow2");
   GLADE_HOOKUP_OBJECT (prefwin, pref_pluginlist, "pref_pluginlist");
+  GLADE_HOOKUP_OBJECT (prefwin, vbox54, "vbox54");
+  GLADE_HOOKUP_OBJECT (prefwin, hbox149, "hbox149");
+  GLADE_HOOKUP_OBJECT (prefwin, label169, "label169");
+  GLADE_HOOKUP_OBJECT (prefwin, plugin_tabbtn_hbox, "plugin_tabbtn_hbox");
+  GLADE_HOOKUP_OBJECT (prefwin, plugin_conf_tab_btn, "plugin_conf_tab_btn");
+  GLADE_HOOKUP_OBJECT (prefwin, plugin_info_tab_btn, "plugin_info_tab_btn");
+  GLADE_HOOKUP_OBJECT (prefwin, plugin_license_tab_btn, "plugin_license_tab_btn");
+  GLADE_HOOKUP_OBJECT (prefwin, label168, "label168");
+  GLADE_HOOKUP_OBJECT (prefwin, plugin_notebook, "plugin_notebook");
+  GLADE_HOOKUP_OBJECT (prefwin, plug_conf_dlg_scrolledwindow, "plug_conf_dlg_scrolledwindow");
+  GLADE_HOOKUP_OBJECT (prefwin, label170, "label170");
   GLADE_HOOKUP_OBJECT (prefwin, vbox12, "vbox12");
   GLADE_HOOKUP_OBJECT (prefwin, hbox103, "hbox103");
   GLADE_HOOKUP_OBJECT (prefwin, label130, "label130");
@@ -3665,17 +3723,11 @@ create_prefwin (void)
   GLADE_HOOKUP_OBJECT (prefwin, scrolledwindow8, "scrolledwindow8");
   GLADE_HOOKUP_OBJECT (prefwin, plug_description, "plug_description");
   GLADE_HOOKUP_OBJECT (prefwin, hbox20, "hbox20");
-  GLADE_HOOKUP_OBJECT (prefwin, configure_plugin, "configure_plugin");
-  GLADE_HOOKUP_OBJECT (prefwin, alignment15, "alignment15");
-  GLADE_HOOKUP_OBJECT (prefwin, hbox56, "hbox56");
-  GLADE_HOOKUP_OBJECT (prefwin, image394, "image394");
-  GLADE_HOOKUP_OBJECT (prefwin, label92, "label92");
-  GLADE_HOOKUP_OBJECT (prefwin, plug_copyright, "plug_copyright");
-  GLADE_HOOKUP_OBJECT (prefwin, alignment20, "alignment20");
-  GLADE_HOOKUP_OBJECT (prefwin, hbox88, "hbox88");
-  GLADE_HOOKUP_OBJECT (prefwin, image521, "image521");
-  GLADE_HOOKUP_OBJECT (prefwin, label117, "label117");
   GLADE_HOOKUP_OBJECT (prefwin, weblink, "weblink");
+  GLADE_HOOKUP_OBJECT (prefwin, label171, "label171");
+  GLADE_HOOKUP_OBJECT (prefwin, scrolledwindow16, "scrolledwindow16");
+  GLADE_HOOKUP_OBJECT (prefwin, plug_license, "plug_license");
+  GLADE_HOOKUP_OBJECT (prefwin, label172, "label172");
   GLADE_HOOKUP_OBJECT (prefwin, label3, "label3");
   GLADE_HOOKUP_OBJECT_NO_REF (prefwin, dialog_action_area2, "dialog_action_area2");
   GLADE_HOOKUP_OBJECT (prefwin, closebutton1, "closebutton1");

--- a/plugins/gtkui/pluginconf.c
+++ b/plugins/gtkui/pluginconf.c
@@ -133,6 +133,15 @@ void apply_conf (GtkWidget *w, ddb_dialog_t *conf, int reset_settings) {
 
         if (reset_settings) {
             conf->set_param (key, def);
+
+            // skip to ;
+            char semicolon[MAX_TOKEN];
+            while ((script = gettoken_warn_eof (script, semicolon))) {
+                if (!strcmp (semicolon, ";")) {
+                    break;
+                }
+            }
+            continue;
         } else {
             // fetch data
             GtkWidget *widget = g_object_get_data (w, key);

--- a/plugins/gtkui/pluginconf.h
+++ b/plugins/gtkui/pluginconf.h
@@ -30,4 +30,7 @@ gtkui_run_dialog (GtkWidget *parentwin, ddb_dialog_t *conf, uint32_t buttons, in
 int
 gtkui_run_dialog_root (ddb_dialog_t *conf, uint32_t buttons, int (*callback)(int button, void *ctx), void *ctx);
 
+void
+gtkui_make_dialog (GtkWidget *win, GtkWidget *containervbox, ddb_dialog_t *conf);
+
 #endif

--- a/plugins/gtkui/pluginconf.h
+++ b/plugins/gtkui/pluginconf.h
@@ -24,6 +24,18 @@
 #ifndef __PLUGINCONF_H
 #define __PLUGINCONF_H
 
+
+typedef struct ddb_pluginprefs_dialog_s ddb_pluginprefs_dialog_t;
+
+struct ddb_pluginprefs_dialog_s {
+    ddb_dialog_t dialog_conf;
+
+    GtkWidget *parent;
+    GtkWidget *containerbox; // The container widget (typically a GtkVBox) that holds all the fields.
+
+    void (*prop_changed) (ddb_pluginprefs_dialog_t *make_dialog_conf);
+};
+
 int
 gtkui_run_dialog (GtkWidget *parentwin, ddb_dialog_t *conf, uint32_t buttons, int (*callback)(int button, void *ctx), void *ctx);
 
@@ -31,6 +43,9 @@ int
 gtkui_run_dialog_root (ddb_dialog_t *conf, uint32_t buttons, int (*callback)(int button, void *ctx), void *ctx);
 
 void
-gtkui_make_dialog (GtkWidget *win, GtkWidget *containervbox, ddb_dialog_t *conf);
+gtkui_make_dialog (ddb_pluginprefs_dialog_t *make_dialog_conf);
+
+void
+apply_conf (GtkWidget *w, ddb_dialog_t *conf, int reset_settings);
 
 #endif

--- a/plugins/gtkui/prefwin.c
+++ b/plugins/gtkui/prefwin.c
@@ -466,7 +466,7 @@ gtkui_run_preferences_dlg (void) {
 
     // Some styling changes since Glade doesn't support setting it
 #if GTK_CHECK_VERSION(3,12,0)
-    GtkHButtonBox *bbox = GTK_NOTEBOOK (lookup_widget (w, "plugin_tabbtn_hbtnbox"));
+    GtkButtonBox *bbox = GTK_BUTTON_BOX (lookup_widget (w, "plugin_tabbtn_hbtnbox"));
     gtk_button_box_set_layout (bbox, GTK_BUTTONBOX_EXPAND);
 #endif
 
@@ -733,12 +733,13 @@ on_pref_pluginlist_cursor_changed      (GtkTreeView     *treeview,
         };
         GtkWidget *box = gtk_vbox_new(FALSE, 0);
         gtk_widget_show (box);
-        if (user_data) {
+        if (user_data == 1) {
+            fprintf(stderr, "Resetting to defaults!\n"); //DEBUG
             apply_conf (box, &conf, 1);
         }
         make_dialog_conf.containerbox = box;
-        gtkui_make_dialog (&make_dialog_conf);
         gtk_container_add (GTK_CONTAINER (container), box);
+        gtkui_make_dialog (&make_dialog_conf);
     }
 }
 
@@ -749,7 +750,6 @@ on_plugin_conf_reset_btn_clicked       (GtkButton       *button,
     GtkWidget *w = prefwin;
     GtkTreeView *treeview = GTK_TREE_VIEW (lookup_widget (w, "pref_pluginlist"));
     on_pref_pluginlist_cursor_changed(treeview, 1);
-    gtk_widget_set_sensitive (button, FALSE);
 }
 
 void
@@ -809,15 +809,20 @@ on_plugin_notebook_switch_page         (GtkNotebook     *notebook,
     GQuark detail = g_quark_from_static_string ("switch_page");
     g_signal_handlers_block_matched ((gpointer)notebook, mask, detail, 0, NULL, NULL, NULL);
 
+    GtkWidget *plugin_actions_btnbox = lookup_widget (w, "plugin_actions_btnbox");
+
     switch (page_num) {
         case 0:
         gtk_toggle_button_set_active (plugin_conf_tab_btn, 1);
+        gtk_widget_show(plugin_actions_btnbox);
         break;
         case 1:
         gtk_toggle_button_set_active (plugin_info_tab_btn, 1);
+        gtk_widget_hide(plugin_actions_btnbox);
         break;
         case 2:
         gtk_toggle_button_set_active (plugin_license_tab_btn, 1);
+        gtk_widget_hide(plugin_actions_btnbox);
     }
     g_signal_handlers_unblock_matched ((gpointer)notebook, mask, detail, 0, NULL, NULL, NULL);
 }

--- a/plugins/gtkui/prefwin.c
+++ b/plugins/gtkui/prefwin.c
@@ -464,6 +464,12 @@ gtkui_run_preferences_dlg (void) {
     gtk_notebook_set_show_tabs(notebook, FALSE);
     gtk_notebook_set_current_page(notebook, 0);
 
+    // Some styling changes since Glade doesn't support setting it
+#if GTK_CHECK_VERSION(3,12,0)
+    GtkHButtonBox *bbox = GTK_NOTEBOOK (lookup_widget (w, "plugin_tabbtn_hbtnbox"));
+    gtk_button_box_set_layout (bbox, GTK_BUTTONBOX_EXPAND);
+#endif
+
     // hotkeys
     prefwin_init_hotkeys (prefwin);
 
@@ -702,7 +708,7 @@ on_pref_pluginlist_cursor_changed      (GtkTreeView     *treeview,
     }
 
 
-    GtkWidget *container = (lookup_widget (w, "plug_conf_dlg_scrolledwindow"));
+    GtkWidget *container = (lookup_widget (w, "plug_conf_dlg_viewport"));
     GtkWidget *child = gtk_bin_get_child (GTK_BIN (container));
     if (child)
         gtk_widget_destroy(child);
@@ -717,7 +723,8 @@ on_pref_pluginlist_cursor_changed      (GtkTreeView     *treeview,
         GtkWidget *box = gtk_vbox_new(FALSE, 0);
         gtk_widget_show (box);
         gtkui_make_dialog (NULL, box, &conf);
-        gtk_scrolled_window_add_with_viewport (GTK_SCROLLED_WINDOW (container), box);
+        gtk_widget_set_size_request(box, 200, -1);
+        gtk_container_add (GTK_CONTAINER (container), box);
     }
 }
 

--- a/plugins/gtkui/prefwin.c
+++ b/plugins/gtkui/prefwin.c
@@ -712,7 +712,6 @@ on_pref_pluginlist_cursor_changed      (GtkTreeView     *treeview,
     }
 
     GtkWidget *plugin_actions_btnbox = lookup_widget (w, "plugin_actions_btnbox");
-    GtkToggleButton *plugin_conf_tab_btn = GTK_TOGGLE_BUTTON (lookup_widget (w, "plugin_conf_tab_btn"));
 
     GtkWidget *container = (lookup_widget (w, "plug_conf_dlg_viewport"));
     GtkWidget *child = gtk_bin_get_child (GTK_BIN (container));
@@ -741,10 +740,8 @@ on_pref_pluginlist_cursor_changed      (GtkTreeView     *treeview,
         gtkui_make_dialog (&make_dialog_conf);
 
         gtk_widget_show (plugin_actions_btnbox);
-        gtk_widget_set_sensitive (plugin_conf_tab_btn, TRUE);
     } else {
         gtk_widget_hide (plugin_actions_btnbox);
-        gtk_widget_set_sensitive (plugin_conf_tab_btn, FALSE);
     }
 }
 

--- a/plugins/gtkui/prefwin.c
+++ b/plugins/gtkui/prefwin.c
@@ -654,8 +654,6 @@ gtkui_conf_get_str (const char *key, char *value, int len, const char *def) {
 
 void plugin_pref_prop_changed_cb(ddb_pluginprefs_dialog_t *make_dialog_conf) {
     apply_conf (GTK_WIDGET (make_dialog_conf->containerbox), &make_dialog_conf->dialog_conf, 0);
-    GtkWidget *resetbtn = lookup_widget (make_dialog_conf->parent, "plugin_conf_reset_btn");
-    gtk_widget_set_sensitive (resetbtn, TRUE);
 }
 
 void
@@ -713,6 +711,8 @@ on_pref_pluginlist_cursor_changed      (GtkTreeView     *treeview,
         gtk_text_view_set_buffer(lictv, NULL);
     }
 
+    GtkWidget *plugin_actions_btnbox = lookup_widget (w, "plugin_actions_btnbox");
+    GtkToggleButton *plugin_conf_tab_btn = GTK_TOGGLE_BUTTON (lookup_widget (w, "plugin_conf_tab_btn"));
 
     GtkWidget *container = (lookup_widget (w, "plug_conf_dlg_viewport"));
     GtkWidget *child = gtk_bin_get_child (GTK_BIN (container));
@@ -734,12 +734,17 @@ on_pref_pluginlist_cursor_changed      (GtkTreeView     *treeview,
         GtkWidget *box = gtk_vbox_new(FALSE, 0);
         gtk_widget_show (box);
         if (user_data == 1) {
-            fprintf(stderr, "Resetting to defaults!\n"); //DEBUG
             apply_conf (box, &conf, 1);
         }
         make_dialog_conf.containerbox = box;
         gtk_container_add (GTK_CONTAINER (container), box);
         gtkui_make_dialog (&make_dialog_conf);
+
+        gtk_widget_show (plugin_actions_btnbox);
+        gtk_widget_set_sensitive (plugin_conf_tab_btn, TRUE);
+    } else {
+        gtk_widget_hide (plugin_actions_btnbox);
+        gtk_widget_set_sensitive (plugin_conf_tab_btn, FALSE);
     }
 }
 
@@ -809,20 +814,15 @@ on_plugin_notebook_switch_page         (GtkNotebook     *notebook,
     GQuark detail = g_quark_from_static_string ("switch_page");
     g_signal_handlers_block_matched ((gpointer)notebook, mask, detail, 0, NULL, NULL, NULL);
 
-    GtkWidget *plugin_actions_btnbox = lookup_widget (w, "plugin_actions_btnbox");
-
     switch (page_num) {
         case 0:
         gtk_toggle_button_set_active (plugin_conf_tab_btn, 1);
-        gtk_widget_show(plugin_actions_btnbox);
         break;
         case 1:
         gtk_toggle_button_set_active (plugin_info_tab_btn, 1);
-        gtk_widget_hide(plugin_actions_btnbox);
         break;
         case 2:
         gtk_toggle_button_set_active (plugin_license_tab_btn, 1);
-        gtk_widget_hide(plugin_actions_btnbox);
     }
     g_signal_handlers_unblock_matched ((gpointer)notebook, mask, detail, 0, NULL, NULL, NULL);
 }

--- a/plugins/gtkui/prefwin.c
+++ b/plugins/gtkui/prefwin.c
@@ -652,6 +652,12 @@ gtkui_conf_get_str (const char *key, char *value, int len, const char *def) {
     deadbeef->conf_get_str (key, def, value, len);
 }
 
+void plugin_pref_prop_changed_cb(ddb_pluginprefs_dialog_t *make_dialog_conf) {
+    apply_conf (GTK_WIDGET (make_dialog_conf->containerbox), &make_dialog_conf->dialog_conf, 0);
+    GtkWidget *resetbtn = lookup_widget (make_dialog_conf->parent, "plugin_conf_reset_btn");
+    gtk_widget_set_sensitive (resetbtn, TRUE);
+}
+
 void
 on_pref_pluginlist_cursor_changed      (GtkTreeView     *treeview,
                                         gpointer         user_data)
@@ -720,12 +726,30 @@ on_pref_pluginlist_cursor_changed      (GtkTreeView     *treeview,
             .set_param = deadbeef->conf_set_str,
             .get_param = gtkui_conf_get_str,
         };
+        ddb_pluginprefs_dialog_t make_dialog_conf = {
+            .dialog_conf = conf,
+            .parent = prefwin,
+            .prop_changed = plugin_pref_prop_changed_cb,
+        };
         GtkWidget *box = gtk_vbox_new(FALSE, 0);
         gtk_widget_show (box);
-        gtkui_make_dialog (NULL, box, &conf);
-        gtk_widget_set_size_request(box, 200, -1);
+        if (user_data) {
+            apply_conf (box, &conf, 1);
+        }
+        make_dialog_conf.containerbox = box;
+        gtkui_make_dialog (&make_dialog_conf);
         gtk_container_add (GTK_CONTAINER (container), box);
     }
+}
+
+void
+on_plugin_conf_reset_btn_clicked       (GtkButton       *button,
+                                        gpointer         user_data)
+{
+    GtkWidget *w = prefwin;
+    GtkTreeView *treeview = GTK_TREE_VIEW (lookup_widget (w, "pref_pluginlist"));
+    on_pref_pluginlist_cursor_changed(treeview, 1);
+    gtk_widget_set_sensitive (button, FALSE);
 }
 
 void


### PR DESCRIPTION
Notes:

I had to change the code in `apply_conf` from using `lookup_widget` glade utility function to `g_object_get_data` directly as it needs to work with any container and not just top levels where it can find the outermost parent. `gtkui_run_dialog` expected a parent dialog passed to it which remains until none of the child objects are needed. I hope this change has no side effects this time.

