### PR TITLE
windows_postbuild: fix parsing for unresolved libs

### DIFF
--- a/scripts/windows_postbuild.sh
+++ b/scripts/windows_postbuild.sh
@@ -36,6 +36,7 @@ ldd "$1/plugins/"*.dll "$1/deadbeef.exe" | awk 'NF == 4 {print $3}; NF == 2 {pri
 									 | grep -iv "System32" \
 									 | grep -iv "WinSxS" \
 									 | grep -iv "ConEmu" \
+									 | grep -ivx "not" \
 									 | grep -iv "`readlink -f \"$1\"`" \
 									 | sort -u > .libraries.tmp
 


### PR DESCRIPTION
Fixes build failure caused by `ldd` update in msys2 repo.
I suggest to rerun open PR builds after merging this.