### PR TITLE
oss: cleanup the header handling

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -597,7 +597,7 @@ AS_IF([test "${enable_oss}" != "no"], [
         for i in `cat /etc/oss.conf`; do
             t=`echo $i | sed -e 's/OSSLIBDIR=//'`
             AS_IF([test "${i}" != "${t}"], [
-                AS_IF([test -f "${t}/include/sys/soundcard.h" -o -f "${i}/include/soundcard.h"], [
+                AS_IF([test -f "${t}/include/sys/soundcard.h"], [
                     OSS_CFLAGS="-I$t/include/sys"
                     AC_MSG_RESULT([$OSS_CFLAGS])
                     have_oss=yes

--- a/plugins/oss/oss.c
+++ b/plugins/oss/oss.c
@@ -25,11 +25,7 @@
 #endif
 #include <stdio.h>
 #include <string.h>
-#if HAVE_SYS_SOUNDCARD_H
 #include <sys/soundcard.h>
-#else
-#include <soundcard.h>
-#endif
 #include <fcntl.h>
 #include <sys/ioctl.h>
 #include <stdlib.h>


### PR DESCRIPTION
OpenBSD has not used OSS in quite awhile so remove checking for soundcard.h
outside of sys/, FreeBSD / NetBSD / DragonFly have the header in sys/.