### PR TITLE
junklib: Do not define LIBICONV_PLUG for OpenBSD

### DIFF
--- a/junklib.c
+++ b/junklib.c
@@ -32,7 +32,7 @@
 #include <stdlib.h>
 #include <string.h>
 #if HAVE_ICONV
-  #ifndef __MINGW32__
+  #if !defined(__MINGW32__) && !defined(__OpenBSD__)
   #define LIBICONV_PLUG
   #endif
   #include <iconv.h>


### PR DESCRIPTION
This breaks building with GNU iconv.