### PR TITLE
Feature/multithreaded converter

### DIFF
--- a/plugins/converter/converter.c
+++ b/plugins/converter/converter.c
@@ -815,9 +815,9 @@ check_dir (const char *dir, mode_t mode)
         slash = strstr (slash+1, "/");
         if (slash)
             *slash = 0;
-        if (-1 == stat (tmp, &stat_buf))
+        if (0 != mkdir (tmp, mode))
         {
-            if (0 != mkdir (tmp, mode))
+            if (errno == EEXIST && (-1 == stat (tmp, &stat_buf)) || errno != EEXIST)
             {
                 trace ("Failed to create %s\n", tmp);
                 free (tmp);

--- a/plugins/converter/converter.c
+++ b/plugins/converter/converter.c
@@ -1585,10 +1585,6 @@ converter_stop (void) {
     return 0;
 }
 
-static const char settings_dialog[] =
-    "property \"Number of threads\" entry converter.threads 4;\n"
-;
-
 // define plugin interface
 static ddb_converter_t plugin = {
     .misc.plugin.api_vmajor = DB_API_VERSION_MAJOR,
@@ -1627,7 +1623,6 @@ static ddb_converter_t plugin = {
     .misc.plugin.start = converter_start,
     .misc.plugin.stop = converter_stop,
     .misc.plugin.command = converter_cmd,
-    .misc.plugin.configdialog = settings_dialog,
     .encoder_preset_alloc = encoder_preset_alloc,
     .encoder_preset_free = encoder_preset_free,
     .encoder_preset_load = encoder_preset_load,

--- a/plugins/converter/converter.c
+++ b/plugins/converter/converter.c
@@ -202,7 +202,7 @@ encoder_preset_save (ddb_encoder_preset_t *p, int overwrite) {
         FILE *fp = fopen (path, "rb");
         if (fp) {
             fclose (fp);
-            return -2; 
+            return -2;
         }
     }
 
@@ -408,7 +408,7 @@ dsp_preset_save (ddb_dsp_preset_t *p, int overwrite) {
         FILE *fp = fopen (path, "rb");
         if (fp) {
             fclose (fp);
-            return -2; 
+            return -2;
         }
     }
 
@@ -1585,6 +1585,10 @@ converter_stop (void) {
     return 0;
 }
 
+static const char settings_dialog[] =
+    "property \"Number of threads\" entry converter.threads 4;\n"
+;
+
 // define plugin interface
 static ddb_converter_t plugin = {
     .misc.plugin.api_vmajor = DB_API_VERSION_MAJOR,
@@ -1597,7 +1601,7 @@ static ddb_converter_t plugin = {
     .misc.plugin.id = "converter",
     .misc.plugin.descr = "Converts any supported formats to other formats.\n"
         "Requires separate GUI plugin, e.g. Converter GTK UI\n",
-    .misc.plugin.copyright = 
+    .misc.plugin.copyright =
         "Converter for DeaDBeeF Player\n"
         "Copyright (C) 2009-2015 Oleksiy Yakovenko and other contributors\n"
         "\n"
@@ -1623,6 +1627,7 @@ static ddb_converter_t plugin = {
     .misc.plugin.start = converter_start,
     .misc.plugin.stop = converter_stop,
     .misc.plugin.command = converter_cmd,
+    .misc.plugin.configdialog = settings_dialog,
     .encoder_preset_alloc = encoder_preset_alloc,
     .encoder_preset_free = encoder_preset_free,
     .encoder_preset_load = encoder_preset_load,

--- a/plugins/converter/converter.h
+++ b/plugins/converter/converter.h
@@ -265,6 +265,25 @@ typedef struct {
          // *pabort will be checked regularly, conversion will be interrupted if it's non-zero
          int *pabort
     );
+
+    // for multi-threaded calls since 1.9.3
+    int
+    (*convert3) (
+         // converter settings
+         ddb_converter_settings_t *settings,
+
+         // track to convert
+         DB_playItem_t *it,
+
+         // fully qualified output path with filename and extension
+         const char *outpath,
+
+         // read lock for accessing pabort
+         pthread_rwlock_t *abort_lock,
+
+         // *pabort will be checked regularly, conversion will be interrupted if it's non-zero
+         int *pabort
+    );
 } ddb_converter_t;
 
 #endif

--- a/plugins/converter/converter.h
+++ b/plugins/converter/converter.h
@@ -101,6 +101,14 @@ typedef struct ddb_converter_settings_s {
     int rewrite_tags_after_copy;
 } ddb_converter_settings_t;
 
+typedef struct ddb_converter_abort_status_s {
+    pthread_rwlock_t *lock;
+    int *abort;
+} ddb_converter_abort_status_t;
+
+int
+ddb_get_abort_status_lock (ddb_converter_abort_status_t *abort_status);
+
 typedef struct {
     DB_misc_t misc;
 
@@ -278,11 +286,8 @@ typedef struct {
          // fully qualified output path with filename and extension
          const char *outpath,
 
-         // read lock for accessing pabort
-         pthread_rwlock_t *abort_lock,
-
-         // *pabort will be checked regularly, conversion will be interrupted if it's non-zero
-         int *pabort
+         // *abort_status is checked regularly, conversion is stopped if ddb_get_abort_lock_status return non-zero values
+         ddb_converter_abort_status_t *abort_status
     );
 } ddb_converter_t;
 

--- a/plugins/converter/convgui.c
+++ b/plugins/converter/convgui.c
@@ -147,8 +147,8 @@ free_conversion_utils (converter_ctx_t *conv) {
         free (conv->outfile);
         converter_plugin->encoder_preset_free (conv->encoder_preset);
         converter_plugin->dsp_preset_free (conv->dsp_preset);
+        free (conv);
     }
-    free (conv);
 }
 
 typedef struct {
@@ -215,8 +215,8 @@ free_converter_thread_msgs(converter_thread_ctx_t *self)
     if(self->conv_msgs) {
         for(int k = 0; k < self->threads; ++k)
             free(self->conv_msgs[k]);
+        free(self->conv_msgs);
     }
-    free(self->conv_msgs);
 }
 
 void

--- a/plugins/converter/convgui.c
+++ b/plugins/converter/convgui.c
@@ -130,8 +130,9 @@ get_folder_root (converter_ctx_t *self, char* root) {
 }
 
 static gboolean
-destroy_progress_cb (gpointer ctx) {
-    gtk_widget_destroy (ctx);
+destroy_progress_cb (gpointer progress_dialog) {
+    gtk_widget_destroy (progress_dialog);
+    g_object_unref (progress_dialog);
     return FALSE;
 }
 
@@ -612,6 +613,7 @@ converter_process (converter_ctx_t *conv)
 
     GtkWidget *progress_dialog = gtk_dialog_new_with_buttons (_("Converting..."), GTK_WINDOW (gtkui_plugin->get_mainwin ()), GTK_DIALOG_DESTROY_WITH_PARENT, GTK_STOCK_CANCEL, GTK_RESPONSE_CANCEL, NULL);
     conv->progress_dialog = progress_dialog;
+    g_object_ref (progress_dialog);
     conv->text = add_scrolled_text(progress_dialog);
 
 

--- a/plugins/converter/convgui.c
+++ b/plugins/converter/convgui.c
@@ -290,14 +290,13 @@ on_converter_realize                 (GtkWidget        *widget,
 
 typedef struct {
     GtkWidget *entry;
-    char *text;
+    char text[2048];
 } update_progress_info_t;
 
 static gboolean
 update_progress_cb (gpointer ctx) {
     update_progress_info_t *info = ctx;
     gtk_entry_set_text (GTK_ENTRY (info->entry), info->text);
-    free (info->text);
     g_object_unref (info->entry);
     free (info);
     return FALSE;
@@ -370,7 +369,7 @@ try_convert_item (converter_thread_ctx_t *self, DB_playItem_t *item) {
     info->entry = conv->progress_entry;
     g_object_ref (info->entry);
     deadbeef->pl_lock ();
-    info->text = strdup (deadbeef->pl_find_meta (item, ":URI"));
+    snprintf (info->text, sizeof(info->text), "%s (from: %s)", deadbeef->pl_find_meta_raw(item, "title"), deadbeef->pl_find_meta (item, ":URI"));
     deadbeef->pl_unlock ();
     g_idle_add (update_progress_cb, info);
 
@@ -498,7 +497,7 @@ converter_process (converter_ctx_t *conv)
     GtkWidget *progress = gtk_dialog_new_with_buttons (_("Converting..."), GTK_WINDOW (gtkui_plugin->get_mainwin ()), GTK_DIALOG_DESTROY_WITH_PARENT, GTK_STOCK_CANCEL, GTK_RESPONSE_CANCEL, NULL);
     GtkWidget *vbox = gtk_dialog_get_content_area (GTK_DIALOG (progress));
     GtkWidget *entry = gtk_entry_new ();
-    gtk_widget_set_size_request (entry, 400, -1);
+    gtk_widget_set_size_request (entry, 600, -1);
     gtk_editable_set_editable (GTK_EDITABLE (entry), FALSE);
     gtk_widget_show (entry);
     gtk_box_pack_start (GTK_BOX (vbox), entry, TRUE, TRUE, 12);

--- a/plugins/converter/convgui.c
+++ b/plugins/converter/convgui.c
@@ -177,7 +177,7 @@ get_converter_thread_item(converter_thread_ctx_t *self, int index)
 static int
 get_converter_thread_relative_item_id(converter_thread_ctx_t *self, int item_index)
 {
-    return item_index % self->threads;
+    return item_index % self->threads + 1;
 }
 
 static void
@@ -317,7 +317,7 @@ update_progress_cb (gpointer ctx) {
 static int
 print_progress_msg (char *buffer, size_t buffer_size, DB_playItem_t *item, int relative_item_id) {
     deadbeef->pl_lock ();
-    int bytes = snprintf (buffer, buffer_size, "Thread %02d: %s (from: %s)", relative_item_id, deadbeef->pl_find_meta_raw(item, "title"), deadbeef->pl_find_meta (item, ":URI"));
+    int bytes = snprintf (buffer, buffer_size, "Th %02d: '%s' (from: %s)\n", relative_item_id, deadbeef->pl_find_meta_raw(item, "title"), deadbeef->pl_find_meta (item, ":URI"));
     deadbeef->pl_unlock ();
     return bytes;
 }

--- a/plugins/converter/convgui.c
+++ b/plugins/converter/convgui.c
@@ -615,7 +615,7 @@ converter_process (converter_ctx_t *conv)
 
     converter_thread_ctx_t* thread_ctx = make_converter_thread_ctx (conv, get_config_number_of_threads(), 1024);
     g_signal_connect ((gpointer)progress_dialog, "response", G_CALLBACK (on_converter_progress_cancel), thread_ctx);
-    gtk_window_set_default_size(GTK_WINDOW(progress_dialog), 600, 30 * thread_ctx->threads);
+    gtk_window_set_default_size(GTK_WINDOW(progress_dialog), 720, 30 * thread_ctx->threads);
     gtk_widget_show_all(progress_dialog);
 
     intptr_t tid = deadbeef->thread_start (converter_worker, thread_ctx);

--- a/plugins/converter/convgui.c
+++ b/plugins/converter/convgui.c
@@ -621,8 +621,8 @@ converter_process (converter_ctx_t *conv)
 
     converter_thread_ctx_t* thread_ctx = make_converter_thread_ctx (conv, get_gui_num_threads (conv), PATH_MAX);
     g_signal_connect (progress_dialog, "response", G_CALLBACK (on_converter_progress_cancel), thread_ctx);
-    gtk_window_set_default_size(GTK_WINDOW(progress_dialog), 720, 28 * thread_ctx->threads);
-    gtk_widget_show_all(progress_dialog);
+    gtk_window_set_default_size (GTK_WINDOW(progress_dialog), 720, 28 * thread_ctx->threads);
+    gtk_widget_show_all (progress_dialog);
 
     intptr_t tid = deadbeef->thread_start (converter_worker, thread_ctx);
     deadbeef->thread_detach (tid);

--- a/plugins/converter/convgui.c
+++ b/plugins/converter/convgui.c
@@ -210,6 +210,7 @@ void
 free_converter_thread_utils (converter_thread_ctx_t *self) {
     free_conversion_utils (self->conv);
     free_converter_thread_ctx (self);
+    free (self);
 }
 
 static int
@@ -458,14 +459,12 @@ converter_thread_worker (void *ctx) {
 }
 
 static void
-create_pool_threads(converter_thread_ctx_t* self)
-{
+create_pool_threads(converter_thread_ctx_t* self) {
     for(int k = 0; k < self->threads; ++k)
         pthread_create(&self->pids[k], NULL, &converter_thread_worker, (void*)self);
 }
 
-static void join_pool_threads(converter_thread_ctx_t* self)
-{
+static void join_pool_threads(converter_thread_ctx_t* self) {
     for(int k = 0; k < self->threads; ++k)
         pthread_join(self->pids[k], NULL);
 }
@@ -481,12 +480,10 @@ converter_worker (void *ctx) {
         unref_convert_items (conv->convert_items, thread_ctx->next_index, conv->convert_items_count);
     }
     free_converter_thread_utils (thread_ctx);
-    free (thread_ctx);
     deadbeef->background_job_decrement ();
 }
 
-static void set_monospace(GtkTextView* text_view)
-{
+static void set_monospace(GtkTextView *text_view) {
 #if GTK_CHECK_VERSION(3,0,0)
     GtkStyleContext *context = gtk_widget_get_style_context(GTK_WIDGET(text_view));
     GtkCssProvider *provider = gtk_css_provider_new();
@@ -509,14 +506,14 @@ GtkTextView* create_mono_text()
     return text_view;
 }
 
-static GtkWidget*
-add_scrolled_window(GtkWidget* dialog)
+static GtkTextBuffer*
+add_scrolled_text(GtkWidget *dialog)
 {
     GtkWidget *scrolled_window = gtk_scrolled_window_new(NULL, NULL);
     GtkTextView *text_view = create_mono_text();
     gtk_container_add(GTK_CONTAINER(scrolled_window), GTK_WIDGET(text_view));
     gtk_box_pack_start(GTK_BOX(gtk_dialog_get_content_area(GTK_DIALOG(dialog))), scrolled_window, TRUE, TRUE, 0);
-    return scrolled_window;
+    return gtk_text_view_get_buffer (text_view);
 }
 
 static void

--- a/plugins/converter/convgui.c
+++ b/plugins/converter/convgui.c
@@ -862,6 +862,9 @@ converter_show_cb (void *data) {
     gtk_combo_box_set_active (GTK_COMBO_BOX (lookup_widget (conv->converter, "overwrite_action")), deadbeef->conf_get_int ("converter.overwrite_action", 0));
     deadbeef->conf_unlock ();
 
+    GtkWidget *numthreads = lookup_widget (conv->converter, "numthreads");
+    gtk_spin_button_set_value (GTK_SPIN_BUTTON (numthreads), get_config_number_of_threads());
+
     GtkComboBox *combo;
     // fill encoder presets
     combo = GTK_COMBO_BOX (lookup_widget (conv->converter, "encoder"));

--- a/plugins/converter/convgui.c
+++ b/plugins/converter/convgui.c
@@ -350,10 +350,12 @@ print_progress_msg (char *buffer, size_t buffer_size, DB_playItem_t *item, int r
 static update_progress_info_t*
 make_progress_info (converter_thread_ctx_t *self, int item_id) {
     update_progress_info_t *info = malloc (sizeof (*info));
-    info->text_view = self->conv->text_view;
-    g_object_ref (info->text_view);
-    info->relative_item_id = get_converter_thread_relative_item_id(self, item_id);
-    info->item_msg = self->conv_msgs[info->relative_item_id];
+    if (info) {
+        info->text_view = self->conv->text_view;
+        g_object_ref (info->text_view);
+        info->relative_item_id = get_converter_thread_relative_item_id(self, item_id);
+        info->item_msg = self->conv_msgs[info->relative_item_id];
+    }
     return info;
 }
 

--- a/plugins/converter/convgui.c
+++ b/plugins/converter/convgui.c
@@ -485,17 +485,38 @@ converter_worker (void *ctx) {
     deadbeef->background_job_decrement ();
 }
 
-static GtkTextBuffer*
-add_scrolled_text(GtkWidget* dialog)
+static void set_monospace(GtkTextView* text_view)
 {
-    GtkScrolledWindow* scrolled_window = GTK_SCROLLED_WINDOW(gtk_scrolled_window_new(NULL, NULL));
+#if GTK_CHECK_VERSION(3,0,0)
+    GtkStyleContext *context = gtk_widget_get_style_context(GTK_WIDGET(text_view));
+    GtkCssProvider *provider = gtk_css_provider_new();
+    gtk_css_provider_load_from_data(provider, "textview {font-family: \"monospace\";}", -1, NULL);
+    gtk_style_context_add_provider(context, GTK_STYLE_PROVIDER(provider), GTK_STYLE_PROVIDER_PRIORITY_APPLICATION);
+#else
+    PangoFontDescription *descr = pango_font_description_from_string("monospace");
+    gtk_widget_modify_font(GTK_WIDGET(text_view), descr);
+    pango_font_description_free(descr);
+#endif
+}
+
+GtkTextView* create_mono_text()
+{
     GtkTextView* text_view = GTK_TEXT_VIEW(gtk_text_view_new());
     gtk_text_view_set_left_margin(text_view, 5);
     gtk_text_view_set_right_margin(text_view, 5);
+    set_monospace(text_view);
     gtk_text_view_set_editable(text_view, FALSE);
+    return text_view;
+}
+
+static GtkWidget*
+add_scrolled_window(GtkWidget* dialog)
+{
+    GtkWidget *scrolled_window = gtk_scrolled_window_new(NULL, NULL);
+    GtkTextView *text_view = create_mono_text();
     gtk_container_add(GTK_CONTAINER(scrolled_window), GTK_WIDGET(text_view));
-    gtk_box_pack_start(GTK_BOX(gtk_dialog_get_content_area(GTK_DIALOG(dialog))), GTK_WIDGET(scrolled_window), TRUE, TRUE, 0);
-    return gtk_text_view_get_buffer(text_view);
+    gtk_box_pack_start(GTK_BOX(gtk_dialog_get_content_area(GTK_DIALOG(dialog))), scrolled_window, TRUE, TRUE, 0);
+    return scrolled_window;
 }
 
 static void

--- a/plugins/converter/convgui.c
+++ b/plugins/converter/convgui.c
@@ -302,7 +302,7 @@ on_converter_realize                 (GtkWidget        *widget,
 
 typedef struct {
     GtkTextView *text_view;
-    char text[8*1024];
+    char text[64*1024];
 } update_progress_info_t;
 
 static gboolean

--- a/plugins/converter/convgui.c
+++ b/plugins/converter/convgui.c
@@ -369,7 +369,7 @@ make_start_progress_info(converter_thread_ctx_t *self, int item_id) {
 static update_progress_info_t*
 make_end_progress_info(converter_thread_ctx_t *self, int item_id) {
     update_progress_info_t *info = make_progress_info (self, item_id);
-    snprintf (info->item_msg, self->msg_size, "[#%02d] done\n", info->relative_item_id + 1);
+    snprintf (info->item_msg, self->msg_size, "[#%02d] idle\n", info->relative_item_id + 1);
     return info;
 }
 

--- a/plugins/converter/convgui.c
+++ b/plugins/converter/convgui.c
@@ -166,7 +166,7 @@ typedef struct {
 static int
 get_config_number_of_threads()
 {
-    int number_of_threads = deadbeef->conf_get_int("converter.threads", 0);
+    int number_of_threads = deadbeef->conf_get_int("converter.threads", 1);
     if(number_of_threads <= 0) number_of_threads = 1;//against negative user value
     return number_of_threads;
 }

--- a/plugins/converter/convgui.c
+++ b/plugins/converter/convgui.c
@@ -67,7 +67,7 @@ typedef struct {
     ddb_encoder_preset_t *encoder_preset;
     ddb_dsp_preset_t *dsp_preset;
     GtkWidget *progress_dialog;
-    GtkTextBuffer *text;
+    GtkTextBuffer *text_buffer;
     int cancelled;
 } converter_ctx_t;
 
@@ -308,7 +308,7 @@ static progress_info_t*
 make_progress_info (converter_thread_ctx_t *self, int item_id) {
     progress_info_t *info = malloc (sizeof (*info));
     if (info) {
-        info->buffer = self->conv->text;
+        info->buffer = self->conv->text_buffer;
         info->thread_id = get_converter_thread_relative_item_id(self, item_id);
         info->item_msg = malloc (self->msg_size);
     }
@@ -614,7 +614,7 @@ converter_process (converter_ctx_t *conv)
     GtkWidget *progress_dialog = gtk_dialog_new_with_buttons (_("Converting..."), GTK_WINDOW (gtkui_plugin->get_mainwin ()), GTK_DIALOG_DESTROY_WITH_PARENT, GTK_STOCK_CANCEL, GTK_RESPONSE_CANCEL, NULL);
     conv->progress_dialog = progress_dialog;
     g_object_ref (progress_dialog);
-    conv->text = add_scrolled_text(progress_dialog);
+    conv->text_buffer = add_scrolled_text(progress_dialog);
 
 
     converter_thread_ctx_t* thread_ctx = make_converter_thread_ctx (conv, get_gui_num_threads (conv), PATH_MAX);

--- a/plugins/converter/convgui.c
+++ b/plugins/converter/convgui.c
@@ -441,8 +441,7 @@ try_convert (shared_converter_ctx_t *self, int item_id) {
     converter_plugin->get_output_path2 (item, conv->convert_playlist, conv->outfolder, conv->outfile, conv->encoder_preset, conv->preserve_folder_structure, self->root, conv->write_to_source_folder, outpath, sizeof (outpath));
     int skip = get_skip_conversion (item, outpath, conv);
     if (!skip) {
-        int cancelled = get_shared_converter_cancel_lock (self);
-        converter_plugin->convert2 (&self->settings, item, outpath, &cancelled);
+        converter_plugin->convert3 (&self->settings, item, outpath, &self->cancel_lock, &self->conv->cancelled);
     }
 }
 

--- a/plugins/converter/convgui.c
+++ b/plugins/converter/convgui.c
@@ -342,7 +342,7 @@ update_progress_cb (gpointer ctx) {
 static int
 print_progress_msg (char *buffer, size_t buffer_size, DB_playItem_t *item, int relative_item_id) {
     deadbeef->pl_lock ();
-    int bytes = snprintf (buffer, buffer_size, "Th %02d: '%s' (from: %s)\n", relative_item_id + 1, deadbeef->pl_find_meta_raw(item, "title"), deadbeef->pl_find_meta (item, ":URI"));
+    int bytes = snprintf (buffer, buffer_size, "[#%02d] '%s' (%s)\n", relative_item_id + 1, deadbeef->pl_find_meta_raw(item, "title"), deadbeef->pl_find_meta (item, ":URI"));
     deadbeef->pl_unlock ();
     return bytes;
 }
@@ -368,7 +368,7 @@ make_start_progress_info(converter_thread_ctx_t *self, int item_id) {
 static update_progress_info_t*
 make_end_progress_info(converter_thread_ctx_t *self, int item_id) {
     update_progress_info_t *info = make_progress_info (self, item_id);
-    snprintf (info->item_msg, self->msg_size, "Th %02d: done\n", info->relative_item_id + 1);
+    snprintf (info->item_msg, self->msg_size, "[#%02d] done\n", info->relative_item_id + 1);
     return info;
 }
 

--- a/plugins/converter/convgui.c
+++ b/plugins/converter/convgui.c
@@ -90,8 +90,6 @@ get_useful_number_of_threads(const converter_ctx_t *self, int req_threads) {
     return req_threads < self->convert_items_count ? req_threads : self->convert_items_count;
 }
 
-
-
 static void
 get_folder_root (converter_ctx_t *self, char* root) {
     int rootlen = 0;
@@ -452,7 +450,6 @@ try_convert (converter_thread_ctx_t *self, int item_id) {
         converter_plugin->convert2 (&self->settings, item, outpath, &cancelled);
     }
 }
-
 
 static void
 update_gui_convert (converter_thread_ctx_t *self, int item_id) {

--- a/plugins/converter/convgui.c
+++ b/plugins/converter/convgui.c
@@ -318,7 +318,7 @@ typedef struct {
 } thread_converter_ctx_t;
 
 static progress_info_t*
-make_progress_info (thread_converter_ctx_t *self, int item_id) {
+make_progress_info (thread_converter_ctx_t *self) {
     progress_info_t *info = malloc (sizeof (*info));
     if (info) {
         shared_converter_ctx_t *shared_ctx = self->shared_ctx;
@@ -345,7 +345,7 @@ print_idle_progress_msg (char *buffer, size_t buffer_size, int thread_id) {
 
 static progress_info_t*
 make_start_progress_info(thread_converter_ctx_t *self, int item_id) {
-    progress_info_t *info = make_progress_info (self, item_id);
+    progress_info_t *info = make_progress_info (self);
     g_object_ref (info->buffer); //increment further in start because buffer may be GUI-destroyed after the first free_progress_info
     DB_playItem_t *item = get_shared_converter_item (self->shared_ctx, item_id);
     print_active_progress_msg (info->item_msg, self->shared_ctx->msg_size, item, info->thread_id);
@@ -353,8 +353,8 @@ make_start_progress_info(thread_converter_ctx_t *self, int item_id) {
 }
 
 static progress_info_t*
-make_end_progress_info(thread_converter_ctx_t *self, int item_id) {
-    progress_info_t *info = make_progress_info (self, item_id);
+make_end_progress_info(thread_converter_ctx_t *self) {
+    progress_info_t *info = make_progress_info (self);
     g_object_unref (info->buffer); //make_end_progress_info is executed even after GUI destruction, we cancel the start increment
     print_idle_progress_msg (info->item_msg, self->shared_ctx->msg_size, info->thread_id);
     return info;
@@ -451,7 +451,7 @@ update_gui_convert (thread_converter_ctx_t *self, int item_id) {
     progress_info_t *start_info = make_start_progress_info(self, item_id);
     g_idle_add (update_progress_cb, start_info);
     try_convert (self->shared_ctx, item_id);
-    progress_info_t *end_info = make_end_progress_info(self, item_id);
+    progress_info_t *end_info = make_end_progress_info(self);
     g_idle_add (update_progress_cb, end_info);
 }
 

--- a/plugins/converter/convgui.c
+++ b/plugins/converter/convgui.c
@@ -532,7 +532,7 @@ converter_process (converter_ctx_t *conv)
 
     converter_thread_ctx_t* thread_ctx = make_converter_thread_ctx (conv, get_number_of_threads());
     g_signal_connect ((gpointer)progress_dialog, "response", G_CALLBACK (on_converter_progress_cancel), thread_ctx);
-    gtk_window_set_default_size(GTK_WINDOW(progress_dialog), 600, 10 * thread_ctx->threads);
+    gtk_window_set_default_size(GTK_WINDOW(progress_dialog), 600, 30 * thread_ctx->threads);
     gtk_widget_show_all(progress_dialog);
 
     conv->progress_dialog = progress_dialog;

--- a/plugins/converter/convgui.c
+++ b/plugins/converter/convgui.c
@@ -441,7 +441,11 @@ try_convert (shared_converter_ctx_t *self, int item_id) {
     converter_plugin->get_output_path2 (item, conv->convert_playlist, conv->outfolder, conv->outfile, conv->encoder_preset, conv->preserve_folder_structure, self->root, conv->write_to_source_folder, outpath, sizeof (outpath));
     int skip = get_skip_conversion (item, outpath, conv);
     if (!skip) {
-        converter_plugin->convert3 (&self->settings, item, outpath, &self->cancel_lock, &self->conv->cancelled);
+        ddb_converter_abort_status_t abort_status = {
+            .lock = &self->cancel_lock,
+            .abort = &self->conv->cancelled
+        };
+        converter_plugin->convert3 (&self->settings, item, outpath, &abort_status);
     }
 }
 

--- a/plugins/converter/convgui.c
+++ b/plugins/converter/convgui.c
@@ -615,7 +615,7 @@ converter_process (converter_ctx_t *conv)
 
     converter_thread_ctx_t* thread_ctx = make_converter_thread_ctx (conv, get_config_number_of_threads(), 1024);
     g_signal_connect ((gpointer)progress_dialog, "response", G_CALLBACK (on_converter_progress_cancel), thread_ctx);
-    gtk_window_set_default_size(GTK_WINDOW(progress_dialog), 720, 30 * thread_ctx->threads);
+    gtk_window_set_default_size(GTK_WINDOW(progress_dialog), 720, 28 * thread_ctx->threads);
     gtk_widget_show_all(progress_dialog);
 
     intptr_t tid = deadbeef->thread_start (converter_worker, thread_ctx);

--- a/plugins/converter/convgui.c
+++ b/plugins/converter/convgui.c
@@ -177,7 +177,7 @@ get_converter_thread_item(converter_thread_ctx_t *self, int index)
 static int
 get_converter_thread_relative_item_id(converter_thread_ctx_t *self, int item_index)
 {
-    return item_index % self->threads + 1;
+    return item_index % self->threads;
 }
 
 static void
@@ -317,7 +317,7 @@ update_progress_cb (gpointer ctx) {
 static int
 print_progress_msg (char *buffer, size_t buffer_size, DB_playItem_t *item, int relative_item_id) {
     deadbeef->pl_lock ();
-    int bytes = snprintf (buffer, buffer_size, "Th %02d: '%s' (from: %s)\n", relative_item_id, deadbeef->pl_find_meta_raw(item, "title"), deadbeef->pl_find_meta (item, ":URI"));
+    int bytes = snprintf (buffer, buffer_size, "Th %02d: '%s' (from: %s)\n", relative_item_id + 1, deadbeef->pl_find_meta_raw(item, "title"), deadbeef->pl_find_meta (item, ":URI"));
     deadbeef->pl_unlock ();
     return bytes;
 }

--- a/plugins/converter/convgui.c
+++ b/plugins/converter/convgui.c
@@ -308,6 +308,7 @@ static progress_info_t*
 make_progress_info (converter_thread_ctx_t *self, int item_id) {
     progress_info_t *info = malloc (sizeof (*info));
     if (info) {
+        g_object_ref (self->conv->text_buffer);
         info->buffer = self->conv->text_buffer;
         info->thread_id = get_converter_thread_relative_item_id(self, item_id);
         info->item_msg = malloc (self->msg_size);
@@ -341,6 +342,7 @@ make_end_progress_info(converter_thread_ctx_t *self, int item_id) {
 static void
 free_progress_info (progress_info_t* self) {
     if (self) {
+        g_object_unref (self->buffer);
         free(self->item_msg);
     }
 }
@@ -613,7 +615,7 @@ converter_process (converter_ctx_t *conv)
 
     GtkWidget *progress_dialog = gtk_dialog_new_with_buttons (_("Converting..."), GTK_WINDOW (gtkui_plugin->get_mainwin ()), GTK_DIALOG_DESTROY_WITH_PARENT, GTK_STOCK_CANCEL, GTK_RESPONSE_CANCEL, NULL);
     conv->progress_dialog = progress_dialog;
-    g_object_ref (progress_dialog);
+    g_object_ref (conv->progress_dialog);
     conv->text_buffer = add_scrolled_text(progress_dialog);
 
 

--- a/plugins/converter/convgui.c
+++ b/plugins/converter/convgui.c
@@ -598,7 +598,7 @@ converter_process (converter_ctx_t *conv)
 
 
     converter_thread_ctx_t* thread_ctx = make_converter_thread_ctx (conv, get_gui_num_threads (conv), PATH_MAX);
-    g_signal_connect ((gpointer)progress_dialog, "response", G_CALLBACK (on_converter_progress_cancel), thread_ctx);
+    g_signal_connect (progress_dialog, "response", G_CALLBACK (on_converter_progress_cancel), thread_ctx);
     gtk_window_set_default_size(GTK_WINDOW(progress_dialog), 720, 28 * thread_ctx->threads);
     gtk_widget_show_all(progress_dialog);
 

--- a/plugins/converter/convgui.c
+++ b/plugins/converter/convgui.c
@@ -330,9 +330,11 @@ typedef struct {
 static gboolean
 update_progress_cb (gpointer ctx) {
     update_progress_info_t *info = ctx;
-    GtkTextIter iter;
-    gtk_text_buffer_get_iter_at_line (info->buffer, &iter, info->relative_item_id);
-    gtk_text_buffer_insert (info->buffer, &iter, info->item_msg, -1);
+    GtkTextIter start, end;
+    gtk_text_buffer_get_iter_at_line (info->buffer, &start, info->relative_item_id);
+    gtk_text_buffer_get_iter_at_line (info->buffer, &end, info->relative_item_id + 1);
+    gtk_text_buffer_delete (info->buffer, &start, &end);
+    gtk_text_buffer_insert (info->buffer, &start, info->item_msg, -1);
     free (info);
     return FALSE;
 }

--- a/plugins/converter/convgui.c
+++ b/plugins/converter/convgui.c
@@ -164,14 +164,6 @@ typedef struct {
     char root[2000];
 } converter_thread_ctx_t;
 
-static int
-get_config_number_of_threads()
-{
-    int number_of_threads = deadbeef->conf_get_int("converter.threads", 1);
-    if(number_of_threads <= 0) number_of_threads = 1;//against negative user value
-    return number_of_threads;
-}
-
 static DB_playItem_t*
 get_converter_thread_item(converter_thread_ctx_t *self, int index)
 {
@@ -603,6 +595,12 @@ converter_setup_from_gui (converter_ctx_t *conv) {
     return converter_setup_encoder_settings_from_gui (conv);
 }
 
+static int
+get_gui_num_threads (converter_ctx_t *conv) {
+    GtkWidget *numthreads = lookup_widget (conv->converter, "numthreads");
+    return gtk_spin_button_get_value_as_int (GTK_SPIN_BUTTON (numthreads));
+}
+
 int
 converter_process (converter_ctx_t *conv)
 {
@@ -613,7 +611,8 @@ converter_process (converter_ctx_t *conv)
     conv->progress_dialog = progress_dialog;
     conv->text = add_scrolled_text(progress_dialog);
 
-    converter_thread_ctx_t* thread_ctx = make_converter_thread_ctx (conv, get_config_number_of_threads(), 1024);
+
+    converter_thread_ctx_t* thread_ctx = make_converter_thread_ctx (conv, get_gui_num_threads (conv), PATH_MAX);
     g_signal_connect ((gpointer)progress_dialog, "response", G_CALLBACK (on_converter_progress_cancel), thread_ctx);
     gtk_window_set_default_size(GTK_WINDOW(progress_dialog), 720, 28 * thread_ctx->threads);
     gtk_widget_show_all(progress_dialog);
@@ -863,7 +862,7 @@ converter_show_cb (void *data) {
     deadbeef->conf_unlock ();
 
     GtkWidget *numthreads = lookup_widget (conv->converter, "numthreads");
-    gtk_spin_button_set_value (GTK_SPIN_BUTTON (numthreads), get_config_number_of_threads());
+    gtk_spin_button_set_value (GTK_SPIN_BUTTON (numthreads), deadbeef->conf_get_int("converter.threads", 1));
 
     GtkComboBox *combo;
     // fill encoder presets

--- a/plugins/converter/convgui.c
+++ b/plugins/converter/convgui.c
@@ -86,7 +86,7 @@ ddb_converter_settings_t get_converter_settings (converter_ctx_t *conv) {
 }
 
 static int
-get_useful_number_of_threads(const converter_ctx_t *self, int req_threads) {
+get_useful_num_threads(const converter_ctx_t *self, int req_threads) {
     if (req_threads <= 0) req_threads = 1;
     return req_threads < self->convert_items_count ? req_threads : self->convert_items_count;
 }
@@ -199,7 +199,7 @@ static void
 init_converter_thread_ctx(converter_thread_ctx_t *thread_ctx, converter_ctx_t *conv, int threads, size_t msg_size)
 {
     thread_ctx->next_index = 0;
-    thread_ctx->threads = get_useful_number_of_threads(conv, threads);
+    thread_ctx->threads = get_useful_num_threads (conv, threads);
     thread_ctx->pids = malloc(thread_ctx->threads * sizeof(pthread_t));
     pthread_mutex_init(&thread_ctx->item_mutex, NULL);
     pthread_rwlock_init(&thread_ctx->cancel_lock, NULL);

--- a/plugins/converter/convgui.c
+++ b/plugins/converter/convgui.c
@@ -626,6 +626,13 @@ get_gui_num_threads (converter_ctx_t *conv) {
     return gtk_spin_button_get_value_as_int (GTK_SPIN_BUTTON (numthreads));
 }
 
+static void
+init_conv_buffer_text (converter_ctx_t *conv, int threads) {
+    char text[threads];
+    memset (text, '\n', threads);
+    gtk_text_buffer_set_text (conv->text_buffer, text, threads);
+}
+
 int
 converter_process (converter_ctx_t *conv)
 {
@@ -640,6 +647,7 @@ converter_process (converter_ctx_t *conv)
     shared_converter_ctx_t* shared_ctx = make_shared_converter_ctx (conv, get_gui_num_threads (conv), PATH_MAX);
     g_signal_connect (progress_dialog, "response", G_CALLBACK (on_converter_progress_cancel), shared_ctx);
     gtk_window_set_default_size (GTK_WINDOW(progress_dialog), 720, 28 * shared_ctx->threads);
+    init_conv_buffer_text (conv, shared_ctx->threads);
     gtk_widget_show_all (progress_dialog);
 
     intptr_t tid = deadbeef->thread_start (converter_worker, shared_ctx);

--- a/plugins/converter/convgui.c
+++ b/plugins/converter/convgui.c
@@ -617,7 +617,7 @@ converter_process (converter_ctx_t *conv)
     conv->progress_dialog = progress_dialog;
     g_object_ref (conv->progress_dialog);
     conv->text_buffer = add_scrolled_text(progress_dialog);
-
+    g_object_ref (conv->text_buffer);
 
     converter_thread_ctx_t* thread_ctx = make_converter_thread_ctx (conv, get_gui_num_threads (conv), PATH_MAX);
     g_signal_connect (progress_dialog, "response", G_CALLBACK (on_converter_progress_cancel), thread_ctx);

--- a/plugins/converter/convgui.c
+++ b/plugins/converter/convgui.c
@@ -71,6 +71,8 @@ typedef struct {
     int cancelled;
 } converter_ctx_t;
 
+converter_ctx_t *current_ctx;
+
 typedef struct {
     int next_index;
     int threads;

--- a/plugins/converter/convgui.c
+++ b/plugins/converter/convgui.c
@@ -131,21 +131,17 @@ destroy_progress_cb (gpointer ctx) {
 
 static void
 free_conversion_utils (converter_ctx_t *conv) {
-    g_idle_add (destroy_progress_cb, conv->progress_dialog);
-    if (conv->convert_items) {
+    if(conv) {
+        g_idle_add (destroy_progress_cb, conv->progress_dialog);
         free (conv->convert_items);
-    }
-    if (conv->convert_playlist) {
-        deadbeef->plt_unref (conv->convert_playlist);
-    }
-    if (conv->outfolder) {
+        if (conv->convert_playlist) {
+            deadbeef->plt_unref (conv->convert_playlist);
+        }
         free (conv->outfolder);
-    }
-    if (conv->outfile) {
         free (conv->outfile);
+        converter_plugin->encoder_preset_free (conv->encoder_preset);
+        converter_plugin->dsp_preset_free (conv->dsp_preset);
     }
-    converter_plugin->encoder_preset_free (conv->encoder_preset);
-    converter_plugin->dsp_preset_free (conv->dsp_preset);
     free (conv);
 }
 

--- a/plugins/converter/convgui.c
+++ b/plugins/converter/convgui.c
@@ -191,9 +191,11 @@ make_converter_thread_ctx(converter_ctx_t *conv, int threads)
 
 void
 free_converter_thread_ctx (converter_thread_ctx_t *self) {
-    free(self->pids);
-    pthread_mutex_destroy(&self->item_mutex);
-    pthread_mutex_destroy(&self->cancel_mutex);
+    if(self) {
+        free(self->pids);
+        pthread_mutex_destroy(&self->item_mutex);
+        pthread_mutex_destroy(&self->cancel_mutex);
+    }
 }
 
 void
@@ -423,7 +425,7 @@ converter_worker (void *ctx) {
         converter_ctx_t* conv = thread_ctx->conv;
         unref_convert_items (conv->convert_items, thread_ctx->next_index, conv->convert_items_count);
     }
-    free_converter_thread_ctx (thread_ctx);
+    free_converter_thread_utils (thread_ctx);
     free (thread_ctx);
     deadbeef->background_job_decrement ();
 }

--- a/plugins/converter/convgui.c
+++ b/plugins/converter/convgui.c
@@ -615,7 +615,7 @@ converter_process (converter_ctx_t *conv)
 
     GtkWidget *progress_dialog = gtk_dialog_new_with_buttons (_("Converting..."), GTK_WINDOW (gtkui_plugin->get_mainwin ()), GTK_DIALOG_DESTROY_WITH_PARENT, GTK_STOCK_CANCEL, GTK_RESPONSE_CANCEL, NULL);
     conv->progress_dialog = progress_dialog;
-    g_object_ref (conv->progress_dialog);
+    g_object_ref_sink (conv->progress_dialog);
     conv->text_buffer = add_scrolled_text(progress_dialog);
     g_object_ref (conv->text_buffer);
 

--- a/plugins/converter/convgui.c
+++ b/plugins/converter/convgui.c
@@ -87,6 +87,7 @@ ddb_converter_settings_t get_converter_settings (converter_ctx_t *conv) {
 
 static int
 get_useful_number_of_threads(const converter_ctx_t *self, int req_threads) {
+    if (req_threads <= 0) req_threads = 1;
     return req_threads < self->convert_items_count ? req_threads : self->convert_items_count;
 }
 

--- a/plugins/converter/interface.c
+++ b/plugins/converter/interface.c
@@ -206,6 +206,7 @@ create_converterdlg (void)
   gtk_container_add (GTK_CONTAINER (edit_dsp_presets), image470);
 
   hbox88 = gtk_hbox_new (FALSE, 8);
+  gtk_widget_show (hbox88);
   gtk_box_pack_start (GTK_BOX (vbox26), hbox88, FALSE, TRUE, 0);
 
   label116 = gtk_label_new (_("Number of threads:"));

--- a/plugins/converter/interface.c
+++ b/plugins/converter/interface.c
@@ -303,7 +303,7 @@ create_converterdlg (void)
   g_signal_connect ((gpointer) edit_dsp_presets, "clicked",
                     G_CALLBACK (on_edit_dsp_presets_clicked),
                     NULL);
-  g_signal_connect ((gpointer) numthreads, "changed",
+  g_signal_connect ((gpointer) numthreads, "output",
                     G_CALLBACK (on_numthreads_changed),
                     NULL);
   g_signal_connect ((gpointer) output_format, "changed",


### PR DESCRIPTION
* Add a configurable multi-threaded converter
* Minimal changes to the existing structures and interfaces, added new structures on top of the existing ones.
* Added a `convert3` method to be able to pass the `rw_lock` on the `abort` variable. The former calls the older `convert2` method.
* Re-used the existing-yet-commented GUI features for selecting the number of threads in the GUI dialogue.
* Looked for any memory leak (found an old one) using the ASan sanitiser. 
* Added some static functions for clarity.