### PR TITLE
gtkui: autosort after dropping files into playlist

### DIFF
--- a/deadbeef.h
+++ b/deadbeef.h
@@ -1430,6 +1430,9 @@ typedef struct {
 
     // sort using title formatting v2
     void (*plt_sort_v2) (ddb_playlist_t *plt, int iter, int id, const char *format, int order);
+    //autosort
+    void (*plt_autosort) (ddb_playlist_t *plt);
+
 
     // playqueue APIs
     int (*playqueue_push) (DB_playItem_t *it);

--- a/plugins.c
+++ b/plugins.c
@@ -454,6 +454,7 @@ static DB_functions_t deadbeef_api = {
     .tf_eval= tf_eval,
 
     .plt_sort_v2 = (void (*) (ddb_playlist_t *plt, int iter, int id, const char *format, int order))plt_sort_v2,
+    .plt_autosort = (void (*) (ddb_playlist_t *plt)) plt_autosort,
 
     .playqueue_push = (int (*) (DB_playItem_t *))playqueue_push,
     .playqueue_clear = playqueue_clear,

--- a/plugins/gtkui/Makefile.am
+++ b/plugins/gtkui/Makefile.am
@@ -4,6 +4,7 @@ EXTRA_DIST = deadbeef.glade\
 
 GTKUI_SOURCES = \
     ../../utf8.c\
+	../../deadbeef.h \
 	actions.c actions.h\
 	callbacks.c callbacks.h\
 	support.c support.h\

--- a/plugins/gtkui/fileman.c
+++ b/plugins/gtkui/fileman.c
@@ -262,6 +262,7 @@ gtkpl_add_fm_dropped_files (DB_playItem_t *drop_before, char *ptr, int length) {
     free (ptr);
 
     deadbeef->plt_add_files_end (plt, 0);
+    deadbeef->plt_autosort(plt);
     deadbeef->plt_save_config (plt);
     deadbeef->plt_unref (plt);
     g_idle_add (set_dnd_cursor_idle, first);

--- a/plugins/gtkui/playlist/mainplaylist.c
+++ b/plugins/gtkui/playlist/mainplaylist.c
@@ -100,6 +100,9 @@ main_drag_n_drop (DdbListviewIter before, DdbPlaylistHandle from_playlist, uint3
     if (!copy && from_playlist != plt) {
         deadbeef->plt_save_config (from_playlist);
     }
+    if ( (ddb_playlist_t *)from_playlist != plt) {
+        deadbeef->plt_autosort (plt);
+    }
     deadbeef->plt_save_config (plt);
     deadbeef->plt_unref (plt);
     deadbeef->pl_unlock ();


### PR DESCRIPTION
fixes #2768 

however, I had to expose `plt_autosort` in the API which means the API version should probably be bumped