### PR TITLE
gtkui: fix rename the right plt_idx

### DIFF
--- a/plugins/gtkui/actionhandlers.c
+++ b/plugins/gtkui/actionhandlers.c
@@ -172,7 +172,10 @@ action_remove_current_playlist_handler (struct DB_plugin_action_s *action, ddb_a
 
 int
 action_rename_current_playlist_handler (struct DB_plugin_action_s *action, ddb_action_context_t ctx) {
-    gtkui_rename_current_playlist();
+    int idx = deadbeef->plt_get_curr_idx ();
+    if (idx != -1) {
+        gtkui_rename_current_playlist(idx);
+    }
     return 0;
 }
 

--- a/plugins/gtkui/gtkui.c
+++ b/plugins/gtkui/gtkui.c
@@ -576,30 +576,27 @@ gtkui_get_curr_playlist_mod (void) {
 }
 
 int
-gtkui_rename_current_playlist (void) {
-    int idx = deadbeef->plt_get_curr_idx ();
-    if (idx != -1) {
-        GtkWidget *dlg = create_entrydialog ();
-        gtk_dialog_set_default_response (GTK_DIALOG (dlg), GTK_RESPONSE_OK);
-        gtk_window_set_title (GTK_WINDOW (dlg), _("Rename Playlist"));
-        GtkWidget *e;
-        e = lookup_widget (dlg, "title_label");
-        gtk_label_set_text (GTK_LABEL(e), _("Title:"));
-        e = lookup_widget (dlg, "title");
-        char t[1000];
-        plt_get_title_wrapper (idx, t, sizeof (t));
-        gtk_entry_set_text (GTK_ENTRY (e), t);
-        int res = gtk_dialog_run (GTK_DIALOG (dlg));
-        if (res == GTK_RESPONSE_OK) {
-            const char *text = gtk_entry_get_text (GTK_ENTRY (e));
-            deadbeef->pl_lock ();
-            ddb_playlist_t *p = deadbeef->plt_get_for_idx (idx);
-            deadbeef->plt_set_title (p, text);
-            deadbeef->plt_unref (p);
-            deadbeef->pl_unlock ();
-        }
-        gtk_widget_destroy (dlg);
+gtkui_rename_current_playlist (int plt_idx) {
+    GtkWidget *dlg = create_entrydialog ();
+    gtk_dialog_set_default_response (GTK_DIALOG (dlg), GTK_RESPONSE_OK);
+    gtk_window_set_title (GTK_WINDOW (dlg), _("Rename Playlist"));
+    GtkWidget *e;
+    e = lookup_widget (dlg, "title_label");
+    gtk_label_set_text (GTK_LABEL(e), _("Title:"));
+    e = lookup_widget (dlg, "title");
+    char t[1000];
+    plt_get_title_wrapper (plt_idx, t, sizeof (t));
+    gtk_entry_set_text (GTK_ENTRY (e), t);
+    int res = gtk_dialog_run (GTK_DIALOG (dlg));
+    if (res == GTK_RESPONSE_OK) {
+        const char *text = gtk_entry_get_text (GTK_ENTRY (e));
+        deadbeef->pl_lock ();
+        ddb_playlist_t *p = deadbeef->plt_get_for_idx (plt_idx);
+        deadbeef->plt_set_title (p, text);
+        deadbeef->plt_unref (p);
+        deadbeef->pl_unlock ();
     }
+    gtk_widget_destroy (dlg);
     return 0;
 }
 

--- a/plugins/gtkui/gtkui.h
+++ b/plugins/gtkui/gtkui.h
@@ -135,7 +135,7 @@ void
 gtkui_playlist_set_curr (int playlist);
 
 int
-gtkui_rename_current_playlist(void);
+gtkui_rename_current_playlist(int plt_idx);
 
 int
 gtkui_get_curr_playlist_mod (void);

--- a/plugins/gtkui/pltmenu.c
+++ b/plugins/gtkui/pltmenu.c
@@ -58,7 +58,9 @@ static void
 on_rename_playlist1_activate           (GtkMenuItem     *menuitem,
                                         gpointer         user_data)
 {
-    gtkui_rename_current_playlist();
+    if (pltmenu_idx != -1) {
+        gtkui_rename_current_playlist(pltmenu_idx);
+    }
 }
 
 static void


### PR DESCRIPTION
I messed up a bit with my last pr. Now renames the right playlist