### PR TITLE
cocoaui: fix centered artwork (try 2)

### DIFF
--- a/plugins/cocoaui/Playlist/PlaylistViewController.m
+++ b/plugins/cocoaui/Playlist/PlaylistViewController.m
@@ -1034,10 +1034,10 @@ artwork_listener (ddb_artwork_listener_event_t event, void *user_data, int64_t p
     if (size.width < size.height) {
         plt_col_info_t *c = &self.columns[(int)col];
         if (c->alignment == ColumnAlignmentCenter) {
-            art_x += availableSize.width/2 - desiredSize.width/2;
+            art_x += art_width/2 - desiredSize.width/2;
         }
         else if (c->alignment == ColumnAlignmentRight) {
-            art_x += availableSize.width-desiredSize.width;
+            art_x += art_width-desiredSize.width;
         }
     }
     CGSize drawSize = [self.view convertSizeFromBacking:desiredSize];

--- a/plugins/cocoaui/Playlist/PlaylistViewController.m
+++ b/plugins/cocoaui/Playlist/PlaylistViewController.m
@@ -1030,17 +1030,17 @@ artwork_listener (ddb_artwork_listener_event_t event, void *user_data, int64_t p
 
     NSSize size = image.size;
     NSSize desiredSize = [CoverManager.shared desiredSizeForImageSize:size availableSize:availableSize];
-
+    CGSize drawSize = [self.view convertSizeFromBacking:desiredSize];
+    
     if (size.width < size.height) {
         plt_col_info_t *c = &self.columns[(int)col];
         if (c->alignment == ColumnAlignmentCenter) {
-            art_x += art_width/2 - desiredSize.width/2;
+            art_x += art_width/2 - drawSize.width/2;
         }
         else if (c->alignment == ColumnAlignmentRight) {
-            art_x += art_width-desiredSize.width;
+            art_x += art_width-drawSize.width;
         }
     }
-    CGSize drawSize = [self.view convertSizeFromBacking:desiredSize];
     drawRect = NSMakeRect(art_x, ypos, drawSize.width, drawSize.height);
 
     if (!grp->cachedImage) {


### PR DESCRIPTION
After further checking with a narrower image, https://github.com/DeaDBeeF-Player/deadbeef/pull/2875 wasn't quite right! It was calculating `art_x` in real display pixels rather than logical pixels, when the draw occurs in logical pixels. Sorry about that - it looked correct with an image that was only slightly narrower than the draw rect.

Updated examples below.

Old:
<img width="1624" alt="center-old" src="https://user-images.githubusercontent.com/637494/196551005-027c4fd1-81df-4de9-a58a-90fc63047d09.png">
<img width="1624" alt="right-old" src="https://user-images.githubusercontent.com/637494/196551020-938d09a2-808d-4d67-9273-792fcbe43735.png">

New:
<img width="1624" alt="center-new" src="https://user-images.githubusercontent.com/637494/196551060-aac65bd6-31b7-4745-8acf-7af0bd8a8183.png">
<img width="1624" alt="right-new" src="https://user-images.githubusercontent.com/637494/196551071-0adbf747-7e2e-4fca-b8a2-56967c296501.png">
