### PR TITLE
do not explicitly link kqueue library for libdispatch

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -251,7 +251,7 @@ AS_IF([test "${enable_staticlink}" != "no"], [
     AC_CHECK_LIB([dispatch], [main], [HAVE_DISPATCH=yes])
 ])
 DISPATCH_CFLAGS=-fblocks
-DISPATCH_LIBS="-ldispatch -lBlocksRuntime -lkqueue"
+DISPATCH_LIBS="-ldispatch -lBlocksRuntime"
 AC_SUBST(DISPATCH_CFLAGS)
 AC_SUBST(DISPATCH_LIBS)
 


### PR DESCRIPTION
fixes build on systems where kqueue is not installed or required for libdispatch