### PR TITLE
Fix for Dockerfile smell DL3009

### DIFF
--- a/tools/docker/Dockerfile-builder
+++ b/tools/docker/Dockerfile-builder
@@ -1,5 +1,7 @@
 FROM ubuntu:trusty
 
 RUN apt-get -qq update
-RUN apt-get install -y -qq autopoint automake autoconf intltool libc6-dev-i386 libc6-dev yasm libglib2.0-bin perl wget g++-multilib zip bzip2 make libtool pkg-config fakeroot
+RUN apt-get install -y -qq autopoint automake autoconf intltool libc6-dev-i386 libc6-dev yasm libglib2.0-bin perl wget g++-multilib zip bzip2 make libtool pkg-config fakeroot \
+    && apt-get clean \
+    && rm -rf /var/lib/apt/lists/*
 


### PR DESCRIPTION
Hi!
The Dockerfile placed at "tools/docker/Dockerfile-builder" contains the best practice violation [DL3009](https://github.com/hadolint/hadolint/wiki/DL3009) detected by the [hadolint](https://github.com/hadolint/hadolint) tool.

The smell DL3009 occurs when the apt tool is used to install packages without wiping the cache and source lists.
This pull request proposes a fix for that smell generated by my fixing tool. The generated patch has been manually verified before opening the pull request.
To fix this smell, specifically, the instructions to clean up the apt cache and remove the /var/lib/apt/lists have been added. This helps keep the image size down.

This change is only aimed at fixing that specific smell. If the fix is not valid or useful, please briefly indicate the reason and suggestions for possible improvements.

Thanks in advance