### PR TITLE
exec_cmdline implementation + small fixes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -35,6 +35,8 @@ m4
 .libs
 *.la
 *.lo
+bin/*
+obj/*
 deadbeef.desktop
 .vimrc
 ddbcellrenderertextmultiline.vapi

--- a/deadbeef.h
+++ b/deadbeef.h
@@ -1746,7 +1746,9 @@ typedef struct DB_plugin_s {
     // can be NULL if plugin doesn't support commandline processing
     // cmdline is 0-separated list of strings, guaranteed to have 0 at the end
     // cmdline_size is number of bytes pointed by cmdline
-    int (*exec_cmdline) (const char *cmdline, int cmdline_size);
+    // fd is file descriptor, send command output there (f. ex. by using dprintf)
+    // returns 0 on success or error code on failure
+    int (*exec_cmdline) (const char *cmdline, int cmdline_size, int fd);
 
     // @returns linked list of actions for the specified track
     // when it is NULL -- the plugin must return list of all actions

--- a/plugins/artwork-legacy/artwork.c
+++ b/plugins/artwork-legacy/artwork.c
@@ -1389,11 +1389,6 @@ local_image_file (const char *cache_path, const char *local_path, const char *ur
             return 0;
         }
     }
-    if (!scan_local_path ("*.jpg", cache_path, local_path, uri, vfsplug) ||
-        !scan_local_path ("*.jpeg", cache_path, local_path, uri, vfsplug) ||
-        !scan_local_path ("*.png", cache_path, local_path, uri, vfsplug)) {
-        return 0;
-    }
 
     trace ("No cover art files in local folder\n");
     return -1;


### PR DESCRIPTION
Fixes:
- Add premake build files into `.gitignore`
- Fix hardcoded wildcards in `artwork-legacy` (fixes #2494)

exec_cmdline:
- Runs in `server_exec_command_line`
- Gets plugins from `plug_get_list()` and calls `exec_cmdline` if implemented
- Calls every plugin even though some plugin might already have used and processed given arguments. I was unsure what 'right' behavior should be. There might be a case where some broken plugin can pretend to have used arguments and make other plugins not receive `exec_cmdline` calls. From other side this can lead to arguments being interpreted twice. Can change depending on your final opinion.


EDIT:
Proposal of implementation can be found here: https://gist.github.com/Alexey-Yakovenko/aa226803af604042721d671ecde94c3d