### PR TITLE
Add experimental DoP support.

### DIFF
--- a/include/deadbeef/deadbeef.h
+++ b/include/deadbeef/deadbeef.h
@@ -657,6 +657,7 @@ typedef struct {
     uint32_t channelmask;
     int is_float; // bps must be 32 if this is true
     int is_bigendian;
+    int is_dop;
 } ddb_waveformat_t;
 
 // since 1.5

--- a/include/deadbeef/deadbeef.h
+++ b/include/deadbeef/deadbeef.h
@@ -71,6 +71,7 @@ extern "C" {
 // that there's a better replacement in the newer deadbeef versions.
 
 // API version history:
+// 1.17 -- deadbeef-1.9.6
 // 1.16 -- deadbeef-1.9.4
 // 1.15 -- deadbeef-1.9.0
 // 1.14 -- deadbeef-1.8.8
@@ -100,7 +101,7 @@ extern "C" {
 // 0.1 -- deadbeef-0.2.0
 
 #define DB_API_VERSION_MAJOR 1
-#define DB_API_VERSION_MINOR 16
+#define DB_API_VERSION_MINOR 17
 
 #if defined(__clang__)
 
@@ -135,6 +136,12 @@ extern "C" {
 
 #ifndef DDB_API_LEVEL
 #define DDB_API_LEVEL DB_API_VERSION_MINOR
+#endif
+
+#if (DDB_WARN_DEPRECATED && DDB_API_LEVEL >= 17)
+#define DEPRECATED_117 DDB_DEPRECATED("since deadbeef API 1.17")
+#else
+#define DEPRECATED_117
 #endif
 
 #if (DDB_WARN_DEPRECATED && DDB_API_LEVEL >= 16)
@@ -656,9 +663,18 @@ typedef struct {
     int samplerate;
     uint32_t channelmask;
     int is_float; // bps must be 32 if this is true
+#if (DDB_API_LEVEL >= 17)
+    uint32_t flags;
+#else
     int is_bigendian;
-    int is_dop;
+#endif
 } ddb_waveformat_t;
+
+#if (DDB_API_LEVEL >= 17)
+enum {
+    DDB_WAVEFORMAT_FLAG_IS_DOP = 0x01,
+};
+#endif
 
 // since 1.5
 #if (DDB_API_LEVEL >= 5)

--- a/plugins/alsa/alsa.c
+++ b/plugins/alsa/alsa.c
@@ -114,6 +114,7 @@ palsa_set_hw_params (ddb_waveformat_t *fmt) {
         // generic format
         plugin.fmt.bps = 16;
         plugin.fmt.is_float = 0;
+        plugin.fmt.is_dop = 0;
         plugin.fmt.channels = 2;
         plugin.fmt.samplerate = 44100;
         plugin.fmt.channelmask = 3;
@@ -184,29 +185,44 @@ palsa_set_hw_params (ddb_waveformat_t *fmt) {
         int fmt_cnt[] = { 16, 24, 32, 32, 8 };
 #if WORDS_BIGENDIAN
         int fmt[] = { SND_PCM_FORMAT_S16_BE, SND_PCM_FORMAT_S24_3BE, SND_PCM_FORMAT_S32_BE, SND_PCM_FORMAT_FLOAT_BE, SND_PCM_FORMAT_S8, -1 };
+        int fmt_dop[] = { SND_PCM_FORMAT_S24_3BE, SND_PCM_FORMAT_S32_BE, -1 };
 #else
         int fmt[] = { SND_PCM_FORMAT_S16_LE, SND_PCM_FORMAT_S24_3LE, SND_PCM_FORMAT_S32_LE, SND_PCM_FORMAT_FLOAT_LE, SND_PCM_FORMAT_S8, -1 };
+        int fmt_dop[] = { SND_PCM_FORMAT_S24_3LE, SND_PCM_FORMAT_S32_LE, -1 };
 #endif
 
         // 1st try formats with higher bps
         int i = 0;
-        for (i = 0; fmt[i] != -1; i++) {
-            if (fmt[i] != sample_fmt && fmt_cnt[i] > plugin.fmt.bps) {
-                if (snd_pcm_hw_params_set_format (audio, hw_params, fmt[i]) >= 0) {
-                    fprintf (stderr, "Found compatible format %d bps\n", fmt_cnt[i]);
-                    sample_fmt = fmt[i];
-                    break;
-                }
-            }
-        }
-        if (fmt[i] == -1) {
-            // next try formats with lower bps
-            i = 0;
+        if(!plugin.fmt.is_dop) {
             for (i = 0; fmt[i] != -1; i++) {
-                if (fmt[i] != sample_fmt && fmt_cnt[i] < plugin.fmt.bps) {
+                if (fmt[i] != sample_fmt && fmt_cnt[i] > plugin.fmt.bps) {
                     if (snd_pcm_hw_params_set_format (audio, hw_params, fmt[i]) >= 0) {
                         fprintf (stderr, "Found compatible format %d bps\n", fmt_cnt[i]);
                         sample_fmt = fmt[i];
+                        break;
+                    }
+                }
+            }
+            if (fmt[i] == -1) {
+                // next try formats with lower bps
+                i = 0;
+                for (i = 0; fmt[i] != -1; i++) {
+                    if (fmt[i] != sample_fmt && fmt_cnt[i] < plugin.fmt.bps) {
+                        if (snd_pcm_hw_params_set_format (audio, hw_params, fmt[i]) >= 0) {
+                            fprintf (stderr, "Found compatible format %d bps\n", fmt_cnt[i]);
+                            sample_fmt = fmt[i];
+                            break;
+                        }
+                    }
+                }
+            }
+        }
+        else {
+            for (i = 0; fmt_dop[i] != -1; i++) {
+                if (fmt_dop[i] != sample_fmt) {
+                    if (snd_pcm_hw_params_set_format (audio, hw_params, fmt_dop[i]) >= 0) {
+                        fprintf (stderr, "Found DoP compatible format\n");
+                        sample_fmt = fmt_dop[i];
                         break;
                     }
                 }
@@ -225,18 +241,27 @@ palsa_set_hw_params (ddb_waveformat_t *fmt) {
     unsigned val = (unsigned)plugin.fmt.samplerate;
     int ret = 0;
 
-    if ((err = snd_pcm_hw_params_set_rate_resample (audio, hw_params, conf_alsa_resample)) < 0) {
+    if ((err = snd_pcm_hw_params_set_rate_resample (audio, hw_params, conf_alsa_resample && !plugin.fmt.is_dop)) < 0) {
         fprintf (stderr, "cannot setup resampling (%s)\n",
                 snd_strerror (err));
         goto error;
     }
 
-    if ((err = snd_pcm_hw_params_set_rate_near (audio, hw_params, &val, &ret)) < 0) {
-        fprintf (stderr, "cannot set sample rate (%s)\n",
-                snd_strerror (err));
-        goto error;
+    if(plugin.fmt.is_dop) {
+        if ((err = snd_pcm_hw_params_set_rate (audio, hw_params, val, 0)) < 0) {
+            fprintf (stderr, "cannot set sample rate (%s)\n",
+                    snd_strerror (err));
+            goto error;
+        }
     }
-    plugin.fmt.samplerate = val;
+    else {
+        if ((err = snd_pcm_hw_params_set_rate_near (audio, hw_params, &val, &ret)) < 0) {
+            fprintf (stderr, "cannot set sample rate (%s)\n",
+                    snd_strerror (err));
+            goto error;
+        }
+        plugin.fmt.samplerate = val;
+    }
     trace ("chosen samplerate: %d Hz\n", val);
 
     unsigned chanmin, chanmax;

--- a/plugins/coreaudio/coreaudio.c
+++ b/plugins/coreaudio/coreaudio.c
@@ -409,10 +409,6 @@ ca_setformat (ddb_waveformat_t *fmt) {
         req_format.mFormatFlags = kLinearPCMFormatFlagIsSignedInteger | kLinearPCMFormatFlagIsPacked | kAudioFormatFlagsNativeEndian;
     }
 
-    if (fmt->is_bigendian) {
-        req_format.mFormatFlags |= kLinearPCMFormatFlagIsBigEndian;
-    }
-
     req_format.mBytesPerPacket = bps / 8 * fmt->channels;
     req_format.mFramesPerPacket = 1;
     req_format.mBytesPerFrame = bps / 8 * fmt->channels;

--- a/plugins/ffmpeg/ffmpeg.c
+++ b/plugins/ffmpeg/ffmpeg.c
@@ -257,9 +257,9 @@ ffmpeg_init (DB_fileinfo_t *_info, DB_playItem_t *it) {
 
     if (enable_dop && is_codec_dsd(info->codec_context->codec_id)) {
         _info->fmt.is_float = 0;
-        _info->fmt.is_dop = 1;
         _info->fmt.bps = 32;
         _info->fmt.samplerate =  info->codec_context->sample_rate / 2;
+        _info->fmt.flags |= DDB_WAVEFORMAT_FLAG_IS_DOP;
     }
 
     // FIXME: channel layout from ffmpeg
@@ -327,13 +327,13 @@ ffmpeg_read (DB_fileinfo_t *_info, char *bytes, int size) {
     if (enable_dop && is_codec_dsd(info->codec_context->codec_id)) {
         _info->fmt.samplerate =  info->codec_context->sample_rate / 2;
         _info->fmt.bps = 32;
-        _info->fmt.is_dop = 1;
         _info->fmt.is_float = 0;
+        _info->fmt.flags |= DDB_WAVEFORMAT_FLAG_IS_DOP;
     } else {
         _info->fmt.samplerate = info->codec_context->sample_rate;
         _info->fmt.bps = av_get_bytes_per_sample (info->codec_context->sample_fmt) * 8;
-        _info->fmt.is_dop = 0;
         _info->fmt.is_float = (info->codec_context->sample_fmt == AV_SAMPLE_FMT_FLT || info->codec_context->sample_fmt == AV_SAMPLE_FMT_FLTP);
+        _info->fmt.flags &=~DDB_WAVEFORMAT_FLAG_IS_DOP;
     }
 
     int samplesize = _info->fmt.channels * _info->fmt.bps / 8;

--- a/plugins/ffmpeg/ffmpeg.c
+++ b/plugins/ffmpeg/ffmpeg.c
@@ -87,6 +87,32 @@ ffmpeg_open (uint32_t hints) {
     return &info->info;
 }
 
+static int enable_dop = 0;
+
+static const uint8_t bit_reverse_table[256] =
+{
+#define R2(n)     n,     n + 2*64,     n + 1*64,     n + 3*64
+#define R4(n) R2(n), R2(n + 2*16), R2(n + 1*16), R2(n + 3*16)
+#define R6(n) R4(n), R4(n + 2*4 ), R4(n + 1*4 ), R4(n + 3*4 )
+    R6(0), R6(2), R6(1), R6(3)
+#undef R2
+#undef R4
+#undef R6
+};
+
+int is_codec_dsd(enum AVCodecID codec_id) {
+    switch(codec_id) {
+    case AV_CODEC_ID_DSD_LSBF:
+    case AV_CODEC_ID_DSD_LSBF_PLANAR:
+    case AV_CODEC_ID_DSD_MSBF:
+    case AV_CODEC_ID_DSD_MSBF_PLANAR:
+        return 1;
+        break;
+    default:
+        return 0;
+    }
+}
+
 // ensure that the buffer can contain entire frame of frame_size bytes per channel
 static int
 ensure_buffer (ffmpeg_info_t *info, int frame_size) {
@@ -229,6 +255,13 @@ ffmpeg_init (DB_fileinfo_t *_info, DB_playItem_t *it) {
         _info->fmt.is_float = 1;
     }
 
+    if (enable_dop && is_codec_dsd(info->codec_context->codec_id)) {
+        _info->fmt.is_float = 0;
+        _info->fmt.is_dop = 1;
+        _info->fmt.bps = 32;
+        _info->fmt.samplerate =  info->codec_context->sample_rate / 2;
+    }
+
     // FIXME: channel layout from ffmpeg
     // int64_t layout = info->ctx->channel_layout;
 
@@ -291,10 +324,17 @@ ffmpeg_read (DB_fileinfo_t *_info, char *bytes, int size) {
     trace ("ffmpeg_read_int16 %d\n", size);
     ffmpeg_info_t *info = (ffmpeg_info_t*)_info;
 
-    _info->fmt.channels = info->codec_context->channels;
-    _info->fmt.samplerate = info->codec_context->sample_rate;
-    _info->fmt.bps = av_get_bytes_per_sample (info->codec_context->sample_fmt) * 8;
-    _info->fmt.is_float = (info->codec_context->sample_fmt == AV_SAMPLE_FMT_FLT || info->codec_context->sample_fmt == AV_SAMPLE_FMT_FLTP);
+    if (enable_dop && is_codec_dsd(info->codec_context->codec_id)) {
+        _info->fmt.samplerate =  info->codec_context->sample_rate / 2;
+        _info->fmt.bps = 32;
+        _info->fmt.is_dop = 1;
+        _info->fmt.is_float = 0;
+    } else {
+        _info->fmt.samplerate = info->codec_context->sample_rate;
+        _info->fmt.bps = av_get_bytes_per_sample (info->codec_context->sample_fmt) * 8;
+        _info->fmt.is_dop = 0;
+        _info->fmt.is_float = (info->codec_context->sample_fmt == AV_SAMPLE_FMT_FLT || info->codec_context->sample_fmt == AV_SAMPLE_FMT_FLTP);
+    }
 
     int samplesize = _info->fmt.channels * _info->fmt.bps / 8;
 
@@ -331,6 +371,9 @@ ffmpeg_read (DB_fileinfo_t *_info, char *bytes, int size) {
             int len = 0;
             //trace ("in: out_size=%d(%d), size=%d\n", out_size, AVCODEC_MAX_AUDIO_FRAME_SIZE, size);
 
+            if (enable_dop && is_codec_dsd(info->codec_context->codec_id)) {
+                len = info->pkt.size;
+            } else {
 #if LIBAVCODEC_VERSION_INT >= AV_VERSION_INT(55, 28, 0)
             int ret = avcodec_send_packet (info->codec_context, &info->pkt);
             if (ret < 0) {
@@ -347,39 +390,108 @@ ffmpeg_read (DB_fileinfo_t *_info, char *bytes, int size) {
             int got_frame = 0;
             len = avcodec_decode_audio4(info->ctx, info->frame, &got_frame, &info->pkt);
 #endif
-
+            }
             if (len > 0) {
-                if (ensure_buffer (info, info->frame->nb_samples * (_info->fmt.bps >> 3))) {
-                    return -1;
-                }
-                if (av_sample_fmt_is_planar(info->codec_context->sample_fmt)) {
-                    out_size = 0;
-                    for (int c = 0; c < info->codec_context->channels; c++) {
-                        for (int i = 0; i < info->frame->nb_samples; i++) {
-                            if (_info->fmt.bps == 8) {
-                                info->buffer[i*info->codec_context->channels+c] = ((int8_t *)info->frame->extended_data[c])[i];
-                                out_size++;
+                if (enable_dop && is_codec_dsd(info->codec_context->codec_id)) {
+                    out_size = info->pkt.size * 2;
+                    if (ensure_buffer (info, info->pkt.duration * 2)) {
+                        return -1;
+                    }
+
+                    int chCnt = info->codec_context->channels;
+                    int chSize = info->pkt.size / chCnt;
+                    uint32_t* pOut = (uint32_t*)info->buffer;
+                    uint8_t  marker = 0x05;
+
+                    if (info->codec_context->codec_id == AV_CODEC_ID_DSD_LSBF_PLANAR ||
+                        info->codec_context->codec_id == AV_CODEC_ID_DSD_MSBF_PLANAR) {
+
+                        uint8_t* pIn[chCnt];
+                        for (int i = 0; i < chCnt; i++) {
+                            pIn[i] = info->pkt.data + chSize * i;
+                        }
+
+                        if (info->codec_context->codec_id == AV_CODEC_ID_DSD_LSBF_PLANAR) {
+                            for (int i = 0; i < chSize; i+=2) {
+                                for (int ch = 0; ch < chCnt; ch++) {
+                                    *pOut++ = (uint32_t)marker                  << 24 |
+                                              bit_reverse_table[*pIn[ch]]       << 16 |
+                                              bit_reverse_table[*(pIn[ch] + 1)] << 8;
+                                    pIn[ch] += 2;
+                                }
+                                marker =~marker;
                             }
-                            else if (_info->fmt.bps == 16) {
-                                int16_t outsample = ((int16_t *)info->frame->extended_data[c])[i];
-                                ((int16_t*)info->buffer)[i*info->codec_context->channels+c] = outsample;
-                                out_size += 2;
-                            }
-                            else if (_info->fmt.bps == 24) {
-                                memcpy (&info->buffer[(i*info->codec_context->channels+c)*3], &((int8_t*)info->frame->extended_data[c])[i*3], 3);
-                                out_size += 3;
-                            }
-                            else if (_info->fmt.bps == 32) {
-                                int32_t sample = ((int32_t *)info->frame->extended_data[c])[i];
-                                ((int32_t*)info->buffer)[i*info->codec_context->channels+c] = sample;
-                                out_size += 4;
+                        }
+                        else {
+                            for (int i = 0; i < chSize / 2; i++) {
+                                for (int ch = 0; ch < chCnt; ch++) {
+                                    *pOut++ = (uint32_t)marker  << 24 |
+                                              *pIn[ch]          << 16 |
+                                              *(pIn[ch] + 1)    << 8;
+                                    pIn[ch] += 2;
+                                }
+                                marker =~marker;
                             }
                         }
                     }
-                }
-                else {
-                    out_size = info->frame->nb_samples * (_info->fmt.bps >> 3) * _info->fmt.channels;
-                    memcpy (info->buffer, info->frame->extended_data[0], out_size);
+                    else {
+                        uint8_t* pIn = info->pkt.data;
+                        if (info->codec_context->codec_id == AV_CODEC_ID_DSD_LSBF) {
+                            for (int i = 0; i < chSize / 2; i++) {
+                                for (int ch = 0; ch < chCnt; ch++) {
+                                    *pOut++ = (uint32_t)marker                       << 24 |
+                                              bit_reverse_table[*(pIn + ch)]         << 16 |
+                                              bit_reverse_table[*(pIn + ch + chCnt)] << 8;
+                                }
+                                pIn += chCnt * 2;
+                                marker =~marker;
+                            }
+                        }
+                        else {
+                            for (int i = 0; i < chSize / 2; i++) {
+                                for (int ch = 0; ch < chCnt; ch++) {
+                                    *pOut++ = (uint32_t)marker    << 24 |
+                                              *(pIn + ch)         << 16 |
+                                              *(pIn + ch + chCnt) << 8;
+                                }
+                                pIn += chCnt * 2;
+                                marker =~marker;
+                            }
+                        }
+                    }
+                } else {
+                    if (ensure_buffer (info, info->frame->nb_samples * (_info->fmt.bps >> 3))) {
+                        return -1;
+                    }
+                    if (av_sample_fmt_is_planar(info->codec_context->sample_fmt)) {
+                        out_size = 0;
+                        for (int c = 0; c < info->codec_context->channels; c++) {
+                            for (int i = 0; i < info->frame->nb_samples; i++) {
+                                if (_info->fmt.bps == 8) {
+                                    info->buffer[i*info->codec_context->channels+c] = ((int8_t *)info->frame->extended_data[c])[i];
+                                    out_size++;
+                                }
+                                else if (_info->fmt.bps == 16) {
+                                    int16_t outsample = ((int16_t *)info->frame->extended_data[c])[i];
+                                    ((int16_t*)info->buffer)[i*info->codec_context->channels+c] = outsample;
+                                    out_size += 2;
+                                }
+                                else if (_info->fmt.bps == 24) {
+                                    memcpy (&info->buffer[(i*info->codec_context->channels+c)*3], &((int8_t*)info->frame->extended_data[c])[i*3], 3);
+                                    out_size += 3;
+                                }
+                                else if (_info->fmt.bps == 32) {
+                                    int32_t sample = ((int32_t *)info->frame->extended_data[c])[i];
+                                    ((int32_t*)info->buffer)[i*info->codec_context->channels+c] = sample;
+                                    out_size += 4;
+                                }
+                            }
+                        }
+                    }
+                    else {
+                        out_size = info->frame->nb_samples * (_info->fmt.bps >> 3) * _info->fmt.channels;
+                        memcpy (info->buffer, info->frame->extended_data[0], out_size);
+                    }
                 }
             }
 
@@ -711,7 +823,12 @@ ffmpeg_insert (ddb_playlist_t *plt, DB_playItem_t *after, const char *fname) {
         deadbeef->pl_add_meta (it, ":BPS", s);
         snprintf (s, sizeof (s), "%d", info.codec_context->channels);
         deadbeef->pl_add_meta (it, ":CHANNELS", s);
-        snprintf (s, sizeof (s), "%d", samplerate);
+        if (is_codec_dsd(info.codec_context->codec_id)) {
+            snprintf (s, sizeof (s), "%d", samplerate * 8);
+        }
+        else {
+            snprintf (s, sizeof (s), "%d", samplerate);
+        }
         deadbeef->pl_add_meta (it, ":SAMPLERATE", s);
         int br = (int)roundf(fsize / duration * 8 / 1000);
         snprintf (s, sizeof (s), "%d", br);
@@ -838,6 +955,9 @@ ffmpeg_init_exts (void) {
         n = add_new_exts (n, UNPOPULATED_EXTS_BY_FFMPEG, ',');
     }
     exts[n] = NULL;
+
+    enable_dop = deadbeef->conf_get_int ("ffmpeg.enable_dop", 0);
+
     deadbeef->conf_unlock ();
 }
 
@@ -919,6 +1039,7 @@ error:
 static const char settings_dlg[] =
     "property \"Use all extensions supported by ffmpeg\" checkbox ffmpeg.enable_all_exts 0;\n"
     "property \"File Extensions (separate with ';')\" entry ffmpeg.extensions \"" DEFAULT_EXTS "\";\n"
+    "property \"Enable DoP output\" checkbox ffmpeg.enable_dop 0;\n"
 ;
 
 // define plugin interface

--- a/src/dsp.c
+++ b/src/dsp.c
@@ -382,6 +382,14 @@ dsp_apply (ddb_waveformat_t *input_fmt, char *input, int inputsize,
 
     *out_dsp_ratio = 1;
 
+    if (input_fmt->is_dop) {
+        memcpy(out_fmt, input_fmt, sizeof(ddb_waveformat_t));
+        *out_bytes = (char*)malloc(inputsize);
+        *out_numbytes = inputsize;
+        memcpy(*out_bytes, input, inputsize);
+        return 1;
+    }
+
     ddb_waveformat_t dspfmt;
     memcpy (&dspfmt, input_fmt, sizeof (ddb_waveformat_t));
     dspfmt.bps = 32;

--- a/src/dsp.c
+++ b/src/dsp.c
@@ -382,7 +382,7 @@ dsp_apply (ddb_waveformat_t *input_fmt, char *input, int inputsize,
 
     *out_dsp_ratio = 1;
 
-    if (input_fmt->is_dop) {
+    if (input_fmt->flags & DDB_WAVEFORMAT_FLAG_IS_DOP) {
         memcpy(out_fmt, input_fmt, sizeof(ddb_waveformat_t));
         *out_bytes = (char*)malloc(inputsize);
         *out_numbytes = inputsize;

--- a/src/replaygain.c
+++ b/src/replaygain.c
@@ -41,7 +41,7 @@ replaygain_apply_with_settings (ddb_replaygain_settings_t *settings, ddb_wavefor
     if (settings->processing_flags == 0) {
         return;
     }
-    if (fmt->is_dop) {
+    if (fmt->flags & DDB_WAVEFORMAT_FLAG_IS_DOP) {
         return;
     }
     if (fmt->bps == 16) {

--- a/src/replaygain.c
+++ b/src/replaygain.c
@@ -41,6 +41,9 @@ replaygain_apply_with_settings (ddb_replaygain_settings_t *settings, ddb_wavefor
     if (settings->processing_flags == 0) {
         return;
     }
+    if (fmt->is_dop) {
+        return;
+    }
     if (fmt->bps == 16) {
         apply_replay_gain_int16 (settings, bytes, numbytes);
     }

--- a/src/streamer.c
+++ b/src/streamer.c
@@ -2005,7 +2005,6 @@ process_output_block (streamblock_t *block, char *bytes, int bytes_available_siz
             .samplerate = block->fmt.samplerate,
             .channelmask = block->fmt.channelmask,
             .is_float = 0,
-            .is_bigendian = 0
         };
 
         pcm_convert (&block->fmt, (char *)input, &out_fmt, (char *)temp_audio_data, sz);
@@ -2093,7 +2092,7 @@ streamer_apply_soft_volume (char *bytes, int sz) {
         return;
     }
 
-    if (output->fmt.is_dop) {
+    if (output->fmt.flags & DDB_WAVEFORMAT_FLAG_IS_DOP) {
         return;
     }
 

--- a/src/streamer.c
+++ b/src/streamer.c
@@ -2093,6 +2093,10 @@ streamer_apply_soft_volume (char *bytes, int sz) {
         return;
     }
 
+    if (output->fmt.is_dop) {
+        return;
+    }
+
     float mod = 1.f;
 
     if (streamer_volume_modifier) {

--- a/src/viz.c
+++ b/src/viz.c
@@ -162,7 +162,7 @@ viz_process (char * restrict _bytes, int _bytes_size, DB_output_t *output, int f
         }
 
         char *bytes = _bytes;
-        if (output->fmt.is_dop) {
+        if (output->fmt.flags & DDB_WAVEFORMAT_FLAG_IS_DOP) {
             bytes = NULL;
         }
         
@@ -173,7 +173,6 @@ viz_process (char * restrict _bytes, int _bytes_size, DB_output_t *output, int f
         out_fmt->samplerate = output->fmt.samplerate;
         out_fmt->channelmask = output->fmt.channelmask;
         out_fmt->is_float = 1;
-        out_fmt->is_bigendian = 0;
 
         const int fft_nframes = fft_size * 2;
 

--- a/src/viz.c
+++ b/src/viz.c
@@ -161,6 +161,10 @@ viz_process (char * restrict _bytes, int _bytes_size, DB_output_t *output, int f
             return;
         }
 
+        if (output->fmt.is_dop) {
+            return;
+        }
+
         char *bytes = _bytes;
 
         // convert to float

--- a/src/viz.c
+++ b/src/viz.c
@@ -161,12 +161,11 @@ viz_process (char * restrict _bytes, int _bytes_size, DB_output_t *output, int f
             return;
         }
 
-        if (output->fmt.is_dop) {
-            return;
-        }
-
         char *bytes = _bytes;
-
+        if (output->fmt.is_dop) {
+            bytes = NULL;
+        }
+        
         // convert to float
         ddb_waveformat_t *out_fmt = calloc (1, sizeof (ddb_waveformat_t));
         out_fmt->bps = 32;


### PR DESCRIPTION
Based on @cqpwx's fork and https://github.com/marcoc1712/squeezelite-R2/blob/Release/dsd.c

Tested both DSF and DFF format.

To use it check `Enable DoP output` option in ffmpeg plugin. 