### PR TITLE
deadbeef.h: fix too early deprecation of streamer_get_playing_track

### DIFF
--- a/include/deadbeef/deadbeef.h
+++ b/include/deadbeef/deadbeef.h
@@ -879,7 +879,7 @@ typedef struct {
 
     // streamer access
     /// This function is unsafe, and has been deprecated in favor of @c streamer_get_playing_track_safe
-    DB_playItem_t *(*streamer_get_playing_track) (void) DEPRECATED_16;
+    DB_playItem_t *(*streamer_get_playing_track) (void) DEPRECATED_116;
     DB_playItem_t *(*streamer_get_streaming_track) (void);
     float (*streamer_get_playpos) (void);
     int (*streamer_ok_to_read) (int len);


### PR DESCRIPTION
`streamer_get_playing_track_safe` is available if `DDB_API_LEVEL >= 16` (API version 1.16), but `streamer_get_playing_track` is defined with `DEPRECATED_16` (deprecate if API version >= 1.6). `DEPRECATED_116` should be used instead.
