### PR TITLE
Fix building with GNU intl

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -63,7 +63,7 @@ deadbeef_SOURCES =\
 
 sdkdir = $(pkgincludedir)
 sdk_HEADERS = deadbeef.h
-deadbeef_LDADD = $(LDADD) $(ICONV_LIB) $(DL_LIBS) -lm -lpthread $(DISPATCH_LIBS) $(INTL_LIBS) shared/libctmap.la plugins/libparser/libparser.la
+deadbeef_LDADD = $(LDADD) $(ICONV_LIB) $(DL_LIBS) -lm -lpthread $(DISPATCH_LIBS) $(LTLIBINTL) shared/libctmap.la plugins/libparser/libparser.la
 
 deadbeef_CFLAGS = $(DEPS_CFLAGS) $(DISPATCH_CFLAGS) -std=c99 -DLOCALEDIR=\"@localedir@\"
 


### PR DESCRIPTION
At one point INTL_LIBS was filled in by an autoconf test, but that was removed
with commit 70339732d8530570861d8fe26112b9f203077e91. This broke building on
OpenBSD. Fix the automake Makefile so it references a variable that is filled
out by the AM_GNU_GETTEXT macro.