### PR TITLE
aac: fix division by zero on malformed mp4a atoms with 0 sample_rate

### DIFF
--- a/plugins/aac/aac.c
+++ b/plugins/aac/aac.c
@@ -906,7 +906,8 @@ _mp4_insert(DB_playItem_t **after, const char *fname, DB_FILE *fp, ddb_playlist_
             if (aac_atom) {
                 aac = aac_atom->data;
                 info.aac_samplerate = aac->sample_rate;
-                break;
+                if (info.aac_samplerate > 0)
+                    break;
             }
         }
         info.trak = info.trak->next;


### PR DESCRIPTION
I got a weird .m4a file which contains an `mp4a` atom but with sample_rate == 0.
Whenever I added this file to the player, it crashes instantly due to division by zero.

With this quick fix the player can add and play the file normally.

For further information, here is the metadata from [mp4dump](https://github.com/axiomatic-systems/Bento4)
```
[ftyp] size=8+16
  major_brand = mp42
  minor_version = 0
  compatible_brand = mp42
  compatible_brand = isom
[moov] size=8+674359
  [mvhd] size=12+96
    timescale = 96000
    duration = 86237184
    duration(ms) = 898304
  [iods] size=12+21
    [InitialObjectDescriptor] size=5+16
      id = 1
      include inline profile level flag = 0
      OD profile level = ff
      scene profile level = ff
      audio profile level = 2b
      visual profile level = ff
      graphics profile level = ff
      [ES_ID_Inc] size=5+4
        track_id = 1
  [trak] size=8+674210
    [tkhd] size=12+80, flags=7
      enabled = 1
      id = 1
      duration = 86237184
      width = 0.000000
      height = 0.000000
    [mdia] size=8+674110
      [mdhd] size=12+20
        timescale = 96000
        duration = 86237184
        duration(ms) = 898304
        language = und
      [hdlr] size=12+25
        handler_type = soun
        handler_name = soun
      [minf] size=8+674033
        [smhd] size=12+4
          balance = 0
        [dinf] size=8+28
          [dref] size=12+16
            [url ] size=12+0, flags=1
              location = [local to file]
        [stbl] size=8+673973
          [stts] size=12+12
            entry_count = 1
          [stsd] size=12+91
            entry_count = 1
            [mp4a] size=8+79
              data_reference_index = 1
              channel_count = 2
              sample_size = 16
              sample_rate = 0
              [esds] size=12+39
                [ESDescriptor] size=5+34
                  es_id = 0
                  stream_priority = 0
                  [DecoderConfig] size=5+20
                    stream_type = 5
                    object_type = 64
                    up_stream = 0
                    buffer_size = 1536
                    max_bitrate = 582144
                    avg_bitrate = 576000
                    DecoderSpecificInfo = 10 10 
                  [Descriptor:06] size=5+1
          [stsz] size=12+336872
            sample_size = 0
            sample_count = 84216
          [stsc] size=12+16
            entry_count = 1
          [stco] size=12+336868
            entry_count = 84216
          [sgpd] size=12+14, version=1
            grouping_type = roll
            default_length = 2
            entry_count = 1
            entries:
              (       0) [ff ff]
          [sbgp] size=12+16
            grouping_type = roll
            entry_count = 1
[mdat] size=8+64677888
```