### PR TITLE
cocoaui: fix artwork center and right align when using high DPI displays

### DIFF
--- a/plugins/cocoaui/Playlist/PlaylistViewController.m
+++ b/plugins/cocoaui/Playlist/PlaylistViewController.m
@@ -1034,10 +1034,10 @@ artwork_listener (ddb_artwork_listener_event_t event, void *user_data, int64_t p
     if (size.width < size.height) {
         plt_col_info_t *c = &self.columns[(int)col];
         if (c->alignment == ColumnAlignmentCenter) {
-            art_x += art_width/2 - desiredSize.width/2;
+            art_x += availableSize.width/2 - desiredSize.width/2;
         }
         else if (c->alignment == ColumnAlignmentRight) {
-            art_x += art_width-desiredSize.width;
+            art_x += availableSize.width-desiredSize.width;
         }
     }
     CGSize drawSize = [self.view convertSizeFromBacking:desiredSize];


### PR DESCRIPTION
On current master, artwork in a centered column is not actually centered:

<img width="1624" alt="image" src="https://user-images.githubusercontent.com/637494/196546421-d8d2d2d2-1dd9-440d-84a3-20f9480147fd.png">

This PR resolves:

<img width="1624" alt="image" src="https://user-images.githubusercontent.com/637494/196546452-d98a3a66-4acf-494c-a47d-368d5269e820.png">

As a side benefit, it also resolves the same issue for right aligned images.