### PR TITLE
Cast to long long when printing %lld

### DIFF
--- a/plugins/aac/aac.c
+++ b/plugins/aac/aac.c
@@ -28,7 +28,6 @@
 #include "../../config.h"
 #endif
 #include <stdlib.h>
-#include <inttypes.h>
 #include <math.h>
 #include <deadbeef/deadbeef.h>
 #include <deadbeef/strdupa.h>
@@ -969,7 +968,7 @@ _mp4_insert(DB_playItem_t **after, const char *fname, DB_FILE *fp, ddb_playlist_
     int64_t fsize = deadbeef->fgetlength (fp);
 
     char s[100];
-    snprintf (s, sizeof (s), "%" PRId64, fsize);
+    snprintf (s, sizeof (s), "%lld", (long long)fsize);
     deadbeef->pl_add_meta (it, ":FILE_SIZE", s);
     deadbeef->pl_add_meta (it, ":BPS", "16");
     snprintf (s, sizeof (s), "%d", channels);
@@ -1091,7 +1090,7 @@ aac_insert (ddb_playlist_t *plt, DB_playItem_t *after, const char *fname) {
 
     if (duration > 0) {
         char s[100];
-        snprintf (s, sizeof (s), "%" PRId64, fsize);
+        snprintf (s, sizeof (s), "%lld", (long long)fsize);
         deadbeef->pl_add_meta (it, ":FILE_SIZE", s);
         deadbeef->pl_add_meta (it, ":BPS", "16");
         snprintf (s, sizeof (s), "%d", channels);

--- a/plugins/aac/aac.c
+++ b/plugins/aac/aac.c
@@ -28,6 +28,7 @@
 #include "../../config.h"
 #endif
 #include <stdlib.h>
+#include <inttypes.h>
 #include <math.h>
 #include <deadbeef/deadbeef.h>
 #include <deadbeef/strdupa.h>
@@ -968,7 +969,7 @@ _mp4_insert(DB_playItem_t **after, const char *fname, DB_FILE *fp, ddb_playlist_
     int64_t fsize = deadbeef->fgetlength (fp);
 
     char s[100];
-    snprintf (s, sizeof (s), "%lld", fsize);
+    snprintf (s, sizeof (s), "%" PRId64, fsize);
     deadbeef->pl_add_meta (it, ":FILE_SIZE", s);
     deadbeef->pl_add_meta (it, ":BPS", "16");
     snprintf (s, sizeof (s), "%d", channels);
@@ -1090,7 +1091,7 @@ aac_insert (ddb_playlist_t *plt, DB_playItem_t *after, const char *fname) {
 
     if (duration > 0) {
         char s[100];
-        snprintf (s, sizeof (s), "%lld", fsize);
+        snprintf (s, sizeof (s), "%" PRId64, fsize);
         deadbeef->pl_add_meta (it, ":FILE_SIZE", s);
         deadbeef->pl_add_meta (it, ":BPS", "16");
         snprintf (s, sizeof (s), "%d", channels);

--- a/plugins/alac/alac_plugin.c
+++ b/plugins/alac/alac_plugin.c
@@ -30,6 +30,7 @@
 #endif
 #include <stdlib.h>
 #include <string.h>
+#include <inttypes.h>
 #include <math.h>
 #include <stdio.h>
 #include <unistd.h>
@@ -412,7 +413,7 @@ alacplug_insert (ddb_playlist_t *plt, DB_playItem_t *after, const char *fname) {
     deadbeef->fclose (fp);
 
     char s[100];
-    snprintf (s, sizeof (s), "%lld", fsize);
+    snprintf (s, sizeof (s), "%" PRId64, fsize);
     deadbeef->pl_add_meta (it, ":FILE_SIZE", s);
     deadbeef->pl_add_meta (it, ":BPS", "16");
     snprintf (s, sizeof (s), "%d", channels);

--- a/plugins/alac/alac_plugin.c
+++ b/plugins/alac/alac_plugin.c
@@ -30,7 +30,6 @@
 #endif
 #include <stdlib.h>
 #include <string.h>
-#include <inttypes.h>
 #include <math.h>
 #include <stdio.h>
 #include <unistd.h>
@@ -413,7 +412,7 @@ alacplug_insert (ddb_playlist_t *plt, DB_playItem_t *after, const char *fname) {
     deadbeef->fclose (fp);
 
     char s[100];
-    snprintf (s, sizeof (s), "%" PRId64, fsize);
+    snprintf (s, sizeof (s), "%lld", (long long)fsize);
     deadbeef->pl_add_meta (it, ":FILE_SIZE", s);
     deadbeef->pl_add_meta (it, ":BPS", "16");
     snprintf (s, sizeof (s), "%d", channels);

--- a/plugins/ffap/ffap.c
+++ b/plugins/ffap/ffap.c
@@ -32,7 +32,6 @@
 #endif
 #include <stdio.h>
 #include <string.h>
-#include <inttypes.h>
 #include <limits.h>
 #include <stdlib.h>
 //#include <alloca.h>
@@ -1672,7 +1671,7 @@ ffap_insert (ddb_playlist_t *plt, DB_playItem_t *after, const char *fname) {
     fp = NULL;
 
     char s[100];
-    snprintf (s, sizeof (s), "%" PRId64, fsize);
+    snprintf (s, sizeof (s), "%lld", (long long)fsize);
     deadbeef->pl_add_meta (it, ":FILE_SIZE", s);
     snprintf (s, sizeof (s), "%d", ape_ctx.bps);
     deadbeef->pl_add_meta (it, ":BPS", s);

--- a/plugins/ffap/ffap.c
+++ b/plugins/ffap/ffap.c
@@ -32,6 +32,7 @@
 #endif
 #include <stdio.h>
 #include <string.h>
+#include <inttypes.h>
 #include <limits.h>
 #include <stdlib.h>
 //#include <alloca.h>
@@ -1671,7 +1672,7 @@ ffap_insert (ddb_playlist_t *plt, DB_playItem_t *after, const char *fname) {
     fp = NULL;
 
     char s[100];
-    snprintf (s, sizeof (s), "%lld", fsize);
+    snprintf (s, sizeof (s), "%" PRId64, fsize);
     deadbeef->pl_add_meta (it, ":FILE_SIZE", s);
     snprintf (s, sizeof (s), "%d", ape_ctx.bps);
     deadbeef->pl_add_meta (it, ":BPS", s);

--- a/plugins/ffmpeg/ffmpeg.c
+++ b/plugins/ffmpeg/ffmpeg.c
@@ -705,7 +705,7 @@ ffmpeg_insert (ddb_playlist_t *plt, DB_playItem_t *after, const char *fname) {
 
     if (fsize >= 0 && duration > 0) {
         char s[100];
-        snprintf (s, sizeof (s), "%" PRId64, fsize);
+        snprintf (s, sizeof (s), "%lld", (long long)fsize);
         deadbeef->pl_add_meta (it, ":FILE_SIZE", s);
         snprintf (s, sizeof (s), "%d", bps);
         deadbeef->pl_add_meta (it, ":BPS", s);

--- a/plugins/ffmpeg/ffmpeg.c
+++ b/plugins/ffmpeg/ffmpeg.c
@@ -705,7 +705,7 @@ ffmpeg_insert (ddb_playlist_t *plt, DB_playItem_t *after, const char *fname) {
 
     if (fsize >= 0 && duration > 0) {
         char s[100];
-        snprintf (s, sizeof (s), "%lld", fsize);
+        snprintf (s, sizeof (s), "%" PRId64, fsize);
         deadbeef->pl_add_meta (it, ":FILE_SIZE", s);
         snprintf (s, sizeof (s), "%d", bps);
         deadbeef->pl_add_meta (it, ":BPS", s);

--- a/plugins/flac/flac.c
+++ b/plugins/flac/flac.c
@@ -40,6 +40,7 @@
 #include <math.h>
 #include <FLAC/stream_decoder.h>
 #include <FLAC/metadata.h>
+#include <inttypes.h>
 #include <limits.h>
 #include <deadbeef/deadbeef.h>
 #include "../liboggedit/oggedit.h"
@@ -924,7 +925,7 @@ cflac_insert (ddb_playlist_t *plt, DB_playItem_t *after, const char *fname) {
     deadbeef->pl_add_meta (it, ":FILETYPE", isogg ? "OggFLAC" : "FLAC");
 
     char s[100];
-    snprintf (s, sizeof (s), "%lld", fsize);
+    snprintf (s, sizeof (s), "%" PRId64, fsize);
     deadbeef->pl_add_meta (it, ":FILE_SIZE", s);
     snprintf (s, sizeof (s), "%d", info.info.fmt.channels);
     deadbeef->pl_add_meta (it, ":CHANNELS", s);

--- a/plugins/flac/flac.c
+++ b/plugins/flac/flac.c
@@ -40,7 +40,6 @@
 #include <math.h>
 #include <FLAC/stream_decoder.h>
 #include <FLAC/metadata.h>
-#include <inttypes.h>
 #include <limits.h>
 #include <deadbeef/deadbeef.h>
 #include "../liboggedit/oggedit.h"
@@ -925,7 +924,7 @@ cflac_insert (ddb_playlist_t *plt, DB_playItem_t *after, const char *fname) {
     deadbeef->pl_add_meta (it, ":FILETYPE", isogg ? "OggFLAC" : "FLAC");
 
     char s[100];
-    snprintf (s, sizeof (s), "%" PRId64, fsize);
+    snprintf (s, sizeof (s), "%lld", (long long)fsize);
     deadbeef->pl_add_meta (it, ":FILE_SIZE", s);
     snprintf (s, sizeof (s), "%d", info.info.fmt.channels);
     deadbeef->pl_add_meta (it, ":CHANNELS", s);

--- a/plugins/mp3/mp3.c
+++ b/plugins/mp3/mp3.c
@@ -25,6 +25,7 @@
 #include <stdio.h>
 #include <assert.h>
 #include <stdlib.h>
+#include <inttypes.h>
 #include <limits.h>
 #include <unistd.h>
 #include <sys/time.h>
@@ -116,7 +117,7 @@ cmp3_set_extra_properties (DB_playItem_t *it, mp3info_t *mp3info, int fake) {
     char s[100];
     int64_t size = mp3info->fsize;
     if (size >= 0) {
-        snprintf (s, sizeof (s), "%lld", size);
+        snprintf (s, sizeof (s), "%" PRId64 , size);
         deadbeef->pl_replace_meta (it, ":FILE_SIZE", s);
     }
     else {

--- a/plugins/mp3/mp3.c
+++ b/plugins/mp3/mp3.c
@@ -25,7 +25,6 @@
 #include <stdio.h>
 #include <assert.h>
 #include <stdlib.h>
-#include <inttypes.h>
 #include <limits.h>
 #include <unistd.h>
 #include <sys/time.h>
@@ -117,7 +116,7 @@ cmp3_set_extra_properties (DB_playItem_t *it, mp3info_t *mp3info, int fake) {
     char s[100];
     int64_t size = mp3info->fsize;
     if (size >= 0) {
-        snprintf (s, sizeof (s), "%" PRId64 , size);
+        snprintf (s, sizeof (s), "%lld", (long long)size);
         deadbeef->pl_replace_meta (it, ":FILE_SIZE", s);
     }
     else {

--- a/plugins/musepack/musepack.c
+++ b/plugins/musepack/musepack.c
@@ -25,7 +25,6 @@
 #include <string.h>
 #include <stdlib.h>
 #include <assert.h>
-#include <inttypes.h>
 #include <limits.h>
 #include <unistd.h>
 #include <math.h>
@@ -312,7 +311,7 @@ musepack_seek (DB_fileinfo_t *_info, float time) {
 void
 mpc_set_trk_properties (DB_playItem_t *it, mpc_streaminfo *si, int64_t fsize) {
     char s[100];
-    snprintf (s, sizeof (s), "%" PRId64, fsize);
+    snprintf (s, sizeof (s), "%lld", (long long)fsize);
     deadbeef->pl_add_meta (it, ":FILE_SIZE", s);
     deadbeef->pl_add_meta (it, ":BPS", "32");
     snprintf (s, sizeof (s), "%d", si->channels);
@@ -329,7 +328,7 @@ mpc_set_trk_properties (DB_playItem_t *it, mpc_streaminfo *si, int64_t fsize) {
     deadbeef->pl_add_meta (it, ":MPC_ENCODER_VERSION", s);
     deadbeef->pl_add_meta (it, ":MPC_PNS_USED", si->pns ? "1" : "0");
     deadbeef->pl_add_meta (it, ":MPC_TRUE_GAPLESS", si->is_true_gapless ? "1" : "0");
-    snprintf (s, sizeof (s), "%" PRId64, (int64_t)si->beg_silence);
+    snprintf (s, sizeof (s), "%lld", (long long)si->beg_silence);
     deadbeef->pl_add_meta (it, ":MPC_BEG_SILENCE", s);
     snprintf (s, sizeof (s), "%d", si->stream_version);
     deadbeef->pl_add_meta (it, ":MPC_STREAM_VERSION", s);

--- a/plugins/musepack/musepack.c
+++ b/plugins/musepack/musepack.c
@@ -25,6 +25,7 @@
 #include <string.h>
 #include <stdlib.h>
 #include <assert.h>
+#include <inttypes.h>
 #include <limits.h>
 #include <unistd.h>
 #include <math.h>
@@ -311,7 +312,7 @@ musepack_seek (DB_fileinfo_t *_info, float time) {
 void
 mpc_set_trk_properties (DB_playItem_t *it, mpc_streaminfo *si, int64_t fsize) {
     char s[100];
-    snprintf (s, sizeof (s), "%lld", fsize);
+    snprintf (s, sizeof (s), "%" PRId64, fsize);
     deadbeef->pl_add_meta (it, ":FILE_SIZE", s);
     deadbeef->pl_add_meta (it, ":BPS", "32");
     snprintf (s, sizeof (s), "%d", si->channels);
@@ -328,7 +329,7 @@ mpc_set_trk_properties (DB_playItem_t *it, mpc_streaminfo *si, int64_t fsize) {
     deadbeef->pl_add_meta (it, ":MPC_ENCODER_VERSION", s);
     deadbeef->pl_add_meta (it, ":MPC_PNS_USED", si->pns ? "1" : "0");
     deadbeef->pl_add_meta (it, ":MPC_TRUE_GAPLESS", si->is_true_gapless ? "1" : "0");
-    snprintf (s, sizeof (s), "%lld", (int64_t)si->beg_silence);
+    snprintf (s, sizeof (s), "%" PRId64, (int64_t)si->beg_silence);
     deadbeef->pl_add_meta (it, ":MPC_BEG_SILENCE", s);
     snprintf (s, sizeof (s), "%d", si->stream_version);
     deadbeef->pl_add_meta (it, ":MPC_STREAM_VERSION", s);

--- a/plugins/opus/opus.c
+++ b/plugins/opus/opus.c
@@ -226,7 +226,7 @@ static void
 set_meta_ll(DB_playItem_t *it, const char *key, const int64_t value)
 {
     char string[11];
-    sprintf(string, "%lld", value);
+    sprintf(string, "%" PRId64, value);
     deadbeef->pl_replace_meta(it, key, string);
 }
 

--- a/plugins/opus/opus.c
+++ b/plugins/opus/opus.c
@@ -226,7 +226,7 @@ static void
 set_meta_ll(DB_playItem_t *it, const char *key, const int64_t value)
 {
     char string[11];
-    sprintf(string, "%" PRId64, value);
+    sprintf(string, "%lld", (long long)value);
     deadbeef->pl_replace_meta(it, key, string);
 }
 

--- a/plugins/psf/psfmain.c
+++ b/plugins/psf/psfmain.c
@@ -27,7 +27,6 @@
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
-#include <inttypes.h>
 #include <deadbeef/deadbeef.h>
 
 #include "ao.h"
@@ -81,7 +80,7 @@ int ao_get_lib(char *filename, uint8 **buffer, uint64 *length)
 	if (!filebuf)
 	{
 		deadbeef->fclose(auxfile);
-		printf("ERROR: could not allocate %" PRId64 " bytes of memory\n", size);
+		printf("ERROR: could not allocate %lld bytes of memory\n", (long long)size);
 		return AO_FAIL;
 	}
 

--- a/plugins/psf/psfmain.c
+++ b/plugins/psf/psfmain.c
@@ -27,6 +27,7 @@
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
+#include <inttypes.h>
 #include <deadbeef/deadbeef.h>
 
 #include "ao.h"
@@ -80,7 +81,7 @@ int ao_get_lib(char *filename, uint8 **buffer, uint64 *length)
 	if (!filebuf)
 	{
 		deadbeef->fclose(auxfile);
-		printf("ERROR: could not allocate %lld bytes of memory\n", size);
+		printf("ERROR: could not allocate %" PRId64 " bytes of memory\n", size);
 		return AO_FAIL;
 	}
 

--- a/plugins/shn/shn.c
+++ b/plugins/shn/shn.c
@@ -28,7 +28,6 @@
 
 #include <stdio.h>
 #include <stdlib.h>
-#include <inttypes.h>
 #include <math.h>
 #include "shorten.h"
 #include <deadbeef/deadbeef.h>
@@ -917,7 +916,7 @@ shn_insert (ddb_playlist_t *plt, DB_playItem_t *after, const char *fname) {
     deadbeef->junk_id3v1_read (it, tmp_file->vars.fd);
 
     char s[100];
-    snprintf (s, sizeof (s), "%" PRId64, fsize);
+    snprintf (s, sizeof (s), "%lld", (long long)fsize);
     deadbeef->pl_add_meta (it, ":FILE_SIZE", s);
     snprintf (s, sizeof (s), "%d", tmp_file->wave_header.bits_per_sample);
     deadbeef->pl_add_meta (it, ":BPS", s);

--- a/plugins/shn/shn.c
+++ b/plugins/shn/shn.c
@@ -28,6 +28,7 @@
 
 #include <stdio.h>
 #include <stdlib.h>
+#include <inttypes.h>
 #include <math.h>
 #include "shorten.h"
 #include <deadbeef/deadbeef.h>
@@ -916,7 +917,7 @@ shn_insert (ddb_playlist_t *plt, DB_playItem_t *after, const char *fname) {
     deadbeef->junk_id3v1_read (it, tmp_file->vars.fd);
 
     char s[100];
-    snprintf (s, sizeof (s), "%lld", fsize);
+    snprintf (s, sizeof (s), "%" PRId64, fsize);
     deadbeef->pl_add_meta (it, ":FILE_SIZE", s);
     snprintf (s, sizeof (s), "%d", tmp_file->wave_header.bits_per_sample);
     deadbeef->pl_add_meta (it, ":BPS", s);

--- a/plugins/sndfile/sndfile.c
+++ b/plugins/sndfile/sndfile.c
@@ -24,7 +24,6 @@
 #endif
 #include <string.h>
 #include <sndfile.h>
-#include <inttypes.h>
 #include <math.h>
 #include <stdlib.h>
 #include <deadbeef/deadbeef.h>
@@ -408,7 +407,7 @@ sndfile_insert (ddb_playlist_t *plt, DB_playItem_t *after, const char *fname) {
     trace ("sndfile: totalsamples=%d, samplerate=%d, duration=%f\n", totalsamples, samplerate, duration);
 
     char s[100];
-    snprintf (s, sizeof (s), "%" PRId64, fsize);
+    snprintf (s, sizeof (s), "%lld", (long long)fsize);
     deadbeef->pl_add_meta (it, ":FILE_SIZE", s);
 
     int bps = -1;

--- a/plugins/sndfile/sndfile.c
+++ b/plugins/sndfile/sndfile.c
@@ -24,6 +24,7 @@
 #endif
 #include <string.h>
 #include <sndfile.h>
+#include <inttypes.h>
 #include <math.h>
 #include <stdlib.h>
 #include <deadbeef/deadbeef.h>
@@ -407,7 +408,7 @@ sndfile_insert (ddb_playlist_t *plt, DB_playItem_t *after, const char *fname) {
     trace ("sndfile: totalsamples=%d, samplerate=%d, duration=%f\n", totalsamples, samplerate, duration);
 
     char s[100];
-    snprintf (s, sizeof (s), "%lld", fsize);
+    snprintf (s, sizeof (s), "%" PRId64, fsize);
     deadbeef->pl_add_meta (it, ":FILE_SIZE", s);
 
     int bps = -1;

--- a/plugins/tta/ttaplug.c
+++ b/plugins/tta/ttaplug.c
@@ -27,6 +27,7 @@
 #include <string.h>
 #include <stdlib.h>
 #include <assert.h>
+#include <inttypes.h>
 #include <limits.h>
 #include <unistd.h>
 #include <math.h>
@@ -221,7 +222,7 @@ tta_insert (ddb_playlist_t *plt, DB_playItem_t *after, const char *fname) {
     }
 
     char s[100];
-    snprintf (s, sizeof (s), "%lld", fsize);
+    snprintf (s, sizeof (s), "%" PRId64, fsize);
     deadbeef->pl_add_meta (it, ":FILE_SIZE", s);
     snprintf (s, sizeof (s), "%d", tta.BPS);
     deadbeef->pl_add_meta (it, ":BPS", s);

--- a/plugins/tta/ttaplug.c
+++ b/plugins/tta/ttaplug.c
@@ -27,7 +27,6 @@
 #include <string.h>
 #include <stdlib.h>
 #include <assert.h>
-#include <inttypes.h>
 #include <limits.h>
 #include <unistd.h>
 #include <math.h>
@@ -222,7 +221,7 @@ tta_insert (ddb_playlist_t *plt, DB_playItem_t *after, const char *fname) {
     }
 
     char s[100];
-    snprintf (s, sizeof (s), "%" PRId64, fsize);
+    snprintf (s, sizeof (s), "%lld", (long long)fsize);
     deadbeef->pl_add_meta (it, ":FILE_SIZE", s);
     snprintf (s, sizeof (s), "%d", tta.BPS);
     deadbeef->pl_add_meta (it, ":BPS", s);

--- a/plugins/vorbis/vorbis.c
+++ b/plugins/vorbis/vorbis.c
@@ -170,7 +170,7 @@ static void
 set_meta_ll(DB_playItem_t *it, const char *key, const int64_t value)
 {
     char string[11];
-    snprintf(string, sizeof(string), "%lld", value);
+    snprintf(string, sizeof(string), "%" PRId64, value);
     deadbeef->pl_replace_meta(it, key, string);
 }
 

--- a/plugins/vorbis/vorbis.c
+++ b/plugins/vorbis/vorbis.c
@@ -170,7 +170,7 @@ static void
 set_meta_ll(DB_playItem_t *it, const char *key, const int64_t value)
 {
     char string[11];
-    snprintf(string, sizeof(string), "%" PRId64, value);
+    snprintf(string, sizeof(string), "%lld", (long long)value);
     deadbeef->pl_replace_meta(it, key, string);
 }
 

--- a/plugins/wavpack/wavpack.c
+++ b/plugins/wavpack/wavpack.c
@@ -41,7 +41,6 @@
 #endif
 #include <stdio.h>
 #include <stdlib.h>
-#include <inttypes.h>
 #include <math.h>
 #include <deadbeef/deadbeef.h>
 #include <deadbeef/strdupa.h>
@@ -361,7 +360,7 @@ wv_insert (ddb_playlist_t *plt, DB_playItem_t *after, const char *fname) {
     deadbeef->pl_add_meta (it, "title", NULL);
 
     char s[100];
-    snprintf (s, sizeof (s), "%" PRId64, deadbeef->fgetlength (fp));
+    snprintf (s, sizeof (s), "%lld", (long long)deadbeef->fgetlength (fp));
     deadbeef->pl_add_meta (it, ":FILE_SIZE", s);
     snprintf (s, sizeof (s), "%d", WavpackGetBytesPerSample (ctx) * 8);
     deadbeef->pl_add_meta (it, ":BPS", s);

--- a/plugins/wavpack/wavpack.c
+++ b/plugins/wavpack/wavpack.c
@@ -41,6 +41,7 @@
 #endif
 #include <stdio.h>
 #include <stdlib.h>
+#include <inttypes.h>
 #include <math.h>
 #include <deadbeef/deadbeef.h>
 #include <deadbeef/strdupa.h>
@@ -360,7 +361,7 @@ wv_insert (ddb_playlist_t *plt, DB_playItem_t *after, const char *fname) {
     deadbeef->pl_add_meta (it, "title", NULL);
 
     char s[100];
-    snprintf (s, sizeof (s), "%lld", deadbeef->fgetlength (fp));
+    snprintf (s, sizeof (s), "%" PRId64, deadbeef->fgetlength (fp));
     deadbeef->pl_add_meta (it, ":FILE_SIZE", s);
     snprintf (s, sizeof (s), "%d", WavpackGetBytesPerSample (ctx) * 8);
     deadbeef->pl_add_meta (it, ":BPS", s);

--- a/src/plmeta.c
+++ b/src/plmeta.c
@@ -27,7 +27,6 @@
 
 #include <string.h>
 #include <stdlib.h>
-#include <inttypes.h>
 #include "plmeta.h"
 #include <deadbeef/deadbeef.h>
 #include "metacache.h"
@@ -305,7 +304,7 @@ pl_set_meta_int (playItem_t *it, const char *key, int value) {
 void
 pl_set_meta_int64 (playItem_t *it, const char *key, int64_t value) {
     char s[20];
-    snprintf (s, sizeof (s), "%" PRId64, value);
+    snprintf (s, sizeof (s), "%lld", (long long)value);
     pl_replace_meta (it, key, s);
 }
 

--- a/src/plmeta.c
+++ b/src/plmeta.c
@@ -27,6 +27,7 @@
 
 #include <string.h>
 #include <stdlib.h>
+#include <inttypes.h>
 #include "plmeta.h"
 #include <deadbeef/deadbeef.h>
 #include "metacache.h"
@@ -304,7 +305,7 @@ pl_set_meta_int (playItem_t *it, const char *key, int value) {
 void
 pl_set_meta_int64 (playItem_t *it, const char *key, int64_t value) {
     char s[20];
-    snprintf (s, sizeof (s), "%lld", value);
+    snprintf (s, sizeof (s), "%" PRId64, value);
     pl_replace_meta (it, key, s);
 }
 


### PR DESCRIPTION
On the linux CI system, the relevant format specifier for `int64_t` is `%ld`, rather than `%lld`. This generates some harmless warnings.

This PR changes current use of `%lld` with `int64_t` to use the portable `PRId64` constant instead, removing the warnings.