### PR TITLE
Sanitize paths for artwork-legacy

### DIFF
--- a/plugins/artwork-legacy/artwork.c
+++ b/plugins/artwork-legacy/artwork.c
@@ -1082,11 +1082,12 @@ make_cache_path2 (char *path, int size, const char *fname, const char *album, co
     }
 
     char esc_album[max_album_chars+1];
-    const char *palbum = strlen (album) > max_album_chars ? album+strlen (album)-max_album_chars : album;
-    size_t i = 0;
-    do {
-        esc_album[i] = esc_char (palbum[i]);
-    } while (palbum[i++]);
+    size_t len = sanitize_name_for_file_system (album, esc_album, max_album_chars + 1);
+    if (len < 1) {
+        // Would only happen if the name was entirely spaces or something like that.
+        trace ("Artwork File Cache: Not possible to get any unique album name.\n");
+        return -1;
+    }
 
     sprintf (path+strlen (path), "%s%s", esc_album, ".jpg");
     return 0;

--- a/plugins/artwork-legacy/artwork.c
+++ b/plugins/artwork-legacy/artwork.c
@@ -1020,17 +1020,9 @@ esc_char (char c) {
 
 static int
 make_cache_dir_path (char *path, int size, const char *artist, int img_size) {
-    char esc_artist[NAME_MAX+1];
+    char esc_artist[NAME_MAX] = "Unknown artist";
     if (artist) {
-        size_t i = 0;
-        while (artist[i] && i < NAME_MAX) {
-            esc_artist[i] = esc_char (artist[i]);
-            i++;
-        }
-        esc_artist[i] = '\0';
-    }
-    else {
-        strcpy (esc_artist, "Unknown artist");
+        sanitize_name_for_file_system(artist, esc_artist, NAME_MAX);
     }
 
     if (make_cache_root_path (path, size) < 0) {

--- a/plugins/artwork-legacy/artwork.c
+++ b/plugins/artwork-legacy/artwork.c
@@ -1082,6 +1082,7 @@ make_cache_path2 (char *path, int size, const char *fname, const char *album, co
     }
 
     size -= strlen (path);
+    size -= 4; // File extension .jpg
     if (size < 1) {
         trace ("Path buffer not long enough for %s and filename\n", path);
         return -1;


### PR DESCRIPTION
These commits were sent as PR to DeaDBeeF-for-Windows by Keith. I told him it would be more appropriate to sent it straight here. It sadly never happened but now I'm doing this because I still think these changes are useful.

Please let me know what you think about these changes and request changes if necessary (`is_illegal_windows_name` could be rewritten for better readability for sure 🙂).