### PR TITLE
Add bit depth override option.

### DIFF
--- a/plugins/gtkui/callbacks.h
+++ b/plugins/gtkui/callbacks.h
@@ -1049,10 +1049,6 @@ on_convert16to24_toggled                (GtkToggleButton *togglebutton,
                                          gpointer       user_data);
 
 void
-on_combo_bit_override_changed                (GtkToggleButton *togglebutton,
-                                         gpointer       user_data);
-
-void
 on_reset_autostop_toggled              (GtkToggleButton *togglebutton,
                                         gpointer         user_data);
 
@@ -1510,4 +1506,8 @@ on_use_visualization_background_color_toggled
 void
 on_visualization_custom_background_color_button_color_set
                                         (GtkColorButton  *colorbutton,
+                                        gpointer         user_data);
+
+void
+on_combo_bit_override_changed          (GtkComboBox     *combobox,
                                         gpointer         user_data);

--- a/plugins/gtkui/callbacks.h
+++ b/plugins/gtkui/callbacks.h
@@ -1049,6 +1049,10 @@ on_convert16to24_toggled                (GtkToggleButton *togglebutton,
                                          gpointer       user_data);
 
 void
+on_combo_bit_override_changed                (GtkToggleButton *togglebutton,
+                                         gpointer       user_data);
+
+void
 on_reset_autostop_toggled              (GtkToggleButton *togglebutton,
                                         gpointer         user_data);
 

--- a/plugins/gtkui/deadbeef.glade
+++ b/plugins/gtkui/deadbeef.glade
@@ -2528,7 +2528,7 @@ Center</property>
 		<widget class="GtkHBox" id="hbox151">
 		  <property name="visible">True</property>
 		  <property name="homogeneous">False</property>
-		  <property name="spacing">0</property>
+		  <property name="spacing">8</property>
 
 		  <child>
 		    <widget class="GtkLabel" id="label_bit_override">
@@ -2559,11 +2559,11 @@ Center</property>
 		    <widget class="GtkComboBox" id="combo_bit_override">
 		      <property name="visible">True</property>
 		      <property name="items" translatable="yes">Disabled
-8-Bit
-16-Bit
-24-Bit
-32-Bit Fixed
-32-Bit Float</property>
+8 bit
+16 bit
+24 bit
+32 bit
+32 bit float</property>
 		      <property name="add_tearoffs">False</property>
 		      <property name="focus_on_click">True</property>
 		      <signal name="changed" handler="on_combo_bit_override_changed" last_modification_time="Fri, 26 May 2023 09:50:38 GMT"/>

--- a/plugins/gtkui/deadbeef.glade
+++ b/plugins/gtkui/deadbeef.glade
@@ -2414,6 +2414,7 @@ Center</property>
 
 		  <child>
 		    <widget class="GtkComboBox" id="pref_output_plugin">
+		      <property name="border_width">1</property>
 		      <property name="visible">True</property>
 		      <property name="add_tearoffs">False</property>
 		      <property name="focus_on_click">True</property>
@@ -2520,6 +2521,64 @@ Center</property>
 		  <property name="padding">0</property>
 		  <property name="expand">False</property>
 		  <property name="fill">False</property>
+		</packing>
+	      </child>
+
+	      <child>
+		<widget class="GtkHBox" id="hbox151">
+		  <property name="visible">True</property>
+		  <property name="homogeneous">False</property>
+		  <property name="spacing">0</property>
+
+		  <child>
+		    <widget class="GtkLabel" id="label_bit_override">
+		      <property name="visible">True</property>
+		      <property name="label" translatable="yes">Override bit depth:</property>
+		      <property name="use_underline">False</property>
+		      <property name="use_markup">False</property>
+		      <property name="justify">GTK_JUSTIFY_LEFT</property>
+		      <property name="wrap">False</property>
+		      <property name="selectable">False</property>
+		      <property name="xalign">0.5</property>
+		      <property name="yalign">0.5</property>
+		      <property name="xpad">0</property>
+		      <property name="ypad">0</property>
+		      <property name="ellipsize">PANGO_ELLIPSIZE_NONE</property>
+		      <property name="width_chars">-1</property>
+		      <property name="single_line_mode">False</property>
+		      <property name="angle">0</property>
+		    </widget>
+		    <packing>
+		      <property name="padding">0</property>
+		      <property name="expand">False</property>
+		      <property name="fill">False</property>
+		    </packing>
+		  </child>
+
+		  <child>
+		    <widget class="GtkComboBox" id="combo_bit_override">
+		      <property name="visible">True</property>
+		      <property name="items" translatable="yes">Disabled
+8-Bit
+16-Bit
+24-Bit
+32-Bit Fixed
+32-Bit Float</property>
+		      <property name="add_tearoffs">False</property>
+		      <property name="focus_on_click">True</property>
+		      <signal name="changed" handler="on_combo_bit_override_changed" last_modification_time="Fri, 26 May 2023 09:50:38 GMT"/>
+		    </widget>
+		    <packing>
+		      <property name="padding">0</property>
+		      <property name="expand">True</property>
+		      <property name="fill">True</property>
+		    </packing>
+		  </child>
+		</widget>
+		<packing>
+		  <property name="padding">0</property>
+		  <property name="expand">False</property>
+		  <property name="fill">True</property>
 		</packing>
 	      </child>
 

--- a/plugins/gtkui/interface.c
+++ b/plugins/gtkui/interface.c
@@ -1535,6 +1535,9 @@ create_prefwin (void)
   GtkWidget *pref_soundcard;
   GtkWidget *convert8to16;
   GtkWidget *convert16to24;
+  GtkWidget *hbox_bit_override;
+  GtkWidget *label_bit_override;
+  GtkWidget *combo_bit_override;
   GtkWidget *frame15;
   GtkWidget *alignment31;
   GtkWidget *vbox52;
@@ -1874,6 +1877,25 @@ create_prefwin (void)
   convert16to24 = gtk_check_button_new_with_mnemonic (_("Always convert 16 bit audio to 24 bit"));
   gtk_widget_show (convert16to24);
   gtk_box_pack_start (GTK_BOX (vbox10), convert16to24, FALSE, FALSE, 0);
+
+  hbox_bit_override = gtk_hbox_new (FALSE, 8);
+  gtk_widget_show (hbox_bit_override);
+  gtk_box_pack_start (GTK_BOX (vbox10), hbox_bit_override, FALSE, FALSE, 0);
+
+  label_bit_override = gtk_label_new(_("Override bit depth:"));
+  gtk_widget_show (label_bit_override);
+  gtk_box_pack_start (GTK_BOX (hbox_bit_override), label_bit_override, FALSE, FALSE, 0);
+  gtk_misc_set_alignment (GTK_MISC (label_bit_override), 0, 0.5);
+
+  combo_bit_override = gtk_combo_box_text_new ();
+  gtk_widget_show (combo_bit_override);
+  gtk_box_pack_start (GTK_BOX (hbox_bit_override), combo_bit_override, TRUE, TRUE, 0);
+  gtk_combo_box_append_text (GTK_COMBO_BOX (combo_bit_override), "Disabled");
+  gtk_combo_box_append_text (GTK_COMBO_BOX (combo_bit_override), "8-Bit");
+  gtk_combo_box_append_text (GTK_COMBO_BOX (combo_bit_override), "16-Bit");
+  gtk_combo_box_append_text (GTK_COMBO_BOX (combo_bit_override), "24-Bit");
+  gtk_combo_box_append_text (GTK_COMBO_BOX (combo_bit_override), "32-Bit Fixed");
+  gtk_combo_box_append_text (GTK_COMBO_BOX (combo_bit_override), "32-Bit Float");
 
   frame15 = gtk_frame_new (NULL);
   gtk_widget_show (frame15);
@@ -3326,6 +3348,9 @@ create_prefwin (void)
   g_signal_connect ((gpointer) convert16to24, "toggled",
                     G_CALLBACK (on_convert16to24_toggled),
                     NULL);
+  g_signal_connect ((gpointer) combo_bit_override, "changed",
+                    G_CALLBACK (on_combo_bit_override_changed),
+                    NULL);
   g_signal_connect ((gpointer) comboboxentry_direct_sr, "changed",
                     G_CALLBACK (on_comboboxentry_direct_sr_changed),
                     NULL);
@@ -3655,6 +3680,7 @@ create_prefwin (void)
   GLADE_HOOKUP_OBJECT (prefwin, pref_soundcard, "pref_soundcard");
   GLADE_HOOKUP_OBJECT (prefwin, convert8to16, "convert8to16");
   GLADE_HOOKUP_OBJECT (prefwin, convert16to24, "convert16to24");
+  GLADE_HOOKUP_OBJECT (prefwin, combo_bit_override, "combo_bit_override");
   GLADE_HOOKUP_OBJECT (prefwin, frame15, "frame15");
   GLADE_HOOKUP_OBJECT (prefwin, alignment31, "alignment31");
   GLADE_HOOKUP_OBJECT (prefwin, vbox52, "vbox52");

--- a/plugins/gtkui/interface.c
+++ b/plugins/gtkui/interface.c
@@ -1879,7 +1879,7 @@ create_prefwin (void)
   gtk_widget_show (convert16to24);
   gtk_box_pack_start (GTK_BOX (vbox10), convert16to24, FALSE, FALSE, 0);
 
-  hbox151 = gtk_hbox_new (FALSE, 0);
+  hbox151 = gtk_hbox_new (FALSE, 8);
   gtk_widget_show (hbox151);
   gtk_box_pack_start (GTK_BOX (vbox10), hbox151, FALSE, TRUE, 0);
 
@@ -1891,11 +1891,11 @@ create_prefwin (void)
   gtk_widget_show (combo_bit_override);
   gtk_box_pack_start (GTK_BOX (hbox151), combo_bit_override, TRUE, TRUE, 0);
   gtk_combo_box_text_append_text (GTK_COMBO_BOX_TEXT (combo_bit_override), _("Disabled"));
-  gtk_combo_box_text_append_text (GTK_COMBO_BOX_TEXT (combo_bit_override), _("8-Bit"));
-  gtk_combo_box_text_append_text (GTK_COMBO_BOX_TEXT (combo_bit_override), _("16-Bit"));
-  gtk_combo_box_text_append_text (GTK_COMBO_BOX_TEXT (combo_bit_override), _("24-Bit"));
-  gtk_combo_box_text_append_text (GTK_COMBO_BOX_TEXT (combo_bit_override), _("32-Bit Fixed"));
-  gtk_combo_box_text_append_text (GTK_COMBO_BOX_TEXT (combo_bit_override), _("32-Bit Float"));
+  gtk_combo_box_text_append_text (GTK_COMBO_BOX_TEXT (combo_bit_override), _("8 bit"));
+  gtk_combo_box_text_append_text (GTK_COMBO_BOX_TEXT (combo_bit_override), _("16 bit"));
+  gtk_combo_box_text_append_text (GTK_COMBO_BOX_TEXT (combo_bit_override), _("24 bit"));
+  gtk_combo_box_text_append_text (GTK_COMBO_BOX_TEXT (combo_bit_override), _("32 bit"));
+  gtk_combo_box_text_append_text (GTK_COMBO_BOX_TEXT (combo_bit_override), _("32 bit float"));
 
   frame15 = gtk_frame_new (NULL);
   gtk_widget_show (frame15);

--- a/plugins/gtkui/interface.c
+++ b/plugins/gtkui/interface.c
@@ -1535,7 +1535,7 @@ create_prefwin (void)
   GtkWidget *pref_soundcard;
   GtkWidget *convert8to16;
   GtkWidget *convert16to24;
-  GtkWidget *hbox_bit_override;
+  GtkWidget *hbox151;
   GtkWidget *label_bit_override;
   GtkWidget *combo_bit_override;
   GtkWidget *frame15;
@@ -1856,6 +1856,7 @@ create_prefwin (void)
   pref_output_plugin = gtk_combo_box_text_new ();
   gtk_widget_show (pref_output_plugin);
   gtk_box_pack_start (GTK_BOX (hbox11), pref_output_plugin, TRUE, TRUE, 0);
+  gtk_container_set_border_width (GTK_CONTAINER (pref_output_plugin), 1);
 
   hbox12 = gtk_hbox_new (FALSE, 8);
   gtk_widget_show (hbox12);
@@ -1878,24 +1879,23 @@ create_prefwin (void)
   gtk_widget_show (convert16to24);
   gtk_box_pack_start (GTK_BOX (vbox10), convert16to24, FALSE, FALSE, 0);
 
-  hbox_bit_override = gtk_hbox_new (FALSE, 8);
-  gtk_widget_show (hbox_bit_override);
-  gtk_box_pack_start (GTK_BOX (vbox10), hbox_bit_override, FALSE, FALSE, 0);
+  hbox151 = gtk_hbox_new (FALSE, 0);
+  gtk_widget_show (hbox151);
+  gtk_box_pack_start (GTK_BOX (vbox10), hbox151, FALSE, TRUE, 0);
 
-  label_bit_override = gtk_label_new(_("Override bit depth:"));
+  label_bit_override = gtk_label_new (_("Override bit depth:"));
   gtk_widget_show (label_bit_override);
-  gtk_box_pack_start (GTK_BOX (hbox_bit_override), label_bit_override, FALSE, FALSE, 0);
-  gtk_misc_set_alignment (GTK_MISC (label_bit_override), 0, 0.5);
+  gtk_box_pack_start (GTK_BOX (hbox151), label_bit_override, FALSE, FALSE, 0);
 
   combo_bit_override = gtk_combo_box_text_new ();
   gtk_widget_show (combo_bit_override);
-  gtk_box_pack_start (GTK_BOX (hbox_bit_override), combo_bit_override, TRUE, TRUE, 0);
-  gtk_combo_box_append_text (GTK_COMBO_BOX (combo_bit_override), "Disabled");
-  gtk_combo_box_append_text (GTK_COMBO_BOX (combo_bit_override), "8-Bit");
-  gtk_combo_box_append_text (GTK_COMBO_BOX (combo_bit_override), "16-Bit");
-  gtk_combo_box_append_text (GTK_COMBO_BOX (combo_bit_override), "24-Bit");
-  gtk_combo_box_append_text (GTK_COMBO_BOX (combo_bit_override), "32-Bit Fixed");
-  gtk_combo_box_append_text (GTK_COMBO_BOX (combo_bit_override), "32-Bit Float");
+  gtk_box_pack_start (GTK_BOX (hbox151), combo_bit_override, TRUE, TRUE, 0);
+  gtk_combo_box_text_append_text (GTK_COMBO_BOX_TEXT (combo_bit_override), _("Disabled"));
+  gtk_combo_box_text_append_text (GTK_COMBO_BOX_TEXT (combo_bit_override), _("8-Bit"));
+  gtk_combo_box_text_append_text (GTK_COMBO_BOX_TEXT (combo_bit_override), _("16-Bit"));
+  gtk_combo_box_text_append_text (GTK_COMBO_BOX_TEXT (combo_bit_override), _("24-Bit"));
+  gtk_combo_box_text_append_text (GTK_COMBO_BOX_TEXT (combo_bit_override), _("32-Bit Fixed"));
+  gtk_combo_box_text_append_text (GTK_COMBO_BOX_TEXT (combo_bit_override), _("32-Bit Float"));
 
   frame15 = gtk_frame_new (NULL);
   gtk_widget_show (frame15);
@@ -3680,6 +3680,8 @@ create_prefwin (void)
   GLADE_HOOKUP_OBJECT (prefwin, pref_soundcard, "pref_soundcard");
   GLADE_HOOKUP_OBJECT (prefwin, convert8to16, "convert8to16");
   GLADE_HOOKUP_OBJECT (prefwin, convert16to24, "convert16to24");
+  GLADE_HOOKUP_OBJECT (prefwin, hbox151, "hbox151");
+  GLADE_HOOKUP_OBJECT (prefwin, label_bit_override, "label_bit_override");
   GLADE_HOOKUP_OBJECT (prefwin, combo_bit_override, "combo_bit_override");
   GLADE_HOOKUP_OBJECT (prefwin, frame15, "frame15");
   GLADE_HOOKUP_OBJECT (prefwin, alignment31, "alignment31");

--- a/plugins/gtkui/prefwin/prefwinsound.c
+++ b/plugins/gtkui/prefwin/prefwinsound.c
@@ -250,6 +250,10 @@ prefwin_init_sound_tab (GtkWidget *_prefwin) {
     // 16_to_24
     prefwin_set_toggle_button("convert16to24", deadbeef->conf_get_int ("streamer.16_to_24", 0));
 
+    // override bit depth
+    GtkComboBox *combo_bit_override = GTK_COMBO_BOX (lookup_widget (w, "combo_bit_override"));
+    gtk_combo_box_set_active(combo_bit_override, deadbeef->conf_get_int ("streamer.bit_override", 0));
+
     // override samplerate checkbox
     int override_sr = deadbeef->conf_get_int ("streamer.override_samplerate", 0);
     prefwin_set_toggle_button ("checkbutton_sr_override", override_sr);
@@ -282,3 +286,11 @@ on_convert16to24_toggled                (GtkToggleButton *togglebutton,
     deadbeef->sendmessage (DB_EV_CONFIGCHANGED, 0, 0, 0);
 }
 
+void
+on_combo_bit_override_changed           (GtkComboBox     *combobox,
+                                         gpointer         user_data)
+{
+    int active = gtk_combo_box_get_active (combobox);
+    deadbeef->conf_set_int ("streamer.bit_override", active);
+    deadbeef->sendmessage (DB_EV_CONFIGCHANGED, 0, 0, 0);
+}

--- a/src/streamer.c
+++ b/src/streamer.c
@@ -83,6 +83,7 @@ static int autoconv_8_to_16 = 1;
 
 static int autoconv_16_to_24 = 0;
 
+static int bit_override = 0;
 
 static int conf_streamer_override_samplerate = 0;
 static int conf_streamer_use_dependent_samplerate = 0;
@@ -1582,6 +1583,26 @@ get_desired_output_format (ddb_waveformat_t *in_fmt, ddb_waveformat_t *out_fmt) 
             out_fmt->bps = 24;
         }
     }
+    if (bit_override == 1) {
+        out_fmt->bps = 8;
+        out_fmt->is_float = 0;
+    }
+    else if (bit_override == 2) {
+        out_fmt->bps = 16;
+        out_fmt->is_float = 0;
+    }
+    else if (bit_override == 3) {
+        out_fmt->bps = 24;
+        out_fmt->is_float = 0;
+    }
+    else if (bit_override == 4) {
+        out_fmt->bps = 32;
+        out_fmt->is_float = 0;
+    }
+    else if (bit_override == 5) {
+        out_fmt->bps = 32;
+        out_fmt->is_float = 1;
+    }
 
 #if !defined(ANDROID) && !defined(HAVE_XGUI)
     // samplerate override
@@ -2413,6 +2434,11 @@ streamer_configchanged (void) {
     int conf_autoconv_16_to_24 = conf_get_int ("streamer.16_to_24",0);
     if (conf_autoconv_16_to_24 != autoconv_16_to_24) {
         autoconv_16_to_24 = conf_autoconv_16_to_24;
+        formatchanged = 1;
+    }
+    int conf_bit_override = conf_get_int ("streamer.bit_override",0);
+    if (conf_bit_override != bit_override) {
+        bit_override = conf_bit_override;
         formatchanged = 1;
     }
 


### PR DESCRIPTION
Add a bit depth selection box, similar to foobar.

Objective is to have a finer control of bit depth, which allows:
- Keep maximum resolution while doing volume math
- Lower resolution for testing/benchmark purpose

<img width="422" alt="image" src="https://github.com/DeaDBeeF-Player/deadbeef/assets/4375114/42b51e34-ab2f-4ac5-addd-ebccf5ae1683">

<img width="437" alt="image" src="https://github.com/DeaDBeeF-Player/deadbeef/assets/4375114/edf65868-1912-438d-b2e4-4a7c8b511e59">
