### PR TITLE
Increase by 4 the maximum album art file size

### DIFF
--- a/plugins/gtkui/covermanager/covermanager.c
+++ b/plugins/gtkui/covermanager/covermanager.c
@@ -31,7 +31,7 @@
 #include "gtkui.h"
 
 #define min(x,y) ((x)<(y)?(x):(y))
-#define MAX_ALBUM_ART_FILE_SIZE (10*2048*2048)
+#define MAX_ALBUM_ART_FILE_SIZE (40*1024*1024)
 
 extern DB_functions_t *deadbeef;
 

--- a/plugins/gtkui/covermanager/covermanager.c
+++ b/plugins/gtkui/covermanager/covermanager.c
@@ -31,7 +31,7 @@
 #include "gtkui.h"
 
 #define min(x,y) ((x)<(y)?(x):(y))
-#define MAX_ALBUM_ART_FILE_SIZE (10*1024*1024)
+#define MAX_ALBUM_ART_FILE_SIZE (10*2048*2048)
 
 extern DB_functions_t *deadbeef;
 


### PR DESCRIPTION
Some albums purchased on Qobuz come with files larger than the current limit. The older artwork plugin displayed those files smoothly.  In addition, I guess this would make the file size more consistent with the 2048px hard-limit in `plugins/artwork/artwork.c`
As a practical test, with this increased size requirement, my 10'000 album arts all fit.