### PR TITLE
streamer: stop after current now works like fb2k (#2124)

### DIFF
--- a/streamer.c
+++ b/streamer.c
@@ -1654,9 +1654,9 @@ streamer_thread (void *unused) {
             if (stop) {
                 stream_track (NULL, 0);
                 if (next) {
-                    playlist_t* cur_pl = plt_get_curr();
-                    int cursor = plt_get_item_idx(cur_pl, next, PL_MAIN);
-                    plt_deselect_all(cur_pl);
+                    playlist_t* cur_pl = plt_get_curr ();
+                    int cursor = plt_get_item_idx (cur_pl, next, PL_MAIN);
+                    plt_deselect_all (cur_pl);
                     pl_set_selected_in_playlist (cur_pl, next, 1);
                     messagepump_push (DB_EV_PLAYLISTCHANGED, 0, DDB_PLAYLIST_CHANGE_SELECTION, 0);
                     plt_set_cursor (cur_pl, PL_MAIN, cursor);

--- a/streamer.c
+++ b/streamer.c
@@ -1656,7 +1656,10 @@ streamer_thread (void *unused) {
                 if (next) {
                     playlist_t* cur_pl = plt_get_curr();
                     int cursor = plt_get_item_idx(cur_pl, next, PL_MAIN);
-                    plt_set_cursor(cur_pl, PL_MAIN, cursor);
+                    plt_deselect_all(cur_pl);
+                    pl_set_selected_in_playlist (cur_pl, next, 1);
+                    messagepump_push (DB_EV_PLAYLISTCHANGED, 0, DDB_PLAYLIST_CHANGE_SELECTION, 0);
+                    plt_set_cursor (cur_pl, PL_MAIN, cursor);
                     pl_item_unref (next);
                 }
             }

--- a/streamer.c
+++ b/streamer.c
@@ -1645,24 +1645,20 @@ streamer_thread (void *unused) {
             // handle stop after current
             int stop = 0;
             if (block->last) {
-                if (stop_after_current) {
+                next = get_next_track(streaming_track, shuffle, repeat);
+                if (stop_after_current || stop_after_album_check (streaming_track, next)) {
                     stop = 1;
-                }
-                else {
-                    next = get_next_track(streaming_track, shuffle, repeat);
-
-                    if (stop_after_album_check (streaming_track, next)) {
-                        stop = 1;
-                    }
-
-                    if (next) {
-                        pl_item_unref (next);
-                    }
                 }
             }
 
             if (stop) {
                 stream_track (NULL, 0);
+                if (next) {
+                    playlist_t* cur_pl = plt_get_curr();
+                    int cursor = plt_get_item_idx(cur_pl, next, PL_MAIN);
+                    plt_set_cursor(cur_pl, PL_MAIN, cursor);
+                    pl_item_unref (next);
+                }
             }
             else {
                 streamer_next (shuffle, repeat, next);

--- a/streamer.c
+++ b/streamer.c
@@ -1660,11 +1660,14 @@ streamer_thread (void *unused) {
                     pl_set_selected_in_playlist (cur_pl, next, 1);
                     messagepump_push (DB_EV_PLAYLISTCHANGED, 0, DDB_PLAYLIST_CHANGE_SELECTION, 0);
                     plt_set_cursor (cur_pl, PL_MAIN, cursor);
-                    pl_item_unref (next);
+                    plt_unref(cur_pl);
                 }
             }
             else {
                 streamer_next (shuffle, repeat, next);
+            }
+            if (next) {
+                pl_item_unref (next);
             }
         }
 


### PR DESCRIPTION
after the streamer stops due to stop after current (track/album), hitting play will now play the next track. before it would play the track that just ended

Resolves #2124

Unfortunately, the selection indicated in `gtkui` is not updated to reflect the new cursor position. I think this may require new signals to implement.