### PR TITLE
test: restore cpp libs even if tests fail

### DIFF
--- a/scripts/test.sh
+++ b/scripts/test.sh
@@ -1,6 +1,5 @@
 #!/bin/bash
 
-set -e
 shopt -s extglob
 
 BUILD=testbuild
@@ -27,23 +26,38 @@ mkdir -p "$BUILD"
 mkdir -p "$BUILD/cpplibs"
 mv $ORIGIN/$STATIC_DEPS/lib-x86-64/lib/*c++*.so* "$BUILD/cpplibs/"
 
-for file in $TEST_C_SOURCES; do
-    base=$(basename $file)
-    if [ "$base" = "main.c" ]; then
-        continue
-    fi
-    echo $CC -std=c99 $CFLAGS -c "$file" -o "$BUILD/${base%.@(c|cc|cpp)}.o"
-    $CC -std=c99 $CFLAGS -c "$file" -o "$BUILD/${base%.@(c|cc|cpp)}.o"
-done
+compile_tests() {
+    for file in $TEST_C_SOURCES; do
+        base=$(basename $file)
+        if [ "$base" = "main.c" ]; then
+            continue
+        fi
+        echo $CC -std=c99 $CFLAGS -c "$file" -o "$BUILD/${base%.@(c|cc|cpp)}.o"
+        $CC -std=c99 $CFLAGS -c "$file" -o "$BUILD/${base%.@(c|cc|cpp)}.o" || return $?
+    done
 
-for file in $GOOGLE_TEST_SOURCES $TEST_CPP_SOURCES; do
-    base=$(basename $file)
-    echo $CXX -std=c++14 $CFLAGS -c "$file" -o "$BUILD/${base%.@(c|cc|cpp)}.o"
-    $CXX -std=c++14 $CFLAGS -c "$file" -o "$BUILD/${base%.@(c|cc|cpp)}.o"
-done
+    for file in $GOOGLE_TEST_SOURCES $TEST_CPP_SOURCES; do
+        base=$(basename $file)
+        echo $CXX -std=c++14 $CFLAGS -c "$file" -o "$BUILD/${base%.@(c|cc|cpp)}.o"
+        $CXX -std=c++14 $CFLAGS -c "$file" -o "$BUILD/${base%.@(c|cc|cpp)}.o" || return $?
+    done
 
-$CXX $LDFLAGS $BUILD/*.o $LIBRARIES -o "$BUILD/runtests"
+    $CXX $LDFLAGS $BUILD/*.o $LIBRARIES -o "$BUILD/runtests" || return $?
+
+    return 0
+}
+
+restore_cpp_libs(){
+    mv "$BUILD"/cpplibs/* $ORIGIN/$STATIC_DEPS/lib-x86-64/lib/
+}
+
+compile_tests
+code=$?
+if [ $code -ne 0 ]; then
+    restore_cpp_libs
+    exit $code
+fi
+
 "$BUILD/runtests"
 
-# restore cpp libs
-mv "$BUILD"/cpplibs/* $ORIGIN/$STATIC_DEPS/lib-x86-64/lib/
+restore_cpp_libs


### PR DESCRIPTION
previously `test.sh` used `set -e` to exit if compiling the tests OR running them failed. this meant that the cpp libs had to be restored manually, as the final line of the script was not reached. by refactoring compilation into its own function and checking its return code, we can exit only when compilation fails. in this event, cpp libs are restored.