### PR TITLE
check_dir: mkdir first and if EEXIST check stat (avoid races conditions)

### DIFF
--- a/plugins/converter/converter.c
+++ b/plugins/converter/converter.c
@@ -202,7 +202,7 @@ encoder_preset_save (ddb_encoder_preset_t *p, int overwrite) {
         FILE *fp = fopen (path, "rb");
         if (fp) {
             fclose (fp);
-            return -2; 
+            return -2;
         }
     }
 
@@ -408,7 +408,7 @@ dsp_preset_save (ddb_dsp_preset_t *p, int overwrite) {
         FILE *fp = fopen (path, "rb");
         if (fp) {
             fclose (fp);
-            return -2; 
+            return -2;
         }
     }
 
@@ -817,7 +817,7 @@ check_dir (const char *dir, mode_t mode)
             *slash = 0;
         if (0 != mkdir (tmp, mode))
         {
-            if (errno == EEXIST && (-1 == stat (tmp, &stat_buf)) || errno != EEXIST)
+            if ( (errno == EEXIST && (-1 == stat (tmp, &stat_buf))) || errno != EEXIST)
             {
                 trace ("Failed to create %s\n", tmp);
                 free (tmp);
@@ -1597,7 +1597,7 @@ static ddb_converter_t plugin = {
     .misc.plugin.id = "converter",
     .misc.plugin.descr = "Converts any supported formats to other formats.\n"
         "Requires separate GUI plugin, e.g. Converter GTK UI\n",
-    .misc.plugin.copyright = 
+    .misc.plugin.copyright =
         "Converter for DeaDBeeF Player\n"
         "Copyright (C) 2009-2015 Oleksiy Yakovenko and other contributors\n"
         "\n"

--- a/plugins/converter/converter.c
+++ b/plugins/converter/converter.c
@@ -815,9 +815,9 @@ check_dir (const char *dir, mode_t mode)
         slash = strstr (slash+1, "/");
         if (slash)
             *slash = 0;
-        if (-1 == stat (tmp, &stat_buf))
+        if (0 != mkdir (tmp, mode))
         {
-            if (0 != mkdir (tmp, mode))
+            if (errno == EEXIST && (-1 == stat (tmp, &stat_buf)) || errno != EEXIST)
             {
                 trace ("Failed to create %s\n", tmp);
                 free (tmp);


### PR DESCRIPTION
Calling `stat` repeatedly from multiple threads leads to race conditions, we should only call it if the directory already exists (i.e. errno set to EEXIST).