### PR TITLE
tests: propagate exit code from running tests properly

### DIFF
--- a/scripts/test.sh
+++ b/scripts/test.sh
@@ -66,5 +66,7 @@ if [ $code -ne 0 ]; then
 fi
 
 "$BUILD/runtests"
+code=$?
 
 restore_cpp_libs
+exit $code


### PR DESCRIPTION
246e3b1 introduced a bug in the test script. If the test suite fails the script still continues, restores the cpp libs that were moved out of the `static-deps` folder, and exits with the exit code of that move. This hides failing or crashing tests from CI. Oops. Luckily it's easily fixed.