### PR TITLE
Make sure to unlock the mutex in conf_free() before calling mutex_free()

### DIFF
--- a/conf.c
+++ b/conf.c
@@ -72,6 +72,7 @@ conf_free (void) {
     }
     conf_items = NULL;
     changed = 0;
+    mutex_unlock (mutex);
     mutex_free (mutex);
     mutex = 0;
 }


### PR DESCRIPTION
Without doing so OpenBSD's POSIX threads implementation will print "pthread_mutex_destroy on mutex with waiters!".