### PR TITLE
Fix deadbeef.desktop launcher

### DIFF
--- a/deadbeef.desktop.in
+++ b/deadbeef.desktop.in
@@ -14,7 +14,7 @@ Comment[zh_TW]=聆聽音樂
 Icon=deadbeef
 Exec=deadbeef %F
 Terminal=false
-Actions=Play;Pause;Toggle Pause;Stop;Next;Prev;
+Actions=Play;Pause;Toggle-Pause;Stop;Next;Prev;
 MimeType=application/ogg;audio/x-vorbis+ogg;application/x-ogg;audio/mp3;audio/prs.sid;audio/x-flac;audio/mpeg;audio/x-mpeg;audio/x-mod;audio/x-it;audio/x-s3m;audio/x-xm;audio/x-mpegurl;audio/x-scpls;application/x-cue;
 Categories=Audio;AudioVideo;Player;GTK;
 Keywords=Sound;Music;Audio;Player;Musicplayer;MP3;
@@ -35,7 +35,7 @@ Name[zh_CN]=暂停
 Name[zh_TW]=暫停
 Exec=deadbeef --pause
 
-[Desktop Action Toggle Pause]
+[Desktop Action Toggle-Pause]
 Name=Toggle Pause
 Name[zh_CN]=播放/暂停
 Name[zh_TW]=播放/暫停


### PR DESCRIPTION
The action identifiers may not contain spaces, only [A-Za-z0-9-]

https://specifications.freedesktop.org/desktop-entry-spec/desktop-entry-spec-latest.html#extra-actions-identifier
