### PR TITLE
Fix "make check" failed

### DIFF
--- a/po/POTFILES.in
+++ b/po/POTFILES.in
@@ -36,6 +36,7 @@ plugins/gtkui/prefwin/prefwinsound.c
 plugins/gtkui/progress.c
 plugins/gtkui/rg.c
 plugins/gtkui/search.c
+plugins/gtkui/selpropertieswidget.c
 plugins/gtkui/trkproperties.c
 plugins/gtkui/widgets.c
 plugins/hotkeys/actionhandlers.c


### PR DESCRIPTION
```make check``` produced the following error
```
Making check in po
make[1]: Entering directory '/tmp/deadbeef-1.9.2/po'
INTLTOOL_EXTRACT="/usr/bin/intltool-extract" XGETTEXT="/usr/bin/xgettext" srcdir=. /usr/bin/intltool-update --gettext-package deadbeef --pot
rm -f missing notexist
srcdir=. /usr/bin/intltool-update -m
The following files contain translations and are currently not in use. Please
consider adding these to the POTFILES.in file, located in the po/ directory.

plugins/gtkui/selpropertieswidget.c

If some of these files are left out on purpose then please add them to
POTFILES.skip instead of POTFILES.in. A file 'missing' containing this list
of left out files has been written in the current directory.
if [ -r missing -o -r notexist ]; then \
  exit 1; \
fi
make[1]: *** [Makefile:202: check] Error 1
make[1]: Leaving directory '/tmp/deadbeef-1.9.2/po'
make: *** [Makefile:1046: check-recursive] Error 1
```