### PR TITLE
Shuffle before play

### DIFF
--- a/plugins/pltbrowser/pltbrowser.c
+++ b/plugins/pltbrowser/pltbrowser.c
@@ -786,8 +786,10 @@ on_pltbrowser_popup_menu (GtkWidget *widget, gpointer user_data) {
 
 static void
 on_pltbrowser_row_activated (GtkTreeView *tree_view, GtkTreePath *path, GtkTreeViewColumn *column, gpointer user_data) {
-    if (deadbeef->conf_get_int ("gtkui.pltbrowser.play_on_double_click", 1))
-        deadbeef->sendmessage (DB_EV_PLAY_NUM, 0, 0, 0);
+    if (deadbeef->conf_get_int ("gtkui.pltbrowser.play_on_double_click", 1)) {
+        deadbeef->sendmessage (DB_EV_STOP, 0, 0, 0);
+        deadbeef->sendmessage (DB_EV_NEXT, 0, 0, 0);
+    }
 }
 
 static void


### PR DESCRIPTION
Adds a new event that shuffles the current playlist and then plays the first track. Also modifies the playlist double click setting to optionally use the new event.

The current implementation seems to always play the first track in the playlist and afterwards proceeds in the shuffle order but I'd prefer for the shuffling to determine the initial track, so I made this.

If you'd like something to be changed let me know.