### PR TITLE
plugins: cdda: cdtext: Try reading magic track 0 first for album artist / title

### DIFF
--- a/plugins/cdda/cdda.c
+++ b/plugins/cdda/cdda.c
@@ -516,7 +516,10 @@ read_track_cdtext (CdIo_t *cdio, int track_nr, DB_playItem_t *item)
     int field_type;
     for (field_type = 0; field_type < MAX_CDTEXT_FIELDS; field_type++) {
 #if CDIO_API_VERSION >= 6
-        const char *text = cdtext_get_const (cdtext, field_type, track_nr);
+        const char *text = cdtext_get_const (cdtext, field_type, 0);
+        if (!text) {
+            text = cdtext_get_const (cdtext, field_type, track_nr);
+        }
 #else
         const char *text = cdtext_get_const (field_type, cdtext);
 #endif


### PR DESCRIPTION
Since cdio API version 6 (introduced in 2012) the magic track index 0 represents the album wide CD-TEXT. Trying to read album artist / title from the track_nr index will result in the track artist / track title being selected.

Having the Artist - Album playlist column enabled and relying on CD-TEXT would previously display the track title instead of the album title after the dash.

API ref: http://git.savannah.gnu.org/cgit/libcdio.git/tree/include/cdio/cdtext.h#n305

Example using the Memory Garden - 1349 CD with CD-Text, added to playlist before and after fix:

![deadbeef-cdtext-before-after](https://github.com/DeaDBeeF-Player/deadbeef/assets/4831577/2863fba6-e699-4323-a74f-922f398b09dd)
