### PR TITLE
formatting: run clang-format

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -3,7 +3,7 @@
 ---
 AccessModifierOffset: -4
 AlignAfterOpenBracket: AlwaysBreak
-AlignArrayOfStructures: None
+AlignArrayOfStructures: Left
 AlignConsecutiveMacros: None
 AlignConsecutiveAssignments: None
 AlignConsecutiveBitFields: None
@@ -170,5 +170,4 @@ UseTab:          Never
 WhitespaceSensitiveMacros:
   - NS_SWIFT_NAME
   - CF_SWIFT_NAME
-AlignArrayOfStructures: Left
 ...

--- a/Tests/AlbumNavigationTests.cpp
+++ b/Tests/AlbumNavigationTests.cpp
@@ -37,53 +37,53 @@ mainloop (void *ctx) {
             if (!term) {
                 DB_output_t *output = plug_get_output ();
                 switch (msg) {
-                    case DB_EV_TERMINATE:
-                        term = 1;
-                        break;
-                    case DB_EV_PLAY_CURRENT:
+                case DB_EV_TERMINATE:
+                    term = 1;
+                    break;
+                case DB_EV_PLAY_CURRENT:
+                    streamer_play_current_track ();
+                    break;
+                case DB_EV_PLAY_NUM:
+                    streamer_set_nextsong (p1, 0);
+                    break;
+                case DB_EV_STOP:
+                    streamer_set_nextsong (-1, 0);
+                    break;
+                case DB_EV_NEXT:
+                    streamer_move_to_nextsong (1);
+                    break;
+                case DB_EV_PREV:
+                    streamer_move_to_prevsong (1);
+                    break;
+                case DB_EV_PAUSE:
+                    if (output->state () != DDB_PLAYBACK_STATE_PAUSED) {
+                        output->pause ();
+                        messagepump_push (DB_EV_PAUSED, 0, 1, 0);
+                    }
+                    break;
+                case DB_EV_TOGGLE_PAUSE:
+                    if (output->state () != DDB_PLAYBACK_STATE_PLAYING) {
                         streamer_play_current_track ();
-                        break;
-                    case DB_EV_PLAY_NUM:
-                        streamer_set_nextsong (p1, 0);
-                        break;
-                    case DB_EV_STOP:
-                        streamer_set_nextsong (-1, 0);
-                        break;
-                    case DB_EV_NEXT:
-                        streamer_move_to_nextsong (1);
-                        break;
-                    case DB_EV_PREV:
-                        streamer_move_to_prevsong (1);
-                        break;
-                    case DB_EV_PAUSE:
-                        if (output->state () != DDB_PLAYBACK_STATE_PAUSED) {
-                            output->pause ();
-                            messagepump_push (DB_EV_PAUSED, 0, 1, 0);
-                        }
-                        break;
-                    case DB_EV_TOGGLE_PAUSE:
-                        if (output->state () != DDB_PLAYBACK_STATE_PLAYING) {
-                            streamer_play_current_track ();
-                        }
-                        else {
-                            output->pause ();
-                            messagepump_push (DB_EV_PAUSED, 0, 1, 0);
-                        }
-                        break;
-                    case DB_EV_PLAY_RANDOM:
-                        streamer_move_to_randomsong (1);
-                        break;
-                    case DB_EV_SEEK: {
-                        int32_t pos = (int32_t)p1;
-                        if (pos < 0) {
-                            pos = 0;
-                        }
-                        streamer_set_seek (p1 / 1000.f);
-                    } break;
-                    case DB_EV_SONGSTARTED:
-                        break;
-                    case DB_EV_TRACKINFOCHANGED:
-                        break;
+                    }
+                    else {
+                        output->pause ();
+                        messagepump_push (DB_EV_PAUSED, 0, 1, 0);
+                    }
+                    break;
+                case DB_EV_PLAY_RANDOM:
+                    streamer_move_to_randomsong (1);
+                    break;
+                case DB_EV_SEEK: {
+                    int32_t pos = (int32_t)p1;
+                    if (pos < 0) {
+                        pos = 0;
+                    }
+                    streamer_set_seek (p1 / 1000.f);
+                } break;
+                case DB_EV_SONGSTARTED:
+                    break;
+                case DB_EV_TRACKINFOCHANGED:
+                    break;
                 }
             }
             if (msg >= DB_EV_FIRST && ctx) {

--- a/Tests/CuesheetTests.cpp
+++ b/Tests/CuesheetTests.cpp
@@ -27,134 +27,129 @@
 #include <deadbeef/common.h>
 #include <gtest/gtest.h>
 
-class CuesheetTests: public ::testing::Test {
+class CuesheetTests : public ::testing::Test {
 protected:
-
-    void SetUp() override {
+    void SetUp () override {
         ddb_logger_init ();
         conf_init ();
         conf_enable_saving (0);
     }
 
-    void TearDown() override {
-        conf_free();
-        ddb_logger_free();
+    void TearDown () override {
+        conf_free ();
+        ddb_logger_free ();
     }
 };
 
+TEST_F (CuesheetTests, testCueWithoutTitles) {
+    const char cue[] = "FILE \"file.wav\" WAVE\n"
+                       "TRACK 01 AUDIO\n"
+                       "INDEX 01 00:00:00\n"
+                       "TRACK 02 AUDIO\n"
+                       "INDEX 01 05:50:65\n"
+                       "TRACK 03 AUDIO\n"
+                       "INDEX 01 09:47:50\n";
 
-TEST_F(CuesheetTests, testCueWithoutTitles) {
-    const char cue[] =
-        "FILE \"file.wav\" WAVE\n"
-        "TRACK 01 AUDIO\n"
-        "INDEX 01 00:00:00\n"
-        "TRACK 02 AUDIO\n"
-        "INDEX 01 05:50:65\n"
-        "TRACK 03 AUDIO\n"
-        "INDEX 01 09:47:50\n";
-
-    playlist_t *plt = plt_alloc("test");
+    playlist_t *plt = plt_alloc ("test");
 
     playItem_t *it = pl_item_alloc_init ("testfile.flac", "stdflac");
     pl_add_meta (it, "cuesheet", cue);
-    plt_process_cue(plt, NULL, it, 60*10*44100, 44100);
+    plt_process_cue (plt, NULL, it, 60 * 10 * 44100, 44100);
 
-    int cnt = plt_get_item_count(plt, PL_MAIN);
+    int cnt = plt_get_item_count (plt, PL_MAIN);
 
-    EXPECT_TRUE(cnt == 3);
+    EXPECT_TRUE (cnt == 3);
 
     plt_free (plt);
 }
 
-TEST_F(CuesheetTests, test_BogusEmbeddedImageCueInSingleTrack_ReturnsSingleTrackWithCorrectMeta) {
-    playlist_t *plt = plt_alloc("test");
+TEST_F (CuesheetTests, test_BogusEmbeddedImageCueInSingleTrack_ReturnsSingleTrackWithCorrectMeta) {
+    playlist_t *plt = plt_alloc ("test");
 
     char path[PATH_MAX];
     snprintf (path, sizeof (path), "%s/TestData/bogus_emb_cue.mp3", dbplugindir);
 
-    playItem_t *it = plt_insert_file2(0, plt, NULL, path, NULL, NULL, NULL);
+    playItem_t *it = plt_insert_file2 (0, plt, NULL, path, NULL, NULL, NULL);
 
-    EXPECT_NE(it, nullptr);
-    EXPECT_EQ(plt_get_item_count(plt, PL_MAIN), 1);
-    EXPECT_EQ(strcmp (pl_find_meta (it, "title"), "TrackTitle2"), 0);
-    EXPECT_EQ(strcmp (pl_find_meta (it, "track"), "2"), 0);
+    EXPECT_NE (it, nullptr);
+    EXPECT_EQ (plt_get_item_count (plt, PL_MAIN), 1);
+    EXPECT_EQ (strcmp (pl_find_meta (it, "title"), "TrackTitle2"), 0);
+    EXPECT_EQ (strcmp (pl_find_meta (it, "track"), "2"), 0);
 
     plt_free (plt);
 }
 
-TEST_F(CuesheetTests, test_ImageAndCue_Adds2TracksWithCorrectTitles) {
-    playlist_t *plt = plt_alloc("test");
+TEST_F (CuesheetTests, test_ImageAndCue_Adds2TracksWithCorrectTitles) {
+    playlist_t *plt = plt_alloc ("test");
 
     char path[PATH_MAX];
     snprintf (path, sizeof (path), "%s/TestData/image+cue", dbplugindir);
 
-    plt_insert_dir2(0, plt, NULL, path, NULL, NULL, NULL);
+    plt_insert_dir2 (0, plt, NULL, path, NULL, NULL, NULL);
 
-    EXPECT_EQ(plt_get_item_count(plt, PL_MAIN), 2);
-    EXPECT_EQ(strcmp (pl_find_meta (plt->head[PL_MAIN], "title"), "Test Track 01"), 0);
-    EXPECT_EQ(strcmp (pl_find_meta (plt->head[PL_MAIN]->next[PL_MAIN], "title"), "Test Track 02"), 0);
+    EXPECT_EQ (plt_get_item_count (plt, PL_MAIN), 2);
+    EXPECT_EQ (strcmp (pl_find_meta (plt->head[PL_MAIN], "title"), "Test Track 01"), 0);
+    EXPECT_EQ (strcmp (pl_find_meta (plt->head[PL_MAIN]->next[PL_MAIN], "title"), "Test Track 02"), 0);
 
     plt_free (plt);
 }
 
-TEST_F(CuesheetTests, test_CueWithTrackComposer_SetsCueComposerForOneTrack) {
-    const char cue[] =
-    "FILE \"file.wav\" WAVE\n"
-    "TRACK 01 AUDIO\n"
-    "REM COMPOSER \"TEST_COMPOSER\"\n"
-    "INDEX 01 00:00:00\n"
-    "TRACK 02 AUDIO\n"
-    "INDEX 01 00:01:00\n";
+TEST_F (CuesheetTests, test_CueWithTrackComposer_SetsCueComposerForOneTrack) {
+    const char cue[] = "FILE \"file.wav\" WAVE\n"
+                       "TRACK 01 AUDIO\n"
+                       "REM COMPOSER \"TEST_COMPOSER\"\n"
+                       "INDEX 01 00:00:00\n"
+                       "TRACK 02 AUDIO\n"
+                       "INDEX 01 00:01:00\n";
 
-    playlist_t *plt = plt_alloc("test");
+    playlist_t *plt = plt_alloc ("test");
 
     playItem_t *it = pl_item_alloc_init ("testfile.flac", "stdflac");
     pl_add_meta (it, "cuesheet", cue);
-    plt_process_cue(plt, NULL, it, 60*10*44100, 44100);
+    plt_process_cue (plt, NULL, it, 60 * 10 * 44100, 44100);
 
-    int cnt = plt_get_item_count(plt, PL_MAIN);
+    int cnt = plt_get_item_count (plt, PL_MAIN);
 
-    EXPECT_EQ(cnt, 2);
+    EXPECT_EQ (cnt, 2);
 
-    playItem_t *cueItem = plt_get_first(plt, PL_MAIN);
+    playItem_t *cueItem = plt_get_first (plt, PL_MAIN);
 
-    const char *composer = pl_find_meta(cueItem, "composer");
-    EXPECT_TRUE(composer);
-    EXPECT_TRUE(!strcmp(composer, "TEST_COMPOSER"));
+    const char *composer = pl_find_meta (cueItem, "composer");
+    EXPECT_TRUE (composer);
+    EXPECT_TRUE (!strcmp (composer, "TEST_COMPOSER"));
 
-    const char *composer2 = pl_find_meta(cueItem->next[PL_MAIN], "composer");
-    EXPECT_TRUE(composer2 == NULL);
+    const char *composer2 = pl_find_meta (cueItem->next[PL_MAIN], "composer");
+    EXPECT_TRUE (composer2 == NULL);
 
-    pl_item_unref(cueItem);
+    pl_item_unref (cueItem);
     plt_free (plt);
 }
 
-TEST_F(CuesheetTests, test_CueWithTrackGain_SetsCueTrackGainForOneTrack) {
-    const char cue[] =
-    "FILE \"file.wav\" WAVE\n"
-    "TRACK 01 AUDIO\n"
-    "REM COMPOSER \"TEST_COMPOSER\"\n"
-    "REM REPLAYGAIN_TRACK_GAIN +1.00 dB\n"
-    "INDEX 01 00:00:00\n"
-    "TRACK 02 AUDIO\n"
-    "INDEX 01 00:01:00\n";
+TEST_F (CuesheetTests, test_CueWithTrackGain_SetsCueTrackGainForOneTrack) {
+    const char cue[] = "FILE \"file.wav\" WAVE\n"
+                       "TRACK 01 AUDIO\n"
+                       "REM COMPOSER \"TEST_COMPOSER\"\n"
+                       "REM REPLAYGAIN_TRACK_GAIN +1.00 dB\n"
+                       "INDEX 01 00:00:00\n"
+                       "TRACK 02 AUDIO\n"
+                       "INDEX 01 00:01:00\n";
 
-    playlist_t *plt = plt_alloc("test");
+    playlist_t *plt = plt_alloc ("test");
 
     playItem_t *it = pl_item_alloc_init ("testfile.flac", "stdflac");
     pl_add_meta (it, "cuesheet", cue);
-    plt_process_cue(plt, NULL, it, 60*10*44100, 44100);
+    plt_process_cue (plt, NULL, it, 60 * 10 * 44100, 44100);
 
-    int cnt = plt_get_item_count(plt, PL_MAIN);
+    int cnt = plt_get_item_count (plt, PL_MAIN);
 
-    EXPECT_EQ(cnt, 2);
+    EXPECT_EQ (cnt, 2);
 
-    playItem_t *cueItem = plt_get_first(plt, PL_MAIN);
+    playItem_t *cueItem = plt_get_first (plt, PL_MAIN);
 
     const char *trackgain = pl_find_meta (cueItem, ":REPLAYGAIN_TRACKGAIN");
-    EXPECT_TRUE(trackgain!=NULL);
-    EXPECT_TRUE(!strcmp(trackgain, "1.00 dB"));
+    EXPECT_TRUE (trackgain != NULL);
+    EXPECT_TRUE (!strcmp (trackgain, "1.00 dB"));
 
-    pl_item_unref(cueItem);
+    pl_item_unref (cueItem);
     plt_free (plt);
 }

--- a/Tests/FormatConversionTests.cpp
+++ b/Tests/FormatConversionTests.cpp
@@ -25,54 +25,46 @@
 #include "premix.h"
 #include <gtest/gtest.h>
 
-TEST(FormatConversionTests, testConvertFromStereoToBackLeftBackRight_AllSamplesDiscarded) {
+TEST (FormatConversionTests, testConvertFromStereoToBackLeftBackRight_AllSamplesDiscarded) {
     int16_t samples[4] = { 0x1000, 0x2000, 0x3000, 0x4000 };
     int16_t outsamples[4] = { 0, 0, 0, 0 };
 
-    ddb_waveformat_t inputfmt = {
-        .bps = 16,
-        .channels = 2,
-        .samplerate = 44100,
-        .channelmask = DDB_SPEAKER_FRONT_LEFT|DDB_SPEAKER_FRONT_RIGHT
-    };
+    ddb_waveformat_t inputfmt = { .bps = 16,
+                                  .channels = 2,
+                                  .samplerate = 44100,
+                                  .channelmask = DDB_SPEAKER_FRONT_LEFT | DDB_SPEAKER_FRONT_RIGHT };
 
-    ddb_waveformat_t outputfmt = {
-        .bps = 16,
-        .channels = 2,
-        .samplerate = 44100,
-        .channelmask = DDB_SPEAKER_BACK_LEFT|DDB_SPEAKER_BACK_RIGHT
-    };
+    ddb_waveformat_t outputfmt = { .bps = 16,
+                                   .channels = 2,
+                                   .samplerate = 44100,
+                                   .channelmask = DDB_SPEAKER_BACK_LEFT | DDB_SPEAKER_BACK_RIGHT };
 
     int res = pcm_convert (&inputfmt, (const char *)samples, &outputfmt, (char *)outsamples, sizeof (samples));
-    EXPECT_TRUE(res == 8);
-    EXPECT_TRUE(outsamples[0] == 0);
-    EXPECT_TRUE(outsamples[1] == 0);
-    EXPECT_TRUE(outsamples[2] == 0);
-    EXPECT_TRUE(outsamples[3] == 0);
+    EXPECT_TRUE (res == 8);
+    EXPECT_TRUE (outsamples[0] == 0);
+    EXPECT_TRUE (outsamples[1] == 0);
+    EXPECT_TRUE (outsamples[2] == 0);
+    EXPECT_TRUE (outsamples[3] == 0);
 }
 
-TEST(FormatConversionTests, testConvertFromStereoToBackLeftFrontRight_LeftChannelDiscarded) {
+TEST (FormatConversionTests, testConvertFromStereoToBackLeftFrontRight_LeftChannelDiscarded) {
     int16_t samples[4] = { 0x1000, 0x2000, 0x3000, 0x4000 };
     int16_t outsamples[4] = { 0, 0, 0, 0 };
 
-    ddb_waveformat_t inputfmt = {
-        .bps = 16,
-        .channels = 2,
-        .samplerate = 44100,
-        .channelmask = DDB_SPEAKER_FRONT_LEFT|DDB_SPEAKER_FRONT_RIGHT
-    };
+    ddb_waveformat_t inputfmt = { .bps = 16,
+                                  .channels = 2,
+                                  .samplerate = 44100,
+                                  .channelmask = DDB_SPEAKER_FRONT_LEFT | DDB_SPEAKER_FRONT_RIGHT };
 
-    ddb_waveformat_t outputfmt = {
-        .bps = 16,
-        .channels = 2,
-        .samplerate = 44100,
-        .channelmask = DDB_SPEAKER_BACK_LEFT|DDB_SPEAKER_FRONT_RIGHT
-    };
+    ddb_waveformat_t outputfmt = { .bps = 16,
+                                   .channels = 2,
+                                   .samplerate = 44100,
+                                   .channelmask = DDB_SPEAKER_BACK_LEFT | DDB_SPEAKER_FRONT_RIGHT };
 
     int res = pcm_convert (&inputfmt, (const char *)samples, &outputfmt, (char *)outsamples, sizeof (samples));
-    EXPECT_TRUE(res == 8);
-    EXPECT_TRUE(outsamples[0] == 0);
-    EXPECT_TRUE(outsamples[1] == 0x2000);
-    EXPECT_TRUE(outsamples[2] == 0);
-    EXPECT_TRUE(outsamples[3] == 0x4000);
+    EXPECT_TRUE (res == 8);
+    EXPECT_TRUE (outsamples[0] == 0);
+    EXPECT_TRUE (outsamples[1] == 0x2000);
+    EXPECT_TRUE (outsamples[2] == 0);
+    EXPECT_TRUE (outsamples[3] == 0x4000);
 }

--- a/Tests/GrowableBufferTests.cpp
+++ b/Tests/GrowableBufferTests.cpp
@@ -6,47 +6,45 @@
 //  Copyright © 2020 Oleksiy Yakovenko. All rights reserved.
 //
 
-
 #include "growableBuffer.h"
 #include <gtest/gtest.h>
 
-TEST(GrowableBufferTests, test_printf_JustEnoughSpace_Success) {
+TEST (GrowableBufferTests, test_printf_JustEnoughSpace_Success) {
     growableBuffer_t buf;
-    growableBufferInitWithSize(&buf, 5);
-    growableBufferPrintf(&buf, "%s", "abcd");
-    EXPECT_EQ(buf.size, 5);
-    EXPECT_EQ(buf.avail, 1);
-    EXPECT_TRUE(!strcmp(buf.buffer, "abcd"));
-    growableBufferDealloc(&buf);
+    growableBufferInitWithSize (&buf, 5);
+    growableBufferPrintf (&buf, "%s", "abcd");
+    EXPECT_EQ (buf.size, 5);
+    EXPECT_EQ (buf.avail, 1);
+    EXPECT_TRUE (!strcmp (buf.buffer, "abcd"));
+    growableBufferDealloc (&buf);
 }
 
-TEST(GrowableBufferTests, test_printf_NotEnoughSpaceFor0_Grow) {
+TEST (GrowableBufferTests, test_printf_NotEnoughSpaceFor0_Grow) {
     growableBuffer_t buf;
-    growableBufferInitWithSize(&buf, 5);
-    growableBufferPrintf(&buf, "%s", "abcde");
-    EXPECT_EQ(buf.size, 1005);
-    EXPECT_EQ(buf.avail, 1000);
-    EXPECT_TRUE(!strcmp(buf.buffer, "abcde"));
-    growableBufferDealloc(&buf);
+    growableBufferInitWithSize (&buf, 5);
+    growableBufferPrintf (&buf, "%s", "abcde");
+    EXPECT_EQ (buf.size, 1005);
+    EXPECT_EQ (buf.avail, 1000);
+    EXPECT_TRUE (!strcmp (buf.buffer, "abcde"));
+    growableBufferDealloc (&buf);
 }
 
-TEST(GrowableBufferTests, test_printf_NotEnoughSpaceForString_Grow) {
+TEST (GrowableBufferTests, test_printf_NotEnoughSpaceForString_Grow) {
     growableBuffer_t buf;
-    growableBufferInitWithSize(&buf, 5);
-    growableBufferPrintf(&buf, "%s", "abcdeEFGHI");
-    EXPECT_EQ(buf.size, 1005);
-    EXPECT_EQ(buf.avail, 995);
-    EXPECT_TRUE(!strcmp(buf.buffer, "abcdeEFGHI"));
-    growableBufferDealloc(&buf);
+    growableBufferInitWithSize (&buf, 5);
+    growableBufferPrintf (&buf, "%s", "abcdeEFGHI");
+    EXPECT_EQ (buf.size, 1005);
+    EXPECT_EQ (buf.avail, 995);
+    EXPECT_TRUE (!strcmp (buf.buffer, "abcdeEFGHI"));
+    growableBufferDealloc (&buf);
 }
 
-TEST(GrowableBufferTests, test_printf_EmptyString_NothingHappens) {
-    growableBuffer_t *buf = growableBufferInitWithSize (growableBufferAlloc(), 1000);
-    growableBufferInitWithSize(buf, 5);
-    growableBufferPrintf(buf, "");
-    EXPECT_EQ(buf->size, 5);
-    EXPECT_EQ(buf->avail, 5);
-    EXPECT_TRUE(!strcmp(buf->buffer, ""));
-    growableBufferFree(buf);
+TEST (GrowableBufferTests, test_printf_EmptyString_NothingHappens) {
+    growableBuffer_t *buf = growableBufferInitWithSize (growableBufferAlloc (), 1000);
+    growableBufferInitWithSize (buf, 5);
+    growableBufferPrintf (buf, "");
+    EXPECT_EQ (buf->size, 5);
+    EXPECT_EQ (buf->avail, 5);
+    EXPECT_TRUE (!strcmp (buf->buffer, ""));
+    growableBufferFree (buf);
 }
-

--- a/Tests/JunklibTests.cpp
+++ b/Tests/JunklibTests.cpp
@@ -26,50 +26,72 @@
 #include <gtest/gtest.h>
 
 extern "C" {
-    ConversionResult
-    ConvertUTF16BEtoUTF8 (const UTF16** sourceStart, const UTF16* sourceEnd, UTF8** targetStart, UTF8* targetEnd, ConversionFlags flags);
+ConversionResult
+ConvertUTF16BEtoUTF8 (
+    const UTF16 **sourceStart,
+    const UTF16 *sourceEnd,
+    UTF8 **targetStart,
+    UTF8 *targetEnd,
+    ConversionFlags flags);
 
-    ConversionResult
-    ConvertUTF8toUTF16BE (const UTF8** sourceStart, const UTF8* sourceEnd, UTF16** targetStart, UTF16* targetEnd, ConversionFlags flags);
+ConversionResult
+ConvertUTF8toUTF16BE (
+    const UTF8 **sourceStart,
+    const UTF8 *sourceEnd,
+    UTF16 **targetStart,
+    UTF16 *targetEnd,
+    ConversionFlags flags);
 
-    void
-    _split_multivalue (char *text, size_t text_size);
+void
+_split_multivalue (char *text, size_t text_size);
 
-    int
-    junk_utf8_to_cp1252(const uint8_t *in, int inlen, uint8_t *out, int outlen);
+int
+junk_utf8_to_cp1252 (const uint8_t *in, int inlen, uint8_t *out, int outlen);
 }
 
-TEST(JunklibTests, testConvertUTF16BEtoUTF8) {
-    const char input[] = {0x04, 0x10, 0x04, 0x11, 0x04, 0x12, 0x04, 0x13, 0x04, 0x14, 0x00, 0x61, 0x00, 0x62, 0x00, 0x63, 0x00, 0x64};
+TEST (JunklibTests, testConvertUTF16BEtoUTF8) {
+    const char input[] = { 0x04, 0x10, 0x04, 0x11, 0x04, 0x12, 0x04, 0x13, 0x04,
+                           0x14, 0x00, 0x61, 0x00, 0x62, 0x00, 0x63, 0x00, 0x64 };
     const char *pInput = input;
     size_t inlen = sizeof (input);
     char output[1024];
     size_t outlen = sizeof (output);
     memset (output, 0, outlen);
     char *pOut = output;
-    ConversionResult result = ConvertUTF16BEtoUTF8 ((const UTF16**)&pInput, (const UTF16*)(input + inlen), (UTF8**)&pOut, (UTF8*)(output + outlen), strictConversion);
+    ConversionResult result = ConvertUTF16BEtoUTF8 (
+        (const UTF16 **)&pInput,
+        (const UTF16 *)(input + inlen),
+        (UTF8 **)&pOut,
+        (UTF8 *)(output + outlen),
+        strictConversion);
 
     *pOut = 0;
 
-    EXPECT_TRUE(result == conversionOK && !strcmp (output, "АБВГДabcd"));
+    EXPECT_TRUE (result == conversionOK && !strcmp (output, "АБВГДabcd"));
 }
 
-TEST(JunklibTests, testConvertUTF16toUTF8) {
-    const char input[] = {0x10, 0x04, 0x11, 0x04, 0x12, 0x04, 0x13, 0x04, 0x14, 0x04, 0x61, 0x00, 0x62, 0x00, 0x63, 0x00, 0x64, 0x00};
+TEST (JunklibTests, testConvertUTF16toUTF8) {
+    const char input[] = { 0x10, 0x04, 0x11, 0x04, 0x12, 0x04, 0x13, 0x04, 0x14,
+                           0x04, 0x61, 0x00, 0x62, 0x00, 0x63, 0x00, 0x64, 0x00 };
     const char *pInput = input;
     size_t inlen = sizeof (input);
     char output[1024];
     size_t outlen = sizeof (output);
     memset (output, 0, outlen);
     char *pOut = output;
-    ConversionResult result = ConvertUTF16toUTF8 ((const UTF16**)&pInput, (const UTF16*)(input + inlen), (UTF8**)&pOut, (UTF8*)(output + outlen), strictConversion);
+    ConversionResult result = ConvertUTF16toUTF8 (
+        (const UTF16 **)&pInput,
+        (const UTF16 *)(input + inlen),
+        (UTF8 **)&pOut,
+        (UTF8 *)(output + outlen),
+        strictConversion);
 
     *pOut = 0;
 
-    EXPECT_TRUE(result == conversionOK && !strcmp (output, "АБВГДabcd"));
+    EXPECT_TRUE (result == conversionOK && !strcmp (output, "АБВГДabcd"));
 }
 
-TEST(JunklibTests, testConvertUTF8toUTF16) {
+TEST (JunklibTests, testConvertUTF8toUTF16) {
     const char input[] = "АБВГДabcd";
     const char *pInput = input;
     size_t inlen = sizeof (input);
@@ -77,16 +99,21 @@ TEST(JunklibTests, testConvertUTF8toUTF16) {
     size_t outlen = sizeof (output);
     memset (output, 0, outlen);
     char *pOut = output;
-    ConversionResult result = ConvertUTF8toUTF16 ((const UTF8**)&pInput, (const UTF8*)(input + inlen), (UTF16**)&pOut, (UTF16*)(output + outlen), strictConversion);
+    ConversionResult result = ConvertUTF8toUTF16 (
+        (const UTF8 **)&pInput,
+        (const UTF8 *)(input + inlen),
+        (UTF16 **)&pOut,
+        (UTF16 *)(output + outlen),
+        strictConversion);
 
     *pOut = 0;
 
-    const char utf16be_reference[] = {0x10, 0x04, 0x11, 0x04, 0x12, 0x04, 0x13, 0x04, 0x14, 0x04, 0x61, 0x00, 0x62, 0x00, 0x63, 0x00, 0x64, 0x00};
-    EXPECT_TRUE(result == conversionOK && !memcmp (output, utf16be_reference, sizeof (utf16be_reference)));
+    const char utf16be_reference[] = { 0x10, 0x04, 0x11, 0x04, 0x12, 0x04, 0x13, 0x04, 0x14,
+                                       0x04, 0x61, 0x00, 0x62, 0x00, 0x63, 0x00, 0x64, 0x00 };
+    EXPECT_TRUE (result == conversionOK && !memcmp (output, utf16be_reference, sizeof (utf16be_reference)));
 }
 
-
-TEST(JunklibTests, testConvertUTF8toUTF16BE) {
+TEST (JunklibTests, testConvertUTF8toUTF16BE) {
 
     const char input[] = "АБВГДabcd";
     const char *pInput = input;
@@ -95,196 +122,202 @@ TEST(JunklibTests, testConvertUTF8toUTF16BE) {
     size_t outlen = sizeof (output);
     memset (output, 0, outlen);
     char *pOut = output;
-    ConversionResult result = ConvertUTF8toUTF16BE ((const UTF8**)&pInput, (const UTF8*)(input + inlen), (UTF16**)&pOut, (UTF16*)(output + outlen), strictConversion);
+    ConversionResult result = ConvertUTF8toUTF16BE (
+        (const UTF8 **)&pInput,
+        (const UTF8 *)(input + inlen),
+        (UTF16 **)&pOut,
+        (UTF16 *)(output + outlen),
+        strictConversion);
 
     *pOut = 0;
 
-    const char utf16be_reference[] = {0x04, 0x10, 0x04, 0x11, 0x04, 0x12, 0x04, 0x13, 0x04, 0x14, 0x00, 0x61, 0x00, 0x62, 0x00, 0x63, 0x00, 0x64};
-    EXPECT_TRUE(result == conversionOK && !memcmp (output, utf16be_reference, sizeof (utf16be_reference)));
+    const char utf16be_reference[] = { 0x04, 0x10, 0x04, 0x11, 0x04, 0x12, 0x04, 0x13, 0x04,
+                                       0x14, 0x00, 0x61, 0x00, 0x62, 0x00, 0x63, 0x00, 0x64 };
+    EXPECT_TRUE (result == conversionOK && !memcmp (output, utf16be_reference, sizeof (utf16be_reference)));
 }
 
-TEST(JunklibTests, testConvertUTF8toCP1252) {
+TEST (JunklibTests, testConvertUTF8toCP1252) {
     const char input[] = "€ù‰•abcd";
-    size_t inlen = sizeof (input)-1;
+    size_t inlen = sizeof (input) - 1;
     char output[1024];
     size_t outlen = sizeof (output);
     memset (output, 0, outlen);
 
-    int res = junk_utf8_to_cp1252((const uint8_t *)input, (int)inlen, (uint8_t *)output, (int)outlen);
+    int res = junk_utf8_to_cp1252 ((const uint8_t *)input, (int)inlen, (uint8_t *)output, (int)outlen);
 
     const unsigned char cp1252_reference[] = { 0x80, 0xf9, 0x89, 0x95, 0x61, 0x62, 0x63, 0x64 };
-    EXPECT_TRUE(res == sizeof (cp1252_reference) && !memcmp (output, cp1252_reference, sizeof (cp1252_reference)));
+    EXPECT_TRUE (res == sizeof (cp1252_reference) && !memcmp (output, cp1252_reference, sizeof (cp1252_reference)));
 }
 
-TEST(JunklibTests, testSplitMultivalue_IgnoresUnspacedSlash) {
+TEST (JunklibTests, testSplitMultivalue_IgnoresUnspacedSlash) {
     char input[] = "Test/Value/With/Shashes";
-    _split_multivalue(input, sizeof (input)-1);
+    _split_multivalue (input, sizeof (input) - 1);
 
-    EXPECT_TRUE(!strcmp (input, "Test/Value/With/Shashes"));
+    EXPECT_TRUE (!strcmp (input, "Test/Value/With/Shashes"));
 }
 
-TEST(JunklibTests, testSplitMultivalue_SplitsOnSpacedSlash) {
+TEST (JunklibTests, testSplitMultivalue_SplitsOnSpacedSlash) {
     char input[] = "Test / Value / With / Shashes";
-    _split_multivalue(input, sizeof (input)-1);
+    _split_multivalue (input, sizeof (input) - 1);
 
-    EXPECT_TRUE(!strcmp (input, "Test\0\0\0Value\0\0\0With\0\0\0Shashes"));
+    EXPECT_TRUE (!strcmp (input, "Test\0\0\0Value\0\0\0With\0\0\0Shashes"));
 }
 
-TEST(JunklibTests, testSplitMultivalue_IgnoreSpacedSlashBegin) {
+TEST (JunklibTests, testSplitMultivalue_IgnoreSpacedSlashBegin) {
     char input[] = "/ Test";
-    _split_multivalue(input, sizeof (input)-1);
+    _split_multivalue (input, sizeof (input) - 1);
 
-    EXPECT_TRUE(!strcmp (input, "/ Test"));
+    EXPECT_TRUE (!strcmp (input, "/ Test"));
 }
 
-TEST(JunklibTests, testSplitMultivalue_IgnoreSpacedSlashEnd) {
+TEST (JunklibTests, testSplitMultivalue_IgnoreSpacedSlashEnd) {
     char input[] = "Test /";
-    _split_multivalue(input, sizeof (input)-1);
+    _split_multivalue (input, sizeof (input) - 1);
 
-    EXPECT_TRUE(!strcmp (input, "Test /"));
+    EXPECT_TRUE (!strcmp (input, "Test /"));
 }
 
-TEST(JunklibTests, test_starsFromPopmRating_0_0) {
+TEST (JunklibTests, test_starsFromPopmRating_0_0) {
     unsigned stars = junk_stars_from_popm_rating (0);
-    EXPECT_EQ(stars, 0);
+    EXPECT_EQ (stars, 0);
 }
 
-TEST(JunklibTests, test_starsFromPopmRating_1_1) {
+TEST (JunklibTests, test_starsFromPopmRating_1_1) {
     unsigned stars = junk_stars_from_popm_rating (1);
-    EXPECT_EQ(stars, 1);
+    EXPECT_EQ (stars, 1);
 }
 
-TEST(JunklibTests, test_starsFromPopmRating_63_1) {
+TEST (JunklibTests, test_starsFromPopmRating_63_1) {
     unsigned stars = junk_stars_from_popm_rating (63);
-    EXPECT_EQ(stars, 1);
+    EXPECT_EQ (stars, 1);
 }
 
-TEST(JunklibTests, test_starsFromPopmRating_64_2) {
+TEST (JunklibTests, test_starsFromPopmRating_64_2) {
     unsigned stars = junk_stars_from_popm_rating (64);
-    EXPECT_EQ(stars, 2);
+    EXPECT_EQ (stars, 2);
 }
 
-TEST(JunklibTests, test_starsFromPopmRating_127_2) {
+TEST (JunklibTests, test_starsFromPopmRating_127_2) {
     unsigned stars = junk_stars_from_popm_rating (127);
-    EXPECT_EQ(stars, 2);
+    EXPECT_EQ (stars, 2);
 }
 
-TEST(JunklibTests, test_starsFromPopmRating_128_3) {
+TEST (JunklibTests, test_starsFromPopmRating_128_3) {
     unsigned stars = junk_stars_from_popm_rating (128);
-    EXPECT_EQ(stars, 3);
+    EXPECT_EQ (stars, 3);
 }
 
-TEST(JunklibTests, test_starsFromPopmRating_195_3) {
+TEST (JunklibTests, test_starsFromPopmRating_195_3) {
     unsigned stars = junk_stars_from_popm_rating (195);
-    EXPECT_EQ(stars, 3);
+    EXPECT_EQ (stars, 3);
 }
 
-TEST(JunklibTests, test_starsFromPopmRating_196_4) {
+TEST (JunklibTests, test_starsFromPopmRating_196_4) {
     unsigned stars = junk_stars_from_popm_rating (196);
-    EXPECT_EQ(stars, 4);
+    EXPECT_EQ (stars, 4);
 }
 
-TEST(JunklibTests, test_starsFromPopmRating_254_4) {
+TEST (JunklibTests, test_starsFromPopmRating_254_4) {
     unsigned stars = junk_stars_from_popm_rating (254);
-    EXPECT_EQ(stars, 4);
+    EXPECT_EQ (stars, 4);
 }
 
-TEST(JunklibTests, test_starsFromPopmRating_255_5) {
+TEST (JunklibTests, test_starsFromPopmRating_255_5) {
     unsigned stars = junk_stars_from_popm_rating (255);
-    EXPECT_EQ(stars, 5);
+    EXPECT_EQ (stars, 5);
 }
 
-TEST(JunklibTests, test_popmRatingFromStars_0_0) {
-    uint8_t rating = junk_popm_rating_from_stars(0);
-    EXPECT_EQ(rating, 0);
+TEST (JunklibTests, test_popmRatingFromStars_0_0) {
+    uint8_t rating = junk_popm_rating_from_stars (0);
+    EXPECT_EQ (rating, 0);
 }
 
-TEST(JunklibTests, test_popmRatingFromStars_1_63) {
-    uint8_t rating = junk_popm_rating_from_stars(1);
-    EXPECT_EQ(rating, 63);
+TEST (JunklibTests, test_popmRatingFromStars_1_63) {
+    uint8_t rating = junk_popm_rating_from_stars (1);
+    EXPECT_EQ (rating, 63);
 }
 
-TEST(JunklibTests, test_popmRatingFromStars_2_127) {
-    uint8_t rating = junk_popm_rating_from_stars(2);
-    EXPECT_EQ(rating, 127);
+TEST (JunklibTests, test_popmRatingFromStars_2_127) {
+    uint8_t rating = junk_popm_rating_from_stars (2);
+    EXPECT_EQ (rating, 127);
 }
 
-TEST(JunklibTests, test_popmRatingFromStars_3_195) {
-    uint8_t rating = junk_popm_rating_from_stars(3);
-    EXPECT_EQ(rating, 195);
+TEST (JunklibTests, test_popmRatingFromStars_3_195) {
+    uint8_t rating = junk_popm_rating_from_stars (3);
+    EXPECT_EQ (rating, 195);
 }
 
-TEST(JunklibTests, test_popmRatingFromStars_4_254) {
-    uint8_t rating = junk_popm_rating_from_stars(4);
-    EXPECT_EQ(rating, 254);
+TEST (JunklibTests, test_popmRatingFromStars_4_254) {
+    uint8_t rating = junk_popm_rating_from_stars (4);
+    EXPECT_EQ (rating, 254);
 }
 
-TEST(JunklibTests, test_junkMakeTdrcString_fullInput_validOutput) {
+TEST (JunklibTests, test_junkMakeTdrcString_fullInput_validOutput) {
     char buffer[100];
-    junk_make_tdrc_string(buffer, sizeof(buffer), 2022, 11, 7, 16, 55);
+    junk_make_tdrc_string (buffer, sizeof (buffer), 2022, 11, 7, 16, 55);
 
-    EXPECT_TRUE(!strcmp(buffer, "2022-11-07-T16:55"));
+    EXPECT_TRUE (!strcmp (buffer, "2022-11-07-T16:55"));
 }
 
-TEST(JunklibTests, test_junkMakeTdrcString_invalidHours_noTimeInOutput) {
+TEST (JunklibTests, test_junkMakeTdrcString_invalidHours_noTimeInOutput) {
     char buffer[100];
-    junk_make_tdrc_string(buffer, sizeof(buffer), 2022, 11, 7, -1, 55);
+    junk_make_tdrc_string (buffer, sizeof (buffer), 2022, 11, 7, -1, 55);
 
-    EXPECT_TRUE(!strcmp(buffer, "2022-11-07"));
+    EXPECT_TRUE (!strcmp (buffer, "2022-11-07"));
 }
 
-TEST(JunklibTests, test_junkMakeTdrcString_invalidMinutes_noTimeInOutput) {
+TEST (JunklibTests, test_junkMakeTdrcString_invalidMinutes_noTimeInOutput) {
     char buffer[100];
-    junk_make_tdrc_string(buffer, sizeof(buffer), 2022, 11, 7, 16, -1);
+    junk_make_tdrc_string (buffer, sizeof (buffer), 2022, 11, 7, 16, -1);
 
-    EXPECT_TRUE(!strcmp(buffer, "2022-11-07"));
+    EXPECT_TRUE (!strcmp (buffer, "2022-11-07"));
 }
 
-TEST(JunklibTests, test_junkMakeTdrcString_zeroMinutes_validOutputWithTime) {
+TEST (JunklibTests, test_junkMakeTdrcString_zeroMinutes_validOutputWithTime) {
     char buffer[100];
-    junk_make_tdrc_string(buffer, sizeof(buffer), 2022, 11, 7, 16, 00);
+    junk_make_tdrc_string (buffer, sizeof (buffer), 2022, 11, 7, 16, 00);
 
-    EXPECT_TRUE(!strcmp(buffer, "2022-11-07-T16:00"));
+    EXPECT_TRUE (!strcmp (buffer, "2022-11-07-T16:00"));
 }
 
-TEST(JunklibTests, test_junkMakeTdrcString_zeroHours_validOutputWithTime) {
+TEST (JunklibTests, test_junkMakeTdrcString_zeroHours_validOutputWithTime) {
     char buffer[100];
-    junk_make_tdrc_string(buffer, sizeof(buffer), 2022, 11, 7, 00, 55);
+    junk_make_tdrc_string (buffer, sizeof (buffer), 2022, 11, 7, 00, 55);
 
-    EXPECT_TRUE(!strcmp(buffer, "2022-11-07-T00:55"));
+    EXPECT_TRUE (!strcmp (buffer, "2022-11-07-T00:55"));
 }
 
-TEST(JunklibTests, test_junkMakeTdrcString_invalidDay_emptyOutput) {
+TEST (JunklibTests, test_junkMakeTdrcString_invalidDay_emptyOutput) {
     char buffer[100];
-    junk_make_tdrc_string(buffer, sizeof(buffer), 2022, 11, -1, 16, 55);
+    junk_make_tdrc_string (buffer, sizeof (buffer), 2022, 11, -1, 16, 55);
 
-    EXPECT_STREQ(buffer, "");
+    EXPECT_STREQ (buffer, "");
 }
 
-TEST(JunklibTests, test_junkMakeTdrcString_invalidMonth_emptyOutput) {
+TEST (JunklibTests, test_junkMakeTdrcString_invalidMonth_emptyOutput) {
     char buffer[100];
-    junk_make_tdrc_string(buffer, sizeof(buffer), 2022, 0, 7, 16, 55);
+    junk_make_tdrc_string (buffer, sizeof (buffer), 2022, 0, 7, 16, 55);
 
-    EXPECT_STREQ(buffer, "");
+    EXPECT_STREQ (buffer, "");
 }
 
-TEST(JunklibTests, test_junkMakeTdrcString_invalidYear_emptyOutput) {
+TEST (JunklibTests, test_junkMakeTdrcString_invalidYear_emptyOutput) {
     char buffer[100];
-    junk_make_tdrc_string(buffer, sizeof(buffer), 0, 11, 7, 16, 55);
+    junk_make_tdrc_string (buffer, sizeof (buffer), 0, 11, 7, 16, 55);
 
-    EXPECT_STREQ(buffer, "");
+    EXPECT_STREQ (buffer, "");
 }
 
-TEST(JunklibTests, test_junkMakeTdrcString_bufferTooSmallForTime_outputClippedAtDateBoundary) {
+TEST (JunklibTests, test_junkMakeTdrcString_bufferTooSmallForTime_outputClippedAtDateBoundary) {
     char buffer[12];
-    junk_make_tdrc_string(buffer, sizeof(buffer), 2022, 11, 7, 16, 55);
+    junk_make_tdrc_string (buffer, sizeof (buffer), 2022, 11, 7, 16, 55);
 
-    EXPECT_TRUE(!strcmp(buffer, "2022-11-07"));
+    EXPECT_TRUE (!strcmp (buffer, "2022-11-07"));
 }
 
-TEST(JunklibTests, test_junkMakeTdrcString_bufferTooSmallForDate_outputEmpty) {
+TEST (JunklibTests, test_junkMakeTdrcString_bufferTooSmallForDate_outputEmpty) {
     char buffer[5];
-    junk_make_tdrc_string(buffer, sizeof(buffer), 2022, 11, 7, 16, 55);
+    junk_make_tdrc_string (buffer, sizeof (buffer), 2022, 11, 7, 16, 55);
 
-    EXPECT_TRUE(!strcmp(buffer, ""));
+    EXPECT_TRUE (!strcmp (buffer, ""));
 }

--- a/Tests/M3UTests.cpp
+++ b/Tests/M3UTests.cpp
@@ -14,139 +14,143 @@
 
 extern DB_functions_t *deadbeef;
 
-class M3UTests: public ::testing::Test {
+class M3UTests : public ::testing::Test {
 protected:
-    void SetUp() override {
+    void SetUp () override {
         ddb_logger_init ();
         conf_init ();
         conf_enable_saving (0);
 
-        m3u_load(deadbeef);
+        m3u_load (deadbeef);
     }
-    void TearDown() override {
-        conf_free();
-        ddb_logger_free();
+    void TearDown () override {
+        conf_free ();
+        ddb_logger_free ();
     }
 };
 
-TEST_F(M3UTests, test_loadM3UFromBuffer_SimplePlaylist_Loads2Items) {
+TEST_F (M3UTests, test_loadM3UFromBuffer_SimplePlaylist_Loads2Items) {
     char m3u[1000];
-    snprintf (m3u, sizeof (m3u),
-              "#EXTM3U\n"
-              "%s/TestData/chirp-1sec.mp3\n"
-              "%s/TestData/comm_id3v2.3.mp3\n",
-              dbplugindir, dbplugindir
-              );
+    snprintf (
+        m3u,
+        sizeof (m3u),
+        "#EXTM3U\n"
+        "%s/TestData/chirp-1sec.mp3\n"
+        "%s/TestData/comm_id3v2.3.mp3\n",
+        dbplugindir,
+        dbplugindir);
 
-    ddb_playlist_t *plt = deadbeef->plt_alloc("plt");
+    ddb_playlist_t *plt = deadbeef->plt_alloc ("plt");
 
-    ddb_playItem_t *after = load_m3u_from_buffer(NULL, m3u, strlen(m3u), NULL, "", NULL, plt, NULL);
+    ddb_playItem_t *after = load_m3u_from_buffer (NULL, m3u, strlen (m3u), NULL, "", NULL, plt, NULL);
 
-    EXPECT_TRUE(after);
-    EXPECT_EQ(deadbeef->plt_get_item_count(plt, PL_MAIN), 2);
+    EXPECT_TRUE (after);
+    EXPECT_EQ (deadbeef->plt_get_item_count (plt, PL_MAIN), 2);
 
     deadbeef->plt_unref (plt);
 }
 
-TEST_F(M3UTests, test_loadM3UFromBuffer_UnicodeCharactersNoDash_LoadsItemWithCorrectArtistTitle) {
+TEST_F (M3UTests, test_loadM3UFromBuffer_UnicodeCharactersNoDash_LoadsItemWithCorrectArtistTitle) {
     char m3u[1000];
-    snprintf (m3u, sizeof (m3u),
-              "#EXTM3U\n"
-              "#EXTINF:123, АБВГД\n"
-              "%s/TestData/chirp-1sec.mp3\n",
-              dbplugindir
-              );
+    snprintf (
+        m3u,
+        sizeof (m3u),
+        "#EXTM3U\n"
+        "#EXTINF:123, АБВГД\n"
+        "%s/TestData/chirp-1sec.mp3\n",
+        dbplugindir);
 
-    ddb_playlist_t *plt = deadbeef->plt_alloc("plt");
+    ddb_playlist_t *plt = deadbeef->plt_alloc ("plt");
 
-    ddb_playItem_t *after = load_m3u_from_buffer(NULL, m3u, strlen(m3u), NULL, "", NULL, plt, NULL);
+    ddb_playItem_t *after = load_m3u_from_buffer (NULL, m3u, strlen (m3u), NULL, "", NULL, plt, NULL);
 
-    EXPECT_TRUE(after);
-    EXPECT_EQ(deadbeef->plt_get_item_count(plt, PL_MAIN), 1);
+    EXPECT_TRUE (after);
+    EXPECT_EQ (deadbeef->plt_get_item_count (plt, PL_MAIN), 1);
 
-    const char *title = deadbeef->pl_find_meta(after, "title");
-    const char *artist = deadbeef->pl_find_meta(after, "artist");
+    const char *title = deadbeef->pl_find_meta (after, "title");
+    const char *artist = deadbeef->pl_find_meta (after, "artist");
 
-    EXPECT_TRUE(!strcmp (title, "АБВГД"));
-    EXPECT_TRUE(artist == NULL);
+    EXPECT_TRUE (!strcmp (title, "АБВГД"));
+    EXPECT_TRUE (artist == NULL);
 
     deadbeef->plt_unref (plt);
 }
 
-TEST_F(M3UTests, test_loadM3UFromBuffer_TrailingExtinf_LoadsItemWithCorrectArtistTitle) {
+TEST_F (M3UTests, test_loadM3UFromBuffer_TrailingExtinf_LoadsItemWithCorrectArtistTitle) {
     char m3u[1000];
-    snprintf (m3u, sizeof (m3u),
-              "#EXTM3U\n"
-              "#EXTINF:123, АБВГД\n"
-              "%s/TestData/chirp-1sec.mp3\n"
-              "#EXTINF:123, test",
-              dbplugindir
-              );
+    snprintf (
+        m3u,
+        sizeof (m3u),
+        "#EXTM3U\n"
+        "#EXTINF:123, АБВГД\n"
+        "%s/TestData/chirp-1sec.mp3\n"
+        "#EXTINF:123, test",
+        dbplugindir);
 
-    ddb_playlist_t *plt = deadbeef->plt_alloc("plt");
+    ddb_playlist_t *plt = deadbeef->plt_alloc ("plt");
 
-    ddb_playItem_t *after = load_m3u_from_buffer(NULL, m3u, strlen(m3u), NULL, "", NULL, plt, NULL);
+    ddb_playItem_t *after = load_m3u_from_buffer (NULL, m3u, strlen (m3u), NULL, "", NULL, plt, NULL);
 
-    EXPECT_TRUE(after);
-    EXPECT_EQ(deadbeef->plt_get_item_count(plt, PL_MAIN), 1);
+    EXPECT_TRUE (after);
+    EXPECT_EQ (deadbeef->plt_get_item_count (plt, PL_MAIN), 1);
 
-    const char *title = deadbeef->pl_find_meta(after, "title");
-    const char *artist = deadbeef->pl_find_meta(after, "artist");
+    const char *title = deadbeef->pl_find_meta (after, "title");
+    const char *artist = deadbeef->pl_find_meta (after, "artist");
 
-    EXPECT_TRUE(!strcmp (title, "АБВГД"));
-    EXPECT_TRUE(artist == NULL);
+    EXPECT_TRUE (!strcmp (title, "АБВГД"));
+    EXPECT_TRUE (artist == NULL);
 
     deadbeef->plt_unref (plt);
 }
 
-
-TEST_F(M3UTests, test_loadM3UFromBuffer_UnicodeCharactersWithDash_LoadsItemWithCorrectArtistTitle) {
+TEST_F (M3UTests, test_loadM3UFromBuffer_UnicodeCharactersWithDash_LoadsItemWithCorrectArtistTitle) {
     char m3u[1000];
-    snprintf (m3u, sizeof (m3u),
-              "#EXTM3U\n"
-              "#EXTINF:123, АБВГД - Sample title\n"
-              "%s/TestData/chirp-1sec.mp3\n",
-              dbplugindir
-              );
+    snprintf (
+        m3u,
+        sizeof (m3u),
+        "#EXTM3U\n"
+        "#EXTINF:123, АБВГД - Sample title\n"
+        "%s/TestData/chirp-1sec.mp3\n",
+        dbplugindir);
 
-    ddb_playlist_t *plt = deadbeef->plt_alloc("plt");
+    ddb_playlist_t *plt = deadbeef->plt_alloc ("plt");
 
-    ddb_playItem_t *after = load_m3u_from_buffer(NULL, m3u, strlen(m3u), NULL, "", NULL, plt, NULL);
+    ddb_playItem_t *after = load_m3u_from_buffer (NULL, m3u, strlen (m3u), NULL, "", NULL, plt, NULL);
 
-    EXPECT_TRUE(after);
-    EXPECT_EQ(deadbeef->plt_get_item_count(plt, PL_MAIN), 1);
+    EXPECT_TRUE (after);
+    EXPECT_EQ (deadbeef->plt_get_item_count (plt, PL_MAIN), 1);
 
-    const char *title = deadbeef->pl_find_meta(after, "title");
-    const char *artist = deadbeef->pl_find_meta(after, "artist");
+    const char *title = deadbeef->pl_find_meta (after, "title");
+    const char *artist = deadbeef->pl_find_meta (after, "artist");
 
-    EXPECT_TRUE(!strcmp (title, "Sample title"));
-    EXPECT_TRUE(!strcmp (artist, "АБВГД"));
+    EXPECT_TRUE (!strcmp (title, "Sample title"));
+    EXPECT_TRUE (!strcmp (artist, "АБВГД"));
 
     deadbeef->plt_unref (plt);
 }
 
-TEST_F(M3UTests, test_loadM3UFromBuffer_UnicodeBom_LoadsCorrectly) {
+TEST_F (M3UTests, test_loadM3UFromBuffer_UnicodeBom_LoadsCorrectly) {
     char m3u[1000];
-    snprintf (m3u, sizeof (m3u),
-              "\xef\xbb\xbf#EXTM3U\n"
-              "#EXTINF:123, АБВГД - Sample title\n"
-              "%s/TestData/chirp-1sec.mp3\n",
-              dbplugindir
-              );
+    snprintf (
+        m3u,
+        sizeof (m3u),
+        "\xef\xbb\xbf#EXTM3U\n"
+        "#EXTINF:123, АБВГД - Sample title\n"
+        "%s/TestData/chirp-1sec.mp3\n",
+        dbplugindir);
 
-    ddb_playlist_t *plt = deadbeef->plt_alloc("plt");
+    ddb_playlist_t *plt = deadbeef->plt_alloc ("plt");
 
-    ddb_playItem_t *after = load_m3u_from_buffer(NULL, m3u, strlen(m3u), NULL, "", NULL, plt, NULL);
+    ddb_playItem_t *after = load_m3u_from_buffer (NULL, m3u, strlen (m3u), NULL, "", NULL, plt, NULL);
 
-    EXPECT_TRUE(after);
-    EXPECT_EQ(deadbeef->plt_get_item_count(plt, PL_MAIN), 1);
+    EXPECT_TRUE (after);
+    EXPECT_EQ (deadbeef->plt_get_item_count (plt, PL_MAIN), 1);
 
-    const char *title = deadbeef->pl_find_meta(after, "title");
-    const char *artist = deadbeef->pl_find_meta(after, "artist");
+    const char *title = deadbeef->pl_find_meta (after, "title");
+    const char *artist = deadbeef->pl_find_meta (after, "artist");
 
-    EXPECT_TRUE(!strcmp (title, "Sample title"));
-    EXPECT_TRUE(!strcmp (artist, "АБВГД"));
+    EXPECT_TRUE (!strcmp (title, "Sample title"));
+    EXPECT_TRUE (!strcmp (artist, "АБВГД"));
 
     deadbeef->plt_unref (plt);
 }
-

--- a/Tests/MP3DecoderTests.cpp
+++ b/Tests/MP3DecoderTests.cpp
@@ -15,21 +15,21 @@
 
 extern DB_functions_t *deadbeef;
 
-class MP3DecoderTests: public ::testing::Test {
+class MP3DecoderTests : public ::testing::Test {
 protected:
-    void SetUp() override {
+    void SetUp () override {
         ddb_logger_init ();
         conf_init ();
         conf_enable_saving (0);
     }
-    void TearDown() override {
-        conf_free();
-        ddb_logger_free();
+    void TearDown () override {
+        conf_free ();
+        ddb_logger_free ();
     }
 };
 
-
-static void runMp3TwoPieceTestWithBackend(int backend) {
+static void
+runMp3TwoPieceTestWithBackend (int backend) {
     deadbeef->conf_set_int ("mp3.backend", backend);
 
     char path[PATH_MAX];
@@ -39,31 +39,30 @@ static void runMp3TwoPieceTestWithBackend(int backend) {
 
     DB_playItem_t *it = deadbeef->plt_insert_file2 (0, (ddb_playlist_t *)plt, NULL, path, NULL, NULL, NULL);
 
-
     DB_decoder_t *dec = (DB_decoder_t *)deadbeef->plug_get_for_id ("stdmpg");
 
     DB_fileinfo_t *fi = dec->open (0);
     dec->init (fi, it);
 
     int64_t size = 176400;
-    char *buffer = (char *)malloc (size*2);
+    char *buffer = (char *)malloc (size * 2);
 
     // request twice as much to make sure we don't overshoot
-    int res = dec->read (fi, buffer, (int)size*2);
+    int res = dec->read (fi, buffer, (int)size * 2);
 
-    EXPECT_EQ(res, size);
+    EXPECT_EQ (res, size);
 
-    char *buffer2 = (char *)malloc (size*2); // buffer is over-allocated to check for trailing data
+    char *buffer2 = (char *)malloc (size * 2); // buffer is over-allocated to check for trailing data
 
     // read first part
     dec->seek_sample (fi, 0);
 
-    res = dec->read (fi, buffer2, (int)size/2);
-    EXPECT_EQ(res, size/2);
+    res = dec->read (fi, buffer2, (int)size / 2);
+    EXPECT_EQ (res, size / 2);
 
-    dec->seek_sample (fi, 44100/2);
-    res = dec->read (fi, buffer2+size/2, (int)size);
-    EXPECT_EQ(res, size/2);
+    dec->seek_sample (fi, 44100 / 2);
+    res = dec->read (fi, buffer2 + size / 2, (int)size);
+    EXPECT_EQ (res, size / 2);
 
 #if 0
     FILE *fp1 = fopen ("buffer1.raw", "w+b");
@@ -74,11 +73,11 @@ static void runMp3TwoPieceTestWithBackend(int backend) {
     fclose (fp2);
 #endif
 
-    int cmp1 = memcmp (buffer, buffer2, size/2);
-    EXPECT_TRUE(cmp1==0);
+    int cmp1 = memcmp (buffer, buffer2, size / 2);
+    EXPECT_TRUE (cmp1 == 0);
 
-    int cmp2 = memcmp (buffer+size/2, buffer2+size/2, size/2);
-    EXPECT_TRUE(cmp2==0);
+    int cmp2 = memcmp (buffer + size / 2, buffer2 + size / 2, size / 2);
+    EXPECT_TRUE (cmp2 == 0);
 
     int cmp = memcmp (buffer, buffer2, size);
 
@@ -89,21 +88,21 @@ static void runMp3TwoPieceTestWithBackend(int backend) {
 
     deadbeef->plt_unref ((ddb_playlist_t *)plt);
 
-    EXPECT_TRUE(cmp==0);
+    EXPECT_TRUE (cmp == 0);
 }
 
 #if !TARGET_CPU_ARM64
 // FIXME: Looks like MPG123 generates bad data in that test. Needs proper debugging on arm64 host.
-TEST_F(MP3DecoderTests, test_DecodeMP3As2PiecesMPG123_SameAs1Piece) {
-    runMp3TwoPieceTestWithBackend(0); // mpg123
+TEST_F (MP3DecoderTests, test_DecodeMP3As2PiecesMPG123_SameAs1Piece) {
+    runMp3TwoPieceTestWithBackend (0); // mpg123
 }
 #endif
 
-TEST_F(MP3DecoderTests, test_DecodeMP3As2PiecesLibMAD_SameAs1Piece) {
-    runMp3TwoPieceTestWithBackend(1); // libmad
+TEST_F (MP3DecoderTests, test_DecodeMP3As2PiecesLibMAD_SameAs1Piece) {
+    runMp3TwoPieceTestWithBackend (1); // libmad
 }
 
-TEST_F(MP3DecoderTests, test_FiniteVBRNetworkStream_DecodesFullAmountOfSamples) {
+TEST_F (MP3DecoderTests, test_FiniteVBRNetworkStream_DecodesFullAmountOfSamples) {
     char path[PATH_MAX];
     snprintf (path, sizeof (path), "%s/TestData/mp3parser/vbr_rhytm_30sec.mp3", dbplugindir);
 
@@ -115,13 +114,13 @@ TEST_F(MP3DecoderTests, test_FiniteVBRNetworkStream_DecodesFullAmountOfSamples) 
 
     DB_decoder_t *dec = (DB_decoder_t *)deadbeef->plug_get_for_id ("stdmpg");
 
-    DB_fileinfo_t *fi = dec->open (1<<31); // indicate with a flag to decode in streaming mode (internal flag)
+    DB_fileinfo_t *fi = dec->open (1 << 31); // indicate with a flag to decode in streaming mode (internal flag)
     dec->init (fi, it);
 
     size_t size = 1024751 * 4;
-    char *buffer = (char *)malloc (size*2);
+    char *buffer = (char *)malloc (size * 2);
 
-    int res = dec->read (fi, buffer, (int)size*2);
+    int res = dec->read (fi, buffer, (int)size * 2);
 
     free (buffer);
 
@@ -129,5 +128,5 @@ TEST_F(MP3DecoderTests, test_FiniteVBRNetworkStream_DecodesFullAmountOfSamples) 
 
     deadbeef->plt_unref ((ddb_playlist_t *)plt);
 
-    EXPECT_EQ(res/4, size/4);
+    EXPECT_EQ (res / 4, size / 4);
 }

--- a/Tests/MP3ParserTests.cpp
+++ b/Tests/MP3ParserTests.cpp
@@ -11,180 +11,180 @@
 #include "vfs.h"
 #include <gtest/gtest.h>
 
-#define EXPECT_EQ_WITH_ACCURACY(a,b,accuracy) EXPECT_LT(std::abs(a-b), accuracy)
+#define EXPECT_EQ_WITH_ACCURACY(a, b, accuracy) EXPECT_LT (std::abs (a - b), accuracy)
 
-TEST(MP3ParserTests, test_2secSquareWithLameHeader_XingDetectedWith88200Samples) {
+TEST (MP3ParserTests, test_2secSquareWithLameHeader_XingDetectedWith88200Samples) {
     mp3info_t info;
     char path[PATH_MAX];
     snprintf (path, sizeof (path), "%s/TestData/mp3parser/2sec-square-lamehdr.mp3", dbplugindir);
     DB_FILE *fp = vfs_fopen (path);
-    int64_t fsize = vfs_fgetlength(fp);
+    int64_t fsize = vfs_fgetlength (fp);
     int res = mp3_parse_file (&info, 0, fp, fsize, 0, 0, -1);
-    EXPECT_TRUE(!res);
-    EXPECT_EQ(info.have_xing_header, 1);
-    EXPECT_EQ(info.ref_packet.samplerate, 44100);
-    EXPECT_EQ(info.totalsamples-info.delay-info.padding, 88200);
-    EXPECT_EQ(info.delay, 1105);
-    EXPECT_EQ(info.padding, 551);
-    EXPECT_EQ(info.lame_musiclength, 16508);
+    EXPECT_TRUE (!res);
+    EXPECT_EQ (info.have_xing_header, 1);
+    EXPECT_EQ (info.ref_packet.samplerate, 44100);
+    EXPECT_EQ (info.totalsamples - info.delay - info.padding, 88200);
+    EXPECT_EQ (info.delay, 1105);
+    EXPECT_EQ (info.padding, 551);
+    EXPECT_EQ (info.lame_musiclength, 16508);
 }
 
-TEST(MP3ParserTests, test_2secSquareWithLameHeader_FullScanGet88200Samples) {
+TEST (MP3ParserTests, test_2secSquareWithLameHeader_FullScanGet88200Samples) {
     mp3info_t info;
     char path[PATH_MAX];
     snprintf (path, sizeof (path), "%s/TestData/mp3parser/2sec-square-lamehdr.mp3", dbplugindir);
     DB_FILE *fp = vfs_fopen (path);
-    int64_t fsize = vfs_fgetlength(fp);
+    int64_t fsize = vfs_fgetlength (fp);
     int res = mp3_parse_file (&info, MP3_PARSE_FULLSCAN, fp, fsize, 0, 0, -1);
-    EXPECT_TRUE(!res);
-    EXPECT_EQ(info.have_xing_header, 1);
-    EXPECT_EQ(info.ref_packet.samplerate, 44100);
-    EXPECT_EQ(info.totalsamples, 88200+576+1080);
-    EXPECT_EQ(info.pcmsample, 0);
-    EXPECT_EQ(info.delay, 529);
-    EXPECT_EQ(info.padding, 0);
-    EXPECT_EQ(info.lame_musiclength, 16508);
+    EXPECT_TRUE (!res);
+    EXPECT_EQ (info.have_xing_header, 1);
+    EXPECT_EQ (info.ref_packet.samplerate, 44100);
+    EXPECT_EQ (info.totalsamples, 88200 + 576 + 1080);
+    EXPECT_EQ (info.pcmsample, 0);
+    EXPECT_EQ (info.delay, 529);
+    EXPECT_EQ (info.padding, 0);
+    EXPECT_EQ (info.lame_musiclength, 16508);
 }
 
-TEST(MP3ParserTests, test_2secSquareSeekTo0_GivesPacketAfterXingPos208) {
+TEST (MP3ParserTests, test_2secSquareSeekTo0_GivesPacketAfterXingPos208) {
     mp3info_t info;
     char path[PATH_MAX];
     snprintf (path, sizeof (path), "%s/TestData/mp3parser/2sec-square-lamehdr.mp3", dbplugindir);
     DB_FILE *fp = vfs_fopen (path);
-    int64_t fsize = vfs_fgetlength(fp);
+    int64_t fsize = vfs_fgetlength (fp);
     int res = mp3_parse_file (&info, 0, fp, fsize, 0, 0, 0);
-    EXPECT_TRUE(!res);
-    EXPECT_EQ(info.packet_offs, 208);
+    EXPECT_TRUE (!res);
+    EXPECT_EQ (info.packet_offs, 208);
 }
 
-TEST(MP3ParserTests, test_2secSquareSeekToDelay_GivesPacketAfterXingPos208) {
+TEST (MP3ParserTests, test_2secSquareSeekToDelay_GivesPacketAfterXingPos208) {
     mp3info_t info;
     char path[PATH_MAX];
     snprintf (path, sizeof (path), "%s/TestData/mp3parser/2sec-square-lamehdr.mp3", dbplugindir);
     DB_FILE *fp = vfs_fopen (path);
-    int64_t fsize = vfs_fgetlength(fp);
+    int64_t fsize = vfs_fgetlength (fp);
     int res = mp3_parse_file (&info, 0, fp, fsize, 0, 0, 576);
-    EXPECT_TRUE(!res);
-    EXPECT_EQ(info.packet_offs, 208);
+    EXPECT_TRUE (!res);
+    EXPECT_EQ (info.packet_offs, 208);
 }
 
-TEST(MP3ParserTests, test_2secSquareSeekTo1sec_SeeksTo1SecMinus10Packets) {
+TEST (MP3ParserTests, test_2secSquareSeekTo1sec_SeeksTo1SecMinus10Packets) {
     mp3info_t info;
     char path[PATH_MAX];
     snprintf (path, sizeof (path), "%s/TestData/mp3parser/2sec-square-lamehdr.mp3", dbplugindir);
     DB_FILE *fp = vfs_fopen (path);
-    int64_t fsize = vfs_fgetlength(fp);
-    int res = mp3_parse_file (&info, 0, fp, fsize, 0, 0, 576+44100);
-    EXPECT_TRUE(!res);
-    EXPECT_EQ(info.packet_offs, 6059);
-    EXPECT_EQ(info.pcmsample, 32256);
+    int64_t fsize = vfs_fgetlength (fp);
+    int res = mp3_parse_file (&info, 0, fp, fsize, 0, 0, 576 + 44100);
+    EXPECT_TRUE (!res);
+    EXPECT_EQ (info.packet_offs, 6059);
+    EXPECT_EQ (info.pcmsample, 32256);
 }
 
-TEST(MP3ParserTests, test_2secSquareNoLameHeader_Gives88200Samples) {
+TEST (MP3ParserTests, test_2secSquareNoLameHeader_Gives88200Samples) {
     mp3info_t info;
     char path[PATH_MAX];
     snprintf (path, sizeof (path), "%s/TestData/mp3parser/2sec-square-nolamehdr.mp3", dbplugindir);
     DB_FILE *fp = vfs_fopen (path);
-    int64_t fsize = vfs_fgetlength(fp);
+    int64_t fsize = vfs_fgetlength (fp);
     int res = mp3_parse_file (&info, 0, fp, fsize, 0, 0, -1);
-    EXPECT_TRUE(!res);
-    EXPECT_EQ(info.have_xing_header, 0);
-    EXPECT_EQ(info.ref_packet.samplerate, 44100);
+    EXPECT_TRUE (!res);
+    EXPECT_EQ (info.have_xing_header, 0);
+    EXPECT_EQ (info.ref_packet.samplerate, 44100);
     // lame adds default encoder delay and padding of 576 and 1080, even without header
-    EXPECT_EQ(info.totalsamples, 88200+576+1080);
-    EXPECT_EQ(info.pcmsample, 0);
-    EXPECT_EQ(info.delay, 529);
-    EXPECT_EQ(info.padding, 0);
+    EXPECT_EQ (info.totalsamples, 88200 + 576 + 1080);
+    EXPECT_EQ (info.pcmsample, 0);
+    EXPECT_EQ (info.delay, 529);
+    EXPECT_EQ (info.padding, 0);
 }
 
-TEST(MP3ParserTests, test_2secSquareNoXHSeekTo1sec_SeeksTo1SecMinus10Packets) {
+TEST (MP3ParserTests, test_2secSquareNoXHSeekTo1sec_SeeksTo1SecMinus10Packets) {
     mp3info_t info;
     char path[PATH_MAX];
     snprintf (path, sizeof (path), "%s/TestData/mp3parser/2sec-square-nolamehdr.mp3", dbplugindir);
     DB_FILE *fp = vfs_fopen (path);
-    int64_t fsize = vfs_fgetlength(fp);
-    int res = mp3_parse_file (&info, 0, fp, fsize, 0, 0, 576+44100);
-    EXPECT_TRUE(!res);
-    EXPECT_EQ(info.have_xing_header, 0);
-    EXPECT_EQ(info.packet_offs, 5851);
-    EXPECT_EQ(info.pcmsample, 32256);
+    int64_t fsize = vfs_fgetlength (fp);
+    int res = mp3_parse_file (&info, 0, fp, fsize, 0, 0, 576 + 44100);
+    EXPECT_TRUE (!res);
+    EXPECT_EQ (info.have_xing_header, 0);
+    EXPECT_EQ (info.packet_offs, 5851);
+    EXPECT_EQ (info.pcmsample, 32256);
 }
 
 // the file contains garbage/invalid data around the middle of the file, with packet markers.
 // we still expect the parser to deal with it
-TEST(MP3ParserTests, test_2secSquareWithGarbage_Reports88200SamplesLength) {
+TEST (MP3ParserTests, test_2secSquareWithGarbage_Reports88200SamplesLength) {
     mp3info_t info;
     char path[PATH_MAX];
     snprintf (path, sizeof (path), "%s/TestData/mp3parser/2sec-square-nolamehdr-garbage.mp3", dbplugindir);
     DB_FILE *fp = vfs_fopen (path);
-    int64_t fsize = vfs_fgetlength(fp);
+    int64_t fsize = vfs_fgetlength (fp);
     int res = mp3_parse_file (&info, 0, fp, fsize, 0, 0, -1);
-    EXPECT_TRUE(!res);
-    EXPECT_EQ(info.have_xing_header, 0);
-    EXPECT_EQ(info.ref_packet.samplerate, 44100);
+    EXPECT_TRUE (!res);
+    EXPECT_EQ (info.have_xing_header, 0);
+    EXPECT_EQ (info.ref_packet.samplerate, 44100);
     // lame adds default encoder delay and padding of 576 and 1080, even without header
-    EXPECT_EQ(info.totalsamples, 88200+576+1080);
-    EXPECT_EQ(info.pcmsample, 0);
-    EXPECT_EQ(info.delay, 529);
-    EXPECT_EQ(info.padding, 0);
+    EXPECT_EQ (info.totalsamples, 88200 + 576 + 1080);
+    EXPECT_EQ (info.pcmsample, 0);
+    EXPECT_EQ (info.delay, 529);
+    EXPECT_EQ (info.padding, 0);
 }
 
-TEST(MP3ParserTests, test_FiniteCBRNetworkStream_ReportsAccurateDuration) {
+TEST (MP3ParserTests, test_FiniteCBRNetworkStream_ReportsAccurateDuration) {
     mp3info_t info;
     char path[PATH_MAX];
     snprintf (path, sizeof (path), "%s/TestData/mp3parser/cbr_rhytm_30sec.mp3", dbplugindir);
     DB_FILE *fp = vfs_fopen (path);
-    int64_t fsize = vfs_fgetlength(fp);
+    int64_t fsize = vfs_fgetlength (fp);
     int res = mp3_parse_file (&info, MP3_PARSE_ESTIMATE_DURATION, fp, fsize, 0, 0, -1);
-    EXPECT_TRUE(!res);
-    EXPECT_EQ(info.have_xing_header, 0);
-    EXPECT_EQ(info.ref_packet.samplerate, 32000);
-    EXPECT_EQ(info.totalsamples, 1025280);
-    EXPECT_EQ(info.npackets, 890);
-    EXPECT_LT(info.valid_packets, info.npackets);
+    EXPECT_TRUE (!res);
+    EXPECT_EQ (info.have_xing_header, 0);
+    EXPECT_EQ (info.ref_packet.samplerate, 32000);
+    EXPECT_EQ (info.totalsamples, 1025280);
+    EXPECT_EQ (info.npackets, 890);
+    EXPECT_LT (info.valid_packets, info.npackets);
 }
 
-TEST(MP3ParserTests, test_FiniteCBRLameHdrNetworkStream_ReportsAccurateDuration) {
+TEST (MP3ParserTests, test_FiniteCBRLameHdrNetworkStream_ReportsAccurateDuration) {
     mp3info_t info;
     char path[PATH_MAX];
     snprintf (path, sizeof (path), "%s/TestData/mp3parser/cbr_rhytm_30sec_lamehdr.mp3", dbplugindir);
     DB_FILE *fp = vfs_fopen (path);
-    int64_t fsize = vfs_fgetlength(fp);
+    int64_t fsize = vfs_fgetlength (fp);
     int res = mp3_parse_file (&info, MP3_PARSE_ESTIMATE_DURATION, fp, fsize, 0, 0, -1);
-    EXPECT_TRUE(!res);
-    EXPECT_EQ(info.have_xing_header, 1);
-    EXPECT_EQ(info.ref_packet.samplerate, 32000);
-    EXPECT_EQ(info.totalsamples, 1025280);
-    EXPECT_EQ(info.npackets, 890);
-    EXPECT_LT(info.valid_packets, info.npackets);
+    EXPECT_TRUE (!res);
+    EXPECT_EQ (info.have_xing_header, 1);
+    EXPECT_EQ (info.ref_packet.samplerate, 32000);
+    EXPECT_EQ (info.totalsamples, 1025280);
+    EXPECT_EQ (info.npackets, 890);
+    EXPECT_LT (info.valid_packets, info.npackets);
 }
 
-TEST(MP3ParserTests, test_FiniteVBRNetworkStream_ReportsApproximateDuration) {
+TEST (MP3ParserTests, test_FiniteVBRNetworkStream_ReportsApproximateDuration) {
     mp3info_t info;
     char path[PATH_MAX];
     snprintf (path, sizeof (path), "%s/TestData/mp3parser/vbr_rhytm_30sec.mp3", dbplugindir);
     DB_FILE *fp = vfs_fopen (path);
-    int64_t fsize = vfs_fgetlength(fp);
+    int64_t fsize = vfs_fgetlength (fp);
     int res = mp3_parse_file (&info, MP3_PARSE_ESTIMATE_DURATION, fp, fsize, 0, 0, -1);
-    EXPECT_TRUE(!res);
-    EXPECT_EQ(info.have_xing_header, 0);
-    EXPECT_EQ(info.ref_packet.samplerate, 32000);
-    EXPECT_EQ_WITH_ACCURACY(info.totalsamples, 1025280, 2000);
-    EXPECT_EQ_WITH_ACCURACY(info.npackets, 890, 10);
-    EXPECT_LT(info.valid_packets, info.npackets);
+    EXPECT_TRUE (!res);
+    EXPECT_EQ (info.have_xing_header, 0);
+    EXPECT_EQ (info.ref_packet.samplerate, 32000);
+    EXPECT_EQ_WITH_ACCURACY (info.totalsamples, 1025280, 2000);
+    EXPECT_EQ_WITH_ACCURACY (info.npackets, 890, 10);
+    EXPECT_LT (info.valid_packets, info.npackets);
 }
 
-TEST(MP3ParserTests, test_FiniteVBRLameHdrNetworkStream_ReportsAccurateDuration) {
+TEST (MP3ParserTests, test_FiniteVBRLameHdrNetworkStream_ReportsAccurateDuration) {
     mp3info_t info;
     char path[PATH_MAX];
     snprintf (path, sizeof (path), "%s/TestData/mp3parser/vbr_rhytm_30sec_lamehdr.mp3", dbplugindir);
     DB_FILE *fp = vfs_fopen (path);
-    int64_t fsize = vfs_fgetlength(fp);
+    int64_t fsize = vfs_fgetlength (fp);
     int res = mp3_parse_file (&info, MP3_PARSE_ESTIMATE_DURATION, fp, fsize, 0, 0, -1);
-    EXPECT_TRUE(!res);
-    EXPECT_EQ(info.have_xing_header, 1);
-    EXPECT_EQ(info.ref_packet.samplerate, 32000);
-    EXPECT_EQ(info.totalsamples, 1025280);
-    EXPECT_EQ_WITH_ACCURACY(info.npackets, 890, 10);
-    EXPECT_LT(info.valid_packets, info.npackets);
+    EXPECT_TRUE (!res);
+    EXPECT_EQ (info.have_xing_header, 1);
+    EXPECT_EQ (info.ref_packet.samplerate, 32000);
+    EXPECT_EQ (info.totalsamples, 1025280);
+    EXPECT_EQ_WITH_ACCURACY (info.npackets, 890, 10);
+    EXPECT_LT (info.valid_packets, info.npackets);
 }

--- a/Tests/PlaylistTests.cpp
+++ b/Tests/PlaylistTests.cpp
@@ -12,130 +12,129 @@
 #include "plugins.h"
 #include <gtest/gtest.h>
 
-TEST(PlaylistTests, test_SearchForValueInSingleValueItems_FindsTheItem) {
-    playlist_t *plt = plt_alloc("test");
-    playItem_t *it = pl_item_alloc();
+TEST (PlaylistTests, test_SearchForValueInSingleValueItems_FindsTheItem) {
+    playlist_t *plt = plt_alloc ("test");
+    playItem_t *it = pl_item_alloc ();
 
-    plt_insert_item(plt, NULL, it);
+    plt_insert_item (plt, NULL, it);
 
-    pl_add_meta(it, "title", "value");
+    pl_add_meta (it, "title", "value");
 
-    plt_search_process(plt, "value");
+    plt_search_process (plt, "value");
 
-    EXPECT_TRUE(plt->head[PL_SEARCH] != NULL);
-    EXPECT_TRUE(plt->head[PL_MAIN]->selected);
+    EXPECT_TRUE (plt->head[PL_SEARCH] != NULL);
+    EXPECT_TRUE (plt->head[PL_MAIN]->selected);
 
     plt_unref (plt);
 }
 
+TEST (PlaylistTests, test_SearchFor2ndValueInMultiValueItems_FindsTheItem) {
+    playlist_t *plt = plt_alloc ("test");
+    playItem_t *it = pl_item_alloc ();
 
-TEST(PlaylistTests, test_SearchFor2ndValueInMultiValueItems_FindsTheItem) {
-    playlist_t *plt = plt_alloc("test");
-    playItem_t *it = pl_item_alloc();
-
-    plt_insert_item(plt, NULL, it);
+    plt_insert_item (plt, NULL, it);
 
     const char values[] = "value1\0value2\0";
-    pl_add_meta_full(it, "title", values, sizeof(values));
+    pl_add_meta_full (it, "title", values, sizeof (values));
 
-    plt_search_process(plt, "value2");
+    plt_search_process (plt, "value2");
 
-    EXPECT_TRUE(plt->head[PL_SEARCH] != NULL);
-    EXPECT_TRUE(plt->head[PL_MAIN]->selected);
+    EXPECT_TRUE (plt->head[PL_SEARCH] != NULL);
+    EXPECT_TRUE (plt->head[PL_MAIN]->selected);
 
     plt_unref (plt);
 }
 
 #pragma mark - IsRelativePathPosix
 
-TEST(PlaylistTests, test_IsRelativePathPosix_AbsolutePath_False) {
+TEST (PlaylistTests, test_IsRelativePathPosix_AbsolutePath_False) {
     int res = is_relative_path_posix ("/path");
-    EXPECT_FALSE(res);
+    EXPECT_FALSE (res);
 }
 
-TEST(PlaylistTests, test_IsRelativePathPosix_AbsolutePathWithUriScheme_False) {
+TEST (PlaylistTests, test_IsRelativePathPosix_AbsolutePathWithUriScheme_False) {
     int res = is_relative_path_posix ("file:///path");
-    EXPECT_FALSE(res);
+    EXPECT_FALSE (res);
 }
 
-TEST(PlaylistTests, test_IsRelativePathPosix_RelativePathWithUriScheme_True) {
+TEST (PlaylistTests, test_IsRelativePathPosix_RelativePathWithUriScheme_True) {
     int res = is_relative_path_posix ("file://path");
-    EXPECT_TRUE(res);
+    EXPECT_TRUE (res);
 }
 
-TEST(PlaylistTests, test_IsRelativePathPosix_VFSPath_False) {
+TEST (PlaylistTests, test_IsRelativePathPosix_VFSPath_False) {
     int res = is_relative_path_posix ("zip://path");
-    EXPECT_FALSE(res);
+    EXPECT_FALSE (res);
 }
 
-TEST(PlaylistTests, test_IsRelativePathPosix_HTTPPath_False) {
+TEST (PlaylistTests, test_IsRelativePathPosix_HTTPPath_False) {
     int res = is_relative_path_posix ("http://path");
-    EXPECT_FALSE(res);
+    EXPECT_FALSE (res);
 }
 
-TEST(PlaylistTests, test_IsRelativePathPosix_RelativePath_True) {
+TEST (PlaylistTests, test_IsRelativePathPosix_RelativePath_True) {
     int res = is_relative_path_posix ("path");
-    EXPECT_TRUE(res);
+    EXPECT_TRUE (res);
 }
 
-TEST(PlaylistTests, test_IsRelativePathPosix_RelativeWithFoldersPath_True) {
+TEST (PlaylistTests, test_IsRelativePathPosix_RelativeWithFoldersPath_True) {
     int res = is_relative_path_posix ("path/filename");
-    EXPECT_TRUE(res);
+    EXPECT_TRUE (res);
 }
 
-TEST(PlaylistTests, test_IsRelativePathPosix_WeirdPath_True) {
+TEST (PlaylistTests, test_IsRelativePathPosix_WeirdPath_True) {
     int res = is_relative_path_posix ("something:something");
-    EXPECT_TRUE(res);
+    EXPECT_TRUE (res);
 }
 
 #pragma mark - IsRelativePathWin32
 
-TEST(PlaylistTests, test_IsRelativePathWin32_AbsolutePath_False) {
+TEST (PlaylistTests, test_IsRelativePathWin32_AbsolutePath_False) {
     int res = is_relative_path_win32 ("z:\\path");
-    EXPECT_FALSE(res);
+    EXPECT_FALSE (res);
 }
 
-TEST(PlaylistTests, test_IsRelativePathWin32_AbsolutePathWithUriScheme_False) {
+TEST (PlaylistTests, test_IsRelativePathWin32_AbsolutePathWithUriScheme_False) {
     int res = is_relative_path_win32 ("file://z:\\path");
-    EXPECT_FALSE(res);
+    EXPECT_FALSE (res);
 }
 
-TEST(PlaylistTests, test_IsRelativePathWin32_AbsolutePathForwardSlash_False) {
+TEST (PlaylistTests, test_IsRelativePathWin32_AbsolutePathForwardSlash_False) {
     int res = is_relative_path_win32 ("z:/path");
-    EXPECT_FALSE(res);
+    EXPECT_FALSE (res);
 }
 
-TEST(PlaylistTests, test_IsRelativePathWin32_AbsolutePathForwardSlashWithUriScheme_False) {
+TEST (PlaylistTests, test_IsRelativePathWin32_AbsolutePathForwardSlashWithUriScheme_False) {
     int res = is_relative_path_win32 ("file://z:/path");
-    EXPECT_FALSE(res);
+    EXPECT_FALSE (res);
 }
 
-TEST(PlaylistTests, test_IsRelativePathWin32_RelativePathWithUriScheme_True) {
+TEST (PlaylistTests, test_IsRelativePathWin32_RelativePathWithUriScheme_True) {
     int res = is_relative_path_win32 ("file://path");
-    EXPECT_TRUE(res);
+    EXPECT_TRUE (res);
 }
 
-TEST(PlaylistTests, test_IsRelativePathWin32_VFSPath_False) {
+TEST (PlaylistTests, test_IsRelativePathWin32_VFSPath_False) {
     int res = is_relative_path_win32 ("zip://path");
-    EXPECT_FALSE(res);
+    EXPECT_FALSE (res);
 }
 
-TEST(PlaylistTests, test_IsRelativePathWin32_HTTPPath_False) {
+TEST (PlaylistTests, test_IsRelativePathWin32_HTTPPath_False) {
     int res = is_relative_path_win32 ("http://path");
-    EXPECT_FALSE(res);
+    EXPECT_FALSE (res);
 }
 
-TEST(PlaylistTests, test_IsRelativePathWin32_RelativePath_True) {
+TEST (PlaylistTests, test_IsRelativePathWin32_RelativePath_True) {
     int res = is_relative_path_win32 ("path");
-    EXPECT_TRUE(res);
+    EXPECT_TRUE (res);
 }
 
-TEST(PlaylistTests, test_IsRelativePathWin32_RelativeWithFoldersPath_True) {
+TEST (PlaylistTests, test_IsRelativePathWin32_RelativeWithFoldersPath_True) {
     int res = is_relative_path_win32 ("path/filename");
-    EXPECT_TRUE(res);
+    EXPECT_TRUE (res);
 }
 
-TEST(PlaylistTests, test_IsRelativePathWin32_WeirdPath_True) {
+TEST (PlaylistTests, test_IsRelativePathWin32_WeirdPath_True) {
     int res = is_relative_path_win32 ("something:something");
-    EXPECT_TRUE(res);
+    EXPECT_TRUE (res);
 }

--- a/Tests/ResamplerTests.cpp
+++ b/Tests/ResamplerTests.cpp
@@ -24,98 +24,94 @@
 #include "dsp.h"
 #include <gtest/gtest.h>
 
-TEST(ResamplerTest, testSimpleDownsamplerBufSizeFrom192To48) {
-    char input[4*2*2];
+TEST (ResamplerTest, testSimpleDownsamplerBufSizeFrom192To48) {
+    char input[4 * 2 * 2];
     char *out_buf;
     int out_size;
 
     int res = dsp_apply_simple_downsampler (192000, 2, input, sizeof (input), 48000, &out_buf, &out_size);
 
-    EXPECT_TRUE(res == sizeof (input));
-    EXPECT_TRUE(out_size == sizeof (input) / 4);
+    EXPECT_TRUE (res == sizeof (input));
+    EXPECT_TRUE (out_size == sizeof (input) / 4);
 }
 
-TEST(ResamplerTest, testSimpleDownsamplerBufSizeFrom96To48) {
-    char input[4*2*2];
+TEST (ResamplerTest, testSimpleDownsamplerBufSizeFrom96To48) {
+    char input[4 * 2 * 2];
     char *out_buf;
     int out_size;
 
     int res = dsp_apply_simple_downsampler (96000, 2, input, sizeof (input), 48000, &out_buf, &out_size);
 
-    EXPECT_TRUE(res == sizeof (input));
-    EXPECT_TRUE(out_size == sizeof (input) / 2);
+    EXPECT_TRUE (res == sizeof (input));
+    EXPECT_TRUE (out_size == sizeof (input) / 2);
 }
 
-TEST(ResamplerTest, testSimpleDownsamplerInvalid32To48) {
-    char input[4*2*2];
+TEST (ResamplerTest, testSimpleDownsamplerInvalid32To48) {
+    char input[4 * 2 * 2];
     char *out_buf;
     int out_size;
 
     int res = dsp_apply_simple_downsampler (32000, 2, input, sizeof (input), 48000, &out_buf, &out_size);
 
-    EXPECT_TRUE(res == sizeof (input));
-    EXPECT_TRUE(out_size == sizeof (input));
+    EXPECT_TRUE (res == sizeof (input));
+    EXPECT_TRUE (out_size == sizeof (input));
 }
 
-TEST(ResamplerTest, testSimpleDownsamplerInvalid50To48) {
-    char input[4*2*2];
+TEST (ResamplerTest, testSimpleDownsamplerInvalid50To48) {
+    char input[4 * 2 * 2];
     char *out_buf;
     int out_size;
 
     int res = dsp_apply_simple_downsampler (50000, 2, input, sizeof (input), 48000, &out_buf, &out_size);
 
-    EXPECT_TRUE(res == sizeof (input));
-    EXPECT_TRUE(out_size == sizeof (input));
+    EXPECT_TRUE (res == sizeof (input));
+    EXPECT_TRUE (out_size == sizeof (input));
 }
 
-TEST(ResamplerTest, testSimpleDownsampler96To48NonMultiple) {
+TEST (ResamplerTest, testSimpleDownsampler96To48NonMultiple) {
     const int samples = 5;
-    char input[samples*2*2];
+    char input[samples * 2 * 2];
     char *out_buf;
     int out_size;
 
     int res = dsp_apply_simple_downsampler (96000, 2, input, (int)sizeof (input), 48000, &out_buf, &out_size);
 
-    EXPECT_TRUE(res == 4*2*2);
-    EXPECT_TRUE(out_size == 4*2);
+    EXPECT_TRUE (res == 4 * 2 * 2);
+    EXPECT_TRUE (out_size == 4 * 2);
 }
 
-TEST(ResamplerTest, testSimpleDownsampler192To48NonMultiple) {
+TEST (ResamplerTest, testSimpleDownsampler192To48NonMultiple) {
     const int samples = 5;
-    char input[samples*2*2];
+    char input[samples * 2 * 2];
     char *out_buf;
     int out_size;
 
     int res = dsp_apply_simple_downsampler (192000, 2, input, (int)sizeof (input), 48000, &out_buf, &out_size);
 
-    EXPECT_TRUE(res == 4*2*2);
-    EXPECT_TRUE(out_size == 2*2);
+    EXPECT_TRUE (res == 4 * 2 * 2);
+    EXPECT_TRUE (out_size == 2 * 2);
 }
 
-TEST(ResamplerTest, testSimpleDownsamplerOutputBufSizeFrom192To48) {
-    short input[4] = {
-        0, 0x7fff, 0, 0x7fff
-    };
+TEST (ResamplerTest, testSimpleDownsamplerOutputBufSizeFrom192To48) {
+    short input[4] = { 0, 0x7fff, 0, 0x7fff };
     char *out_buf;
     int out_size;
 
     int res = dsp_apply_simple_downsampler (192000, 1, (char *)input, sizeof (input), 48000, &out_buf, &out_size);
 
-    EXPECT_TRUE(res == 8);
-    EXPECT_TRUE(out_size == 2);
-    EXPECT_TRUE(((short*)out_buf)[0] == 0x3fff);
+    EXPECT_TRUE (res == 8);
+    EXPECT_TRUE (out_size == 2);
+    EXPECT_TRUE (((short *)out_buf)[0] == 0x3fff);
 }
 
-TEST(ResamplerTest, testSimpleDownsamplerOutputBufSizeFrom96To48) {
-    short input[2] = {
-        0, 0x7fff
-    };
+TEST (ResamplerTest, testSimpleDownsamplerOutputBufSizeFrom96To48) {
+    short input[2] = { 0, 0x7fff };
     char *out_buf;
     int out_size;
 
     int res = dsp_apply_simple_downsampler (96000, 1, (char *)input, sizeof (input), 48000, &out_buf, &out_size);
 
-    EXPECT_TRUE(res == 4);
-    EXPECT_TRUE(out_size == 2);
-    EXPECT_TRUE(((short*)out_buf)[0] == 0x3fff);
+    EXPECT_TRUE (res == 4);
+    EXPECT_TRUE (out_size == 2);
+    EXPECT_TRUE (((short *)out_buf)[0] == 0x3fff);
 }

--- a/Tests/RingBufTests.cpp
+++ b/Tests/RingBufTests.cpp
@@ -24,94 +24,94 @@
 #include <gtest/gtest.h>
 #include "ringbuf.h"
 
-TEST(RingBufTests, read_nowrap_success) {
+TEST (RingBufTests, read_nowrap_success) {
     char buffer[5];
     ringbuf_t ringbuf;
-    ringbuf_init(&ringbuf, buffer, sizeof (buffer));
+    ringbuf_init (&ringbuf, buffer, sizeof (buffer));
 
-    ringbuf_write(&ringbuf, (char *)"hello", 5);
+    ringbuf_write (&ringbuf, (char *)"hello", 5);
     char buf[5];
-    size_t sz = ringbuf_read(&ringbuf, buf, 5);
-    EXPECT_EQ(sz, 5);
-    EXPECT_TRUE(!memcmp(buf, "hello", 5));
+    size_t sz = ringbuf_read (&ringbuf, buf, 5);
+    EXPECT_EQ (sz, 5);
+    EXPECT_TRUE (!memcmp (buf, "hello", 5));
 }
 
-TEST(RingBufTests, read_wrap_success) {
+TEST (RingBufTests, read_wrap_success) {
     char buffer[10];
     ringbuf_t ringbuf;
-    ringbuf_init(&ringbuf, buffer, sizeof (buffer));
+    ringbuf_init (&ringbuf, buffer, sizeof (buffer));
 
     char buf[10];
 
-    ringbuf_write(&ringbuf, (char *)"-----", 5);
-    ringbuf_write(&ringbuf, (char *)"hello", 5);
+    ringbuf_write (&ringbuf, (char *)"-----", 5);
+    ringbuf_write (&ringbuf, (char *)"hello", 5);
 
-    ringbuf_read(&ringbuf, buf, 5);
+    ringbuf_read (&ringbuf, buf, 5);
 
-    ringbuf_write(&ringbuf, (char *)"world", 5);
-    size_t sz = ringbuf_read(&ringbuf, buf, 10);
+    ringbuf_write (&ringbuf, (char *)"world", 5);
+    size_t sz = ringbuf_read (&ringbuf, buf, 10);
 
-    EXPECT_EQ(sz, 10);
-    EXPECT_TRUE(!memcmp(buf, "helloworld", 10));
+    EXPECT_EQ (sz, 10);
+    EXPECT_TRUE (!memcmp (buf, "helloworld", 10));
 }
 
-TEST(RingBufTests, read_fromEmpty_returns0) {
+TEST (RingBufTests, read_fromEmpty_returns0) {
     char buffer[10];
     ringbuf_t ringbuf;
-    ringbuf_init(&ringbuf, buffer, sizeof (buffer));
+    ringbuf_init (&ringbuf, buffer, sizeof (buffer));
 
     char buf[5];
 
-    size_t sz = ringbuf_read(&ringbuf, buf, 5);
+    size_t sz = ringbuf_read (&ringbuf, buf, 5);
 
-    EXPECT_EQ(sz, 0);
+    EXPECT_EQ (sz, 0);
 }
 
-TEST(RingBufTests, read_tooMuchNoWrap_returnsHowMuchWasRead) {
+TEST (RingBufTests, read_tooMuchNoWrap_returnsHowMuchWasRead) {
     char buffer[10];
     ringbuf_t ringbuf;
-    ringbuf_init(&ringbuf, buffer, sizeof (buffer));
+    ringbuf_init (&ringbuf, buffer, sizeof (buffer));
 
-    ringbuf_write(&ringbuf, (char *)"hello", 5);
+    ringbuf_write (&ringbuf, (char *)"hello", 5);
 
     char buf[10];
 
-    size_t sz = ringbuf_read(&ringbuf, buf, 10);
+    size_t sz = ringbuf_read (&ringbuf, buf, 10);
 
-    EXPECT_EQ(sz, 5);
-    EXPECT_TRUE(!memcmp(buf, "hello", 5));
+    EXPECT_EQ (sz, 5);
+    EXPECT_TRUE (!memcmp (buf, "hello", 5));
 }
 
-TEST(RingBufTests, read_tooMuchWrap_returnsHowMuchWasRead) {
+TEST (RingBufTests, read_tooMuchWrap_returnsHowMuchWasRead) {
     char buffer[10];
     ringbuf_t ringbuf;
-    ringbuf_init(&ringbuf, buffer, sizeof (buffer));
+    ringbuf_init (&ringbuf, buffer, sizeof (buffer));
 
     char buf[15];
 
-    ringbuf_write(&ringbuf, (char *)"-----", 5);
-    ringbuf_read(&ringbuf, buf, 5);
+    ringbuf_write (&ringbuf, (char *)"-----", 5);
+    ringbuf_read (&ringbuf, buf, 5);
 
-    ringbuf_write(&ringbuf, (char *)"helloworld", 10);
+    ringbuf_write (&ringbuf, (char *)"helloworld", 10);
 
-    size_t sz = ringbuf_read(&ringbuf, buf, 15);
+    size_t sz = ringbuf_read (&ringbuf, buf, 15);
 
-    EXPECT_EQ(sz, 10);
-    EXPECT_TRUE(!memcmp(buf, "helloworld", 5));
+    EXPECT_EQ (sz, 10);
+    EXPECT_TRUE (!memcmp (buf, "helloworld", 5));
 }
 
-TEST(RingBufTests, readKeep_twice_success) {
+TEST (RingBufTests, readKeep_twice_success) {
     char buffer[5];
     ringbuf_t ringbuf;
-    ringbuf_init(&ringbuf, buffer, sizeof (buffer));
+    ringbuf_init (&ringbuf, buffer, sizeof (buffer));
 
-    ringbuf_write(&ringbuf, (char *)"hello", 5);
+    ringbuf_write (&ringbuf, (char *)"hello", 5);
     char buf[5];
     char buf2[5];
-    size_t sz = ringbuf_read_keep(&ringbuf, buf, 5);
-    size_t sz2 = ringbuf_read_keep(&ringbuf, buf2, 5);
-    EXPECT_EQ(sz, 5);
-    EXPECT_EQ(sz2, 5);
-    EXPECT_TRUE(!memcmp(buf, "hello", 5));
-    EXPECT_TRUE(!memcmp(buf2, "hello", 5));
+    size_t sz = ringbuf_read_keep (&ringbuf, buf, 5);
+    size_t sz2 = ringbuf_read_keep (&ringbuf, buf2, 5);
+    EXPECT_EQ (sz, 5);
+    EXPECT_EQ (sz2, 5);
+    EXPECT_TRUE (!memcmp (buf, "hello", 5));
+    EXPECT_TRUE (!memcmp (buf2, "hello", 5));
 }

--- a/Tests/ScriptableTests.cpp
+++ b/Tests/ScriptableTests.cpp
@@ -14,115 +14,114 @@
 #include "scriptable_encoder.h"
 #include <gtest/gtest.h>
 
-class ScriptableTests: public ::testing::Test {
+class ScriptableTests : public ::testing::Test {
 protected:
-
     scriptableItem_t *root;
 
-    void SetUp() override {
-        snprintf(dbconfdir, sizeof (dbconfdir), "%s/PresetManagerData", dbplugindir);
+    void SetUp () override {
+        snprintf (dbconfdir, sizeof (dbconfdir), "%s/PresetManagerData", dbplugindir);
         ddb_logger_init ();
         conf_init ();
         conf_enable_saving (0);
-        root = scriptableItemAlloc();
+        root = scriptableItemAlloc ();
     }
 
-    void TearDown() override {
-        scriptableItemFree(root);
-        conf_free();
-        ddb_logger_free();
+    void TearDown () override {
+        scriptableItemFree (root);
+        conf_free ();
+        ddb_logger_free ();
     }
 };
 
-TEST_F(ScriptableTests, test_LoadDSPPreset_ReturnsExpectedData) {
+TEST_F (ScriptableTests, test_LoadDSPPreset_ReturnsExpectedData) {
     scriptableDspLoadPresets (root);
     scriptableItem_t *dspRoot = scriptableDspRoot (root);
-    EXPECT_EQ(2, scriptableItemNumChildren (dspRoot));
+    EXPECT_EQ (2, scriptableItemNumChildren (dspRoot));
 }
 
-TEST_F(ScriptableTests, test_DSPPreset_Has3Plugins) {
-    scriptableDspLoadPresets (root);
-    scriptableItem_t *dspRoot = scriptableDspRoot (root);
-
-    scriptableItem_t *preset = scriptableItemNext(scriptableItemChildren(dspRoot));
-    EXPECT_EQ(3, scriptableItemNumChildren (preset));
-}
-
-TEST_F(ScriptableTests, test_DSPPreset_HasExpectedPluginIds) {
+TEST_F (ScriptableTests, test_DSPPreset_Has3Plugins) {
     scriptableDspLoadPresets (root);
     scriptableItem_t *dspRoot = scriptableDspRoot (root);
 
-    scriptableItem_t *preset = scriptableItemNext(scriptableItemChildren(dspRoot));
-    scriptableItem_t *plugin = scriptableItemChildren(preset);
-
-    const char *pluginId = scriptableItemPropertyValueForKey(plugin, "pluginId");
-    EXPECT_TRUE(pluginId);
-    EXPECT_STREQ(pluginId, "supereq");
-
-    plugin = scriptableItemNext(plugin);
-    pluginId = scriptableItemPropertyValueForKey(plugin, "pluginId");
-    EXPECT_TRUE(pluginId);
-    EXPECT_STREQ(pluginId, "SRC");
-
-    plugin = scriptableItemNext(plugin);
-    pluginId = scriptableItemPropertyValueForKey(plugin, "pluginId");
-    EXPECT_TRUE(pluginId);
-    EXPECT_STREQ(pluginId, "m2s");
+    scriptableItem_t *preset = scriptableItemNext (scriptableItemChildren (dspRoot));
+    EXPECT_EQ (3, scriptableItemNumChildren (preset));
 }
 
-TEST_F(ScriptableTests, test_LoadEncoderPreset_ReturnsExpectedData) {
+TEST_F (ScriptableTests, test_DSPPreset_HasExpectedPluginIds) {
+    scriptableDspLoadPresets (root);
+    scriptableItem_t *dspRoot = scriptableDspRoot (root);
+
+    scriptableItem_t *preset = scriptableItemNext (scriptableItemChildren (dspRoot));
+    scriptableItem_t *plugin = scriptableItemChildren (preset);
+
+    const char *pluginId = scriptableItemPropertyValueForKey (plugin, "pluginId");
+    EXPECT_TRUE (pluginId);
+    EXPECT_STREQ (pluginId, "supereq");
+
+    plugin = scriptableItemNext (plugin);
+    pluginId = scriptableItemPropertyValueForKey (plugin, "pluginId");
+    EXPECT_TRUE (pluginId);
+    EXPECT_STREQ (pluginId, "SRC");
+
+    plugin = scriptableItemNext (plugin);
+    pluginId = scriptableItemPropertyValueForKey (plugin, "pluginId");
+    EXPECT_TRUE (pluginId);
+    EXPECT_STREQ (pluginId, "m2s");
+}
+
+TEST_F (ScriptableTests, test_LoadEncoderPreset_ReturnsExpectedData) {
     scriptableEncoderLoadPresets (root);
     scriptableItem_t *encoderRoot = scriptableEncoderRoot (root);
-    EXPECT_EQ(1, scriptableItemNumChildren (encoderRoot));
+    EXPECT_EQ (1, scriptableItemNumChildren (encoderRoot));
 }
 
-TEST_F(ScriptableTests, test_EncoderPreset_HasNoChildren) {
+TEST_F (ScriptableTests, test_EncoderPreset_HasNoChildren) {
     scriptableEncoderLoadPresets (root);
     scriptableItem_t *encoderRoot = scriptableEncoderRoot (root);
 
-    scriptableItem_t *preset = scriptableItemChildren(encoderRoot);
-    EXPECT_EQ(scriptableItemChildren(preset), nullptr);
+    scriptableItem_t *preset = scriptableItemChildren (encoderRoot);
+    EXPECT_EQ (scriptableItemChildren (preset), nullptr);
 }
 
-TEST_F(ScriptableTests, test_EncoderPreset_HasEncoderProperty) {
+TEST_F (ScriptableTests, test_EncoderPreset_HasEncoderProperty) {
     scriptableEncoderLoadPresets (root);
     scriptableItem_t *encoderRoot = scriptableEncoderRoot (root);
 
-    scriptableItem_t *preset = scriptableItemChildren(encoderRoot);
+    scriptableItem_t *preset = scriptableItemChildren (encoderRoot);
 
-    const char *val = scriptableItemPropertyValueForKey(preset, "encoder");
-    EXPECT_TRUE(val);
-    EXPECT_STREQ(val, "cp %i %o");
+    const char *val = scriptableItemPropertyValueForKey (preset, "encoder");
+    EXPECT_TRUE (val);
+    EXPECT_STREQ (val, "cp %i %o");
 }
 
-TEST_F(ScriptableTests, test_ScriptableToConverterEncPreset_EmptyData_CreatesDefault) {
+TEST_F (ScriptableTests, test_ScriptableToConverterEncPreset_EmptyData_CreatesDefault) {
     ddb_encoder_preset_t preset;
-    scriptableItem_t *item = scriptableItemAlloc();
+    scriptableItem_t *item = scriptableItemAlloc ();
     scriptableEncoderPresetToConverterEncoderPreset (item, &preset);
-    EXPECT_TRUE(preset.ext);
-    EXPECT_TRUE(preset.encoder);
-    EXPECT_TRUE(preset.method==0);
-    EXPECT_TRUE(preset.tag_id3v2==0);
-    EXPECT_TRUE(preset.tag_id3v1==0);
-    EXPECT_TRUE(preset.tag_apev2==0);
-    EXPECT_TRUE(preset.tag_flac==0);
-    EXPECT_TRUE(preset.tag_oggvorbis==0);
-    EXPECT_TRUE(preset.tag_mp3xing==0);
-    EXPECT_TRUE(preset.tag_mp4==0);
-    EXPECT_TRUE(preset.id3v2_version==0);
+    EXPECT_TRUE (preset.ext);
+    EXPECT_TRUE (preset.encoder);
+    EXPECT_TRUE (preset.method == 0);
+    EXPECT_TRUE (preset.tag_id3v2 == 0);
+    EXPECT_TRUE (preset.tag_id3v1 == 0);
+    EXPECT_TRUE (preset.tag_apev2 == 0);
+    EXPECT_TRUE (preset.tag_flac == 0);
+    EXPECT_TRUE (preset.tag_oggvorbis == 0);
+    EXPECT_TRUE (preset.tag_mp3xing == 0);
+    EXPECT_TRUE (preset.tag_mp4 == 0);
+    EXPECT_TRUE (preset.id3v2_version == 0);
     free (preset.ext);
     free (preset.encoder);
 }
 
-TEST_F(ScriptableTests, test_DSPPreset_HasPassThrough) {
+TEST_F (ScriptableTests, test_DSPPreset_HasPassThrough) {
     scriptableDspLoadPresets (root);
     scriptableItem_t *dspRoot = scriptableDspRoot (root);
     int numPresets = scriptableItemNumChildren (dspRoot);
-    EXPECT_EQ(numPresets, 2);
+    EXPECT_EQ (numPresets, 2);
 
-    scriptableItem_t *preset = scriptableItemChildren(dspRoot);
-    EXPECT_EQ(0, scriptableItemNumChildren (preset));
+    scriptableItem_t *preset = scriptableItemChildren (dspRoot);
+    EXPECT_EQ (0, scriptableItemNumChildren (preset));
 
-    const char *name = scriptableItemPropertyValueForKey(preset, "name");
-    EXPECT_TRUE(!strcmp (name, "Pass-through"));
+    const char *name = scriptableItemPropertyValueForKey (preset, "name");
+    EXPECT_TRUE (!strcmp (name, "Pass-through"));
 }

--- a/Tests/ShellexecTests.cpp
+++ b/Tests/ShellexecTests.cpp
@@ -11,23 +11,22 @@
 #include "../plugins/shellexec/shellexecutil.h"
 #include <gtest/gtest.h>
 
-TEST(ShellexecTests, test_EvalCommand_FilePathNoSpecialChars_OutputsDirectory) {
+TEST (ShellexecTests, test_EvalCommand_FilePathNoSpecialChars_OutputsDirectory) {
     char output[_POSIX_ARG_MAX];
     playItem_t *it = pl_item_alloc ();
     pl_add_meta (it, ":URI", "/storage/music/file.mp3");
     int res = shellexec_eval_command ("%D", output, sizeof (output), (DB_playItem_t *)it);
-    EXPECT_EQ(res, 0);
-    EXPECT_TRUE(!strcmp (output, "'/storage/music'&"));
+    EXPECT_EQ (res, 0);
+    EXPECT_TRUE (!strcmp (output, "'/storage/music'&"));
     pl_item_unref (it);
 }
 
-TEST(ShellexecTests, test_EvalCommand_DirectoryWithSpecialChars_OutputsDirectory) {
+TEST (ShellexecTests, test_EvalCommand_DirectoryWithSpecialChars_OutputsDirectory) {
     char output[_POSIX_ARG_MAX];
     playItem_t *it = pl_item_alloc ();
     pl_add_meta (it, ":URI", "/storage/folder''name/file.mp3");
     int res = shellexec_eval_command ("%D", output, sizeof (output), (DB_playItem_t *)it);
-    EXPECT_EQ(res, 0);
-    EXPECT_TRUE(!strcmp (output, "'/storage/folder'\"'\"''\"'\"'name'&"));
+    EXPECT_EQ (res, 0);
+    EXPECT_TRUE (!strcmp (output, "'/storage/folder'\"'\"''\"'\"'name'&"));
     pl_item_unref (it);
 }
-

--- a/Tests/TitleFormattingTests.cpp
+++ b/Tests/TitleFormattingTests.cpp
@@ -35,7 +35,8 @@
 
 static ddb_playback_state_t fake_out_state_value = DDB_PLAYBACK_STATE_STOPPED;
 
-static ddb_playback_state_t fake_out_state (void) {
+static ddb_playback_state_t
+fake_out_state (void) {
     return fake_out_state_value;
 }
 
@@ -45,9 +46,9 @@ static DB_output_t fake_out = {
     .state = fake_out_state,
 };
 
-class TitleFormattingTests: public ::testing::Test {
+class TitleFormattingTests : public ::testing::Test {
 protected:
-    void SetUp() override {
+    void SetUp () override {
         ddb_logger_init ();
         conf_init ();
         conf_enable_saving (0);
@@ -59,36 +60,36 @@ protected:
         ctx.it = (DB_playItem_t *)it;
         ctx.plt = NULL;
 
-        messagepump_init();
+        messagepump_init ();
         plug_set_output (&fake_out);
-        streamer_init();
+        streamer_init ();
 
         streamer_set_playing_track (NULL);
 
         fake_out_state_value = DDB_PLAYBACK_STATE_STOPPED;
     }
 
-    void TearDown() override {
+    void TearDown () override {
         streamer_set_playing_track (NULL);
         pl_item_unref (it);
         ctx.it = NULL;
         ctx.plt = NULL;
-        streamer_free();
+        streamer_free ();
 
         // flush any remaining events
         uint32_t _id;
         uintptr_t ctx;
         uint32_t p1;
         uint32_t p2;
-        while (messagepump_pop(&_id, &ctx, &p1, &p2) != -1) {
+        while (messagepump_pop (&_id, &ctx, &p1, &p2) != -1) {
             if (_id >= DB_EV_FIRST && ctx) {
                 messagepump_event_free ((ddb_event_t *)ctx);
             }
         }
 
-        messagepump_free();
-        conf_free();
-        ddb_logger_free();
+        messagepump_free ();
+        conf_free ();
+        ddb_logger_free ();
     }
 
     playItem_t *it;
@@ -96,2368 +97,2368 @@ protected:
     char buffer[1000];
 };
 
-TEST_F(TitleFormattingTests, test_Literal_ReturnsLiteral) {
-    char *bc = tf_compile("hello world");
+TEST_F (TitleFormattingTests, test_Literal_ReturnsLiteral) {
+    char *bc = tf_compile ("hello world");
     tf_eval (&ctx, bc, buffer, sizeof (buffer));
     tf_free (bc);
-    EXPECT_TRUE(!strcmp ("hello world", buffer));
+    EXPECT_TRUE (!strcmp ("hello world", buffer));
 }
 
-TEST_F(TitleFormattingTests, test_AlbumArtistDash4DigitYearSpaceAlbum_ReturnsCorrectResult) {
+TEST_F (TitleFormattingTests, test_AlbumArtistDash4DigitYearSpaceAlbum_ReturnsCorrectResult) {
     pl_add_meta (it, "album artist", "TheAlbumArtist");
     pl_add_meta (it, "year", "12345678");
     pl_add_meta (it, "album", "TheNameOfAlbum");
 
-    char *bc = tf_compile("%album artist% - ($left($meta(year),4)) %album%");
+    char *bc = tf_compile ("%album artist% - ($left($meta(year),4)) %album%");
     tf_eval (&ctx, bc, buffer, sizeof (buffer));
     tf_free (bc);
-    EXPECT_TRUE(!strcmp ("TheAlbumArtist - (1234) TheNameOfAlbum", buffer));
+    EXPECT_TRUE (!strcmp ("TheAlbumArtist - (1234) TheNameOfAlbum", buffer));
 }
 
-TEST_F(TitleFormattingTests, test_Unicode_AlbumArtistDash4DigitYearSpaceAlbum_ReturnsCorrectResult) {
+TEST_F (TitleFormattingTests, test_Unicode_AlbumArtistDash4DigitYearSpaceAlbum_ReturnsCorrectResult) {
     pl_add_meta (it, "album artist", "ИсполнительДанногоАльбома");
     pl_add_meta (it, "year", "12345678");
     pl_add_meta (it, "album", "Альбом");
 
-    char *bc = tf_compile("%album artist% - ($left($meta(year),4)) %album%");
+    char *bc = tf_compile ("%album artist% - ($left($meta(year),4)) %album%");
     tf_eval (&ctx, bc, buffer, sizeof (buffer));
     tf_free (bc);
-    EXPECT_TRUE(!strcmp ("ИсполнительДанногоАльбома - (1234) Альбом", buffer));
+    EXPECT_TRUE (!strcmp ("ИсполнительДанногоАльбома - (1234) Альбом", buffer));
 }
 
-TEST_F(TitleFormattingTests, test_TotalDiscsGreaterThan1_ReturnsExpectedResult) {
+TEST_F (TitleFormattingTests, test_TotalDiscsGreaterThan1_ReturnsExpectedResult) {
     pl_add_meta (it, "numdiscs", "20");
     pl_add_meta (it, "disc", "18");
 
-    char *bc = tf_compile("$if($greater(%totaldiscs%,1),- Disc: %discnumber%/%totaldiscs%)");
+    char *bc = tf_compile ("$if($greater(%totaldiscs%,1),- Disc: %discnumber%/%totaldiscs%)");
     tf_eval (&ctx, bc, buffer, sizeof (buffer));
     tf_free (bc);
-    EXPECT_TRUE(!strcmp ("- Disc: 18/20", buffer));
+    EXPECT_TRUE (!strcmp ("- Disc: 18/20", buffer));
 }
 
-TEST_F(TitleFormattingTests, test_AlbumArtistSameAsArtist_ReturnsBlankTrackArtist) {
+TEST_F (TitleFormattingTests, test_AlbumArtistSameAsArtist_ReturnsBlankTrackArtist) {
     pl_add_meta (it, "artist", "Artist Name");
     pl_add_meta (it, "album artist", "Artist Name");
 
-    char *bc = tf_compile("%track artist%");
+    char *bc = tf_compile ("%track artist%");
     tf_eval (&ctx, bc, buffer, sizeof (buffer));
     tf_free (bc);
-    EXPECT_TRUE(!buffer[0]);
+    EXPECT_TRUE (!buffer[0]);
 }
 
-TEST_F(TitleFormattingTests, test_TrackArtistIsUndef_ReturnsBlankTrackArtist) {
+TEST_F (TitleFormattingTests, test_TrackArtistIsUndef_ReturnsBlankTrackArtist) {
     pl_add_meta (it, "album artist", "Artist Name");
 
-    char *bc = tf_compile("%track artist%");
+    char *bc = tf_compile ("%track artist%");
     tf_eval (&ctx, bc, buffer, sizeof (buffer));
     tf_free (bc);
-    EXPECT_TRUE(!buffer[0]);
+    EXPECT_TRUE (!buffer[0]);
 }
 
-TEST_F(TitleFormattingTests, test_TrackArtistIsDefined_ReturnsTheTrackArtist) {
+TEST_F (TitleFormattingTests, test_TrackArtistIsDefined_ReturnsTheTrackArtist) {
     pl_add_meta (it, "artist", "Track Artist Name");
     pl_add_meta (it, "album artist", "Album Artist Name");
 
-    char *bc = tf_compile("%track artist%");
+    char *bc = tf_compile ("%track artist%");
     tf_eval (&ctx, bc, buffer, sizeof (buffer));
     tf_free (bc);
-    EXPECT_TRUE(!strcmp ("Track Artist Name", buffer));
+    EXPECT_TRUE (!strcmp ("Track Artist Name", buffer));
 }
 
-TEST_F(TitleFormattingTests, test_Add10And2_Gives12) {
-    char *bc = tf_compile("$add(10,2)");
+TEST_F (TitleFormattingTests, test_Add10And2_Gives12) {
+    char *bc = tf_compile ("$add(10,2)");
     tf_eval (&ctx, bc, buffer, sizeof (buffer));
     tf_free (bc);
-    EXPECT_TRUE(!strcmp ("12", buffer));
+    EXPECT_TRUE (!strcmp ("12", buffer));
 }
 
-TEST_F(TitleFormattingTests, test_StrcmpChannelsMono_GivesMo) {
-    char *bc = tf_compile("$if($strcmp(%channels%,mono),mo,st)");
+TEST_F (TitleFormattingTests, test_StrcmpChannelsMono_GivesMo) {
+    char *bc = tf_compile ("$if($strcmp(%channels%,mono),mo,st)");
     pl_replace_meta (it, ":CHANNELS", "1");
     tf_eval (&ctx, bc, buffer, sizeof (buffer));
     tf_free (bc);
-    EXPECT_TRUE(!strcmp ("mo", buffer));
+    EXPECT_TRUE (!strcmp ("mo", buffer));
 }
 
-TEST_F(TitleFormattingTests, test_StrcmpChannelsMono_GivesSt) {
-    char *bc = tf_compile("$if($strcmp(%channels%,mono),mo,st)");
+TEST_F (TitleFormattingTests, test_StrcmpChannelsMono_GivesSt) {
+    char *bc = tf_compile ("$if($strcmp(%channels%,mono),mo,st)");
     pl_replace_meta (it, ":CHANNELS", "2");
     tf_eval (&ctx, bc, buffer, sizeof (buffer));
     tf_free (bc);
-    EXPECT_TRUE(!strcmp ("st", buffer));
+    EXPECT_TRUE (!strcmp ("st", buffer));
 }
 
 // This test validates that overflowing the buffer wouldn't cause a crash
-TEST_F(TitleFormattingTests, test_LongCommentOverflowBuffer_ExpectedResult) {
+TEST_F (TitleFormattingTests, test_LongCommentOverflowBuffer_ExpectedResult) {
     char longcomment[2048];
     for (int i = 0; i < sizeof (longcomment) - 1; i++) {
         longcomment[i] = (i % 33) + 'a';
     }
-    longcomment[sizeof (longcomment)-1] = 0;
+    longcomment[sizeof (longcomment) - 1] = 0;
 
     pl_add_meta (it, "comment", longcomment);
 
-    char *bc = tf_compile("$meta(comment)");
+    char *bc = tf_compile ("$meta(comment)");
     tf_eval (&ctx, bc, buffer, 200);
     tf_free (bc);
-    EXPECT_TRUE(!memcmp (buffer, "abcdef", 6));
+    EXPECT_TRUE (!memcmp (buffer, "abcdef", 6));
 }
 
-TEST_F(TitleFormattingTests, test_ParticularLongExpressionDoesntAllocateZeroBytes) {
+TEST_F (TitleFormattingTests, test_ParticularLongExpressionDoesntAllocateZeroBytes) {
     pl_replace_meta (it, "artist", "Frank Schätzing");
     pl_replace_meta (it, "year", "1999");
     pl_replace_meta (it, "album", "Tod und Teufel");
     pl_replace_meta (it, "disc", "1");
     pl_replace_meta (it, "disctotal", "4");
     pl_replace_meta (it, ":FILETYPE", "FLAC");
-    char *bc = tf_compile("$if($strcmp(%genre%,Classical),%composer%,$if([%band%],%band%,%album artist%)) | ($left(%year%,4)) %album% $if($greater(%totaldiscs%,1),- Disc: %discnumber%/%totaldiscs%) - \\[%codec%\\]");
+    char *bc = tf_compile (
+        "$if($strcmp(%genre%,Classical),%composer%,$if([%band%],%band%,%album artist%)) | ($left(%year%,4)) %album% $if($greater(%totaldiscs%,1),- Disc: %discnumber%/%totaldiscs%) - \\[%codec%\\]");
 
-    EXPECT_TRUE(bc != NULL);
+    EXPECT_TRUE (bc != NULL);
 
     tf_free (bc);
 }
 
-TEST_F(TitleFormattingTests, test_If2FirstArgIsTrue_EvalToFirstArg) {
+TEST_F (TitleFormattingTests, test_If2FirstArgIsTrue_EvalToFirstArg) {
     pl_replace_meta (it, "title", "a title");
-    char *bc = tf_compile("$if2(%title%,def)");
+    char *bc = tf_compile ("$if2(%title%,def)");
     tf_eval (&ctx, bc, buffer, sizeof (buffer));
     tf_free (bc);
-    EXPECT_TRUE(!strcmp ("a title", buffer));
+    EXPECT_TRUE (!strcmp ("a title", buffer));
 }
 
-TEST_F(TitleFormattingTests, test_If2FirstArgIsMixedStringTrue_EvalToFirstArg) {
-    pl_replace_meta (it, "title", "a title");
-    pl_replace_meta (it, "artist", "an artist");
-    char *bc = tf_compile("$if2(%title%%artist%,def)");
-    tf_eval (&ctx, bc, buffer, sizeof (buffer));
-    tf_free (bc);
-    EXPECT_TRUE(!strcmp ("a titlean artist", buffer));
-}
-
-TEST_F(TitleFormattingTests, test_If2FirstArgIsMissingField_EvalToLastArg) {
+TEST_F (TitleFormattingTests, test_If2FirstArgIsMixedStringTrue_EvalToFirstArg) {
     pl_replace_meta (it, "title", "a title");
     pl_replace_meta (it, "artist", "an artist");
-    char *bc = tf_compile("$if2(%garbage%,def)");
+    char *bc = tf_compile ("$if2(%title%%artist%,def)");
     tf_eval (&ctx, bc, buffer, sizeof (buffer));
     tf_free (bc);
-    EXPECT_TRUE(!strcmp ("def", buffer));
+    EXPECT_TRUE (!strcmp ("a titlean artist", buffer));
 }
 
-TEST_F(TitleFormattingTests, test_If2FirstArgIsMixedWithGarbageTrue_EvalToFirstArg) {
+TEST_F (TitleFormattingTests, test_If2FirstArgIsMissingField_EvalToLastArg) {
     pl_replace_meta (it, "title", "a title");
     pl_replace_meta (it, "artist", "an artist");
-    char *bc = tf_compile("$if2(%garbage%xxx%title%,def)");
+    char *bc = tf_compile ("$if2(%garbage%,def)");
     tf_eval (&ctx, bc, buffer, sizeof (buffer));
     tf_free (bc);
-    EXPECT_TRUE(!strcmp ("xxxa title", buffer));
+    EXPECT_TRUE (!strcmp ("def", buffer));
 }
 
-TEST_F(TitleFormattingTests, test_If2FirstArgIsMixedWithGarbageTailTrue_EvalToFirstArg) {
+TEST_F (TitleFormattingTests, test_If2FirstArgIsMixedWithGarbageTrue_EvalToFirstArg) {
     pl_replace_meta (it, "title", "a title");
     pl_replace_meta (it, "artist", "an artist");
-    char *bc = tf_compile("$if2(%title%%garbage%xxx,def)");
+    char *bc = tf_compile ("$if2(%garbage%xxx%title%,def)");
     tf_eval (&ctx, bc, buffer, sizeof (buffer));
     tf_free (bc);
-    EXPECT_TRUE(!strcmp ("a titlexxx", buffer));
+    EXPECT_TRUE (!strcmp ("xxxa title", buffer));
 }
 
-TEST_F(TitleFormattingTests, test_If2FirstArgIsFalse_EvalToSecondArg) {
-    char *bc = tf_compile("$if2(,ghi)");
-    tf_eval (&ctx, bc, buffer, sizeof (buffer));
-    tf_free (bc);
-    EXPECT_TRUE(!strcmp ("ghi", buffer));
-}
-
-TEST_F(TitleFormattingTests, test_If3FirstArgIsTrue_EvalToFirstArg) {
+TEST_F (TitleFormattingTests, test_If2FirstArgIsMixedWithGarbageTailTrue_EvalToFirstArg) {
     pl_replace_meta (it, "title", "a title");
-    char *bc = tf_compile("$if3(%title%,def)");
+    pl_replace_meta (it, "artist", "an artist");
+    char *bc = tf_compile ("$if2(%title%%garbage%xxx,def)");
     tf_eval (&ctx, bc, buffer, sizeof (buffer));
     tf_free (bc);
-    EXPECT_TRUE(!strcmp ("a title", buffer));
+    EXPECT_TRUE (!strcmp ("a titlexxx", buffer));
 }
 
-TEST_F(TitleFormattingTests, test_If3AllButLastAreFalse_EvalToLastArg) {
-    char *bc = tf_compile("$if3(,,,,,lastarg)");
+TEST_F (TitleFormattingTests, test_If2FirstArgIsFalse_EvalToSecondArg) {
+    char *bc = tf_compile ("$if2(,ghi)");
     tf_eval (&ctx, bc, buffer, sizeof (buffer));
     tf_free (bc);
-    EXPECT_TRUE(!strcmp ("lastarg", buffer));
+    EXPECT_TRUE (!strcmp ("ghi", buffer));
 }
 
-TEST_F(TitleFormattingTests, test_If3OneOfTheArgsBeforeLastIsTrue_EvalToFirstTrueArg) {
-    char *bc = tf_compile("$if3(,,firstarg,,secondarg,lastarg)");
+TEST_F (TitleFormattingTests, test_If3FirstArgIsTrue_EvalToFirstArg) {
+    pl_replace_meta (it, "title", "a title");
+    char *bc = tf_compile ("$if3(%title%,def)");
     tf_eval (&ctx, bc, buffer, sizeof (buffer));
     tf_free (bc);
-    EXPECT_TRUE(!strcmp ("lastarg", buffer));
+    EXPECT_TRUE (!strcmp ("a title", buffer));
 }
 
-TEST_F(TitleFormattingTests, test_IfEqualTrue_EvalsToThen) {
-    char *bc = tf_compile("$ifequal(100,100,then,else)");
+TEST_F (TitleFormattingTests, test_If3AllButLastAreFalse_EvalToLastArg) {
+    char *bc = tf_compile ("$if3(,,,,,lastarg)");
     tf_eval (&ctx, bc, buffer, sizeof (buffer));
     tf_free (bc);
-    EXPECT_TRUE(!strcmp ("then", buffer));
+    EXPECT_TRUE (!strcmp ("lastarg", buffer));
 }
 
-TEST_F(TitleFormattingTests, test_IfEqualFalse_EvalsToElse) {
-    char *bc = tf_compile("$ifequal(100,200,then,else)");
+TEST_F (TitleFormattingTests, test_If3OneOfTheArgsBeforeLastIsTrue_EvalToFirstTrueArg) {
+    char *bc = tf_compile ("$if3(,,firstarg,,secondarg,lastarg)");
     tf_eval (&ctx, bc, buffer, sizeof (buffer));
     tf_free (bc);
-    EXPECT_TRUE(!strcmp ("else", buffer));
+    EXPECT_TRUE (!strcmp ("lastarg", buffer));
 }
 
-TEST_F(TitleFormattingTests, test_IfGreaterTrue_EvalsToThen) {
-    char *bc = tf_compile("$ifgreater(200,100,then,else)");
+TEST_F (TitleFormattingTests, test_IfEqualTrue_EvalsToThen) {
+    char *bc = tf_compile ("$ifequal(100,100,then,else)");
     tf_eval (&ctx, bc, buffer, sizeof (buffer));
     tf_free (bc);
-    EXPECT_TRUE(!strcmp ("then", buffer));
+    EXPECT_TRUE (!strcmp ("then", buffer));
 }
 
-TEST_F(TitleFormattingTests, test_IfGreaterFalse_EvalsToElse) {
-    char *bc = tf_compile("$ifgreater(100,200,then,else)");
+TEST_F (TitleFormattingTests, test_IfEqualFalse_EvalsToElse) {
+    char *bc = tf_compile ("$ifequal(100,200,then,else)");
     tf_eval (&ctx, bc, buffer, sizeof (buffer));
     tf_free (bc);
-    EXPECT_TRUE(!strcmp ("else", buffer));
+    EXPECT_TRUE (!strcmp ("else", buffer));
 }
 
-TEST_F(TitleFormattingTests, test_GreaterIsTrue_EvalsToTrue) {
-    char *bc = tf_compile("$if($greater(2,1),istrue,isfalse)");
+TEST_F (TitleFormattingTests, test_IfGreaterTrue_EvalsToThen) {
+    char *bc = tf_compile ("$ifgreater(200,100,then,else)");
     tf_eval (&ctx, bc, buffer, sizeof (buffer));
     tf_free (bc);
-    EXPECT_TRUE(!strcmp ("istrue", buffer));
+    EXPECT_TRUE (!strcmp ("then", buffer));
 }
 
-TEST_F(TitleFormattingTests, test_GreaterIsFalse_EvalsToFalse) {
-    char *bc = tf_compile("$if($greater(1,2),istrue,isfalse)");
+TEST_F (TitleFormattingTests, test_IfGreaterFalse_EvalsToElse) {
+    char *bc = tf_compile ("$ifgreater(100,200,then,else)");
     tf_eval (&ctx, bc, buffer, sizeof (buffer));
     tf_free (bc);
-    EXPECT_TRUE(!strcmp ("isfalse", buffer));
+    EXPECT_TRUE (!strcmp ("else", buffer));
 }
 
-TEST_F(TitleFormattingTests, test_GreaterIsFalseEmptyArguments_EvalsToFalse) {
-    char *bc = tf_compile("$if($greater(,),istrue,isfalse)");
+TEST_F (TitleFormattingTests, test_GreaterIsTrue_EvalsToTrue) {
+    char *bc = tf_compile ("$if($greater(2,1),istrue,isfalse)");
     tf_eval (&ctx, bc, buffer, sizeof (buffer));
     tf_free (bc);
-    EXPECT_TRUE(!strcmp ("isfalse", buffer));
+    EXPECT_TRUE (!strcmp ("istrue", buffer));
 }
 
-TEST_F(TitleFormattingTests, test_Greater_CalculatedValueTrue_EvalsToTrue) {
+TEST_F (TitleFormattingTests, test_GreaterIsFalse_EvalsToFalse) {
+    char *bc = tf_compile ("$if($greater(1,2),istrue,isfalse)");
+    tf_eval (&ctx, bc, buffer, sizeof (buffer));
+    tf_free (bc);
+    EXPECT_TRUE (!strcmp ("isfalse", buffer));
+}
+
+TEST_F (TitleFormattingTests, test_GreaterIsFalseEmptyArguments_EvalsToFalse) {
+    char *bc = tf_compile ("$if($greater(,),istrue,isfalse)");
+    tf_eval (&ctx, bc, buffer, sizeof (buffer));
+    tf_free (bc);
+    EXPECT_TRUE (!strcmp ("isfalse", buffer));
+}
+
+TEST_F (TitleFormattingTests, test_Greater_CalculatedValueTrue_EvalsToTrue) {
     pl_replace_meta (it, "album", "abcdefabcdefabcdefabcdef");
-    char *bc = tf_compile("$if($greater($len(%album%),20),GREATER $len(%album%) %album%,NOT GREATER $len(%album%) %album%)");
+    char *bc =
+        tf_compile ("$if($greater($len(%album%),20),GREATER $len(%album%) %album%,NOT GREATER $len(%album%) %album%)");
     tf_eval (&ctx, bc, buffer, sizeof (buffer));
     tf_free (bc);
-    EXPECT_TRUE(!strcmp ("GREATER 24 abcdefabcdefabcdefabcdef", buffer));
+    EXPECT_TRUE (!strcmp ("GREATER 24 abcdefabcdefabcdefabcdef", buffer));
 }
 
-TEST_F(TitleFormattingTests, test_Greater_CalculatedValueFalse_EvalsToFalse) {
+TEST_F (TitleFormattingTests, test_Greater_CalculatedValueFalse_EvalsToFalse) {
     pl_replace_meta (it, "album", "abcdef");
-    char *bc = tf_compile("$if($greater($len(%album%),20),GREATER $len(%album%) %album%,NOT GREATER $len(%album%) %album%)");
+    char *bc =
+        tf_compile ("$if($greater($len(%album%),20),GREATER $len(%album%) %album%,NOT GREATER $len(%album%) %album%)");
     tf_eval (&ctx, bc, buffer, sizeof (buffer));
     tf_free (bc);
-    EXPECT_TRUE(!strcmp ("NOT GREATER 6 abcdef", buffer));
+    EXPECT_TRUE (!strcmp ("NOT GREATER 6 abcdef", buffer));
 }
 
-TEST_F(TitleFormattingTests, test_Greater_Largenumber_EvalsToTrue) {
-    char *bc = tf_compile("$if($greater(50,20),GREATER,NOT GREATER)");
+TEST_F (TitleFormattingTests, test_Greater_Largenumber_EvalsToTrue) {
+    char *bc = tf_compile ("$if($greater(50,20),GREATER,NOT GREATER)");
     tf_eval (&ctx, bc, buffer, sizeof (buffer));
     tf_free (bc);
-    EXPECT_TRUE(!strcmp ("GREATER", buffer));
+    EXPECT_TRUE (!strcmp ("GREATER", buffer));
 }
 
-TEST_F(TitleFormattingTests, test_StrCmpEmptyArguments_EvalsToTrue) {
-    char *bc = tf_compile("$if($strcmp(,),istrue,isfalse)");
+TEST_F (TitleFormattingTests, test_StrCmpEmptyArguments_EvalsToTrue) {
+    char *bc = tf_compile ("$if($strcmp(,),istrue,isfalse)");
     tf_eval (&ctx, bc, buffer, sizeof (buffer));
     tf_free (bc);
-    EXPECT_TRUE(!strcmp ("istrue", buffer));
+    EXPECT_TRUE (!strcmp ("istrue", buffer));
 }
 
-TEST_F(TitleFormattingTests, test_StrCmpSameArguments_EvalsToTrue) {
-    char *bc = tf_compile("$if($strcmp(abc,abc),istrue,isfalse)");
+TEST_F (TitleFormattingTests, test_StrCmpSameArguments_EvalsToTrue) {
+    char *bc = tf_compile ("$if($strcmp(abc,abc),istrue,isfalse)");
     tf_eval (&ctx, bc, buffer, sizeof (buffer));
     tf_free (bc);
-    EXPECT_TRUE(!strcmp ("istrue", buffer));
+    EXPECT_TRUE (!strcmp ("istrue", buffer));
 }
 
-TEST_F(TitleFormattingTests, test_IfLongerTrue_EvalsToTrue) {
-    char *bc = tf_compile("$iflonger(abcd,2,istrue,isfalse)");
+TEST_F (TitleFormattingTests, test_IfLongerTrue_EvalsToTrue) {
+    char *bc = tf_compile ("$iflonger(abcd,2,istrue,isfalse)");
     tf_eval (&ctx, bc, buffer, sizeof (buffer));
     tf_free (bc);
-    EXPECT_TRUE(!strcmp ("istrue", buffer));
+    EXPECT_TRUE (!strcmp ("istrue", buffer));
 }
 
-TEST_F(TitleFormattingTests, test_IfLongerFalse_EvalsToFalse) {
-    char *bc = tf_compile("$iflonger(ab,4,istrue,isfalse)");
+TEST_F (TitleFormattingTests, test_IfLongerFalse_EvalsToFalse) {
+    char *bc = tf_compile ("$iflonger(ab,4,istrue,isfalse)");
     tf_eval (&ctx, bc, buffer, sizeof (buffer));
     tf_free (bc);
-    EXPECT_TRUE(!strcmp ("isfalse", buffer));
+    EXPECT_TRUE (!strcmp ("isfalse", buffer));
 }
 
-TEST_F(TitleFormattingTests, test_SelectMiddle_EvalsToSelectedValue) {
-    char *bc = tf_compile("$select(3,10,20,30,40,50)");
+TEST_F (TitleFormattingTests, test_SelectMiddle_EvalsToSelectedValue) {
+    char *bc = tf_compile ("$select(3,10,20,30,40,50)");
     tf_eval (&ctx, bc, buffer, sizeof (buffer));
     tf_free (bc);
-    EXPECT_TRUE(!strcmp ("30", buffer));
+    EXPECT_TRUE (!strcmp ("30", buffer));
 }
 
-TEST_F(TitleFormattingTests, test_SelectLeftmost_EvalsToSelectedValue) {
-    char *bc = tf_compile("$select(1,10,20,30,40,50)");
+TEST_F (TitleFormattingTests, test_SelectLeftmost_EvalsToSelectedValue) {
+    char *bc = tf_compile ("$select(1,10,20,30,40,50)");
     tf_eval (&ctx, bc, buffer, sizeof (buffer));
     tf_free (bc);
-    EXPECT_TRUE(!strcmp ("10", buffer));
+    EXPECT_TRUE (!strcmp ("10", buffer));
 }
 
-TEST_F(TitleFormattingTests, test_SelectRightmost_EvalsToSelectedValue) {
-    char *bc = tf_compile("$select(5,10,20,30,40,50)");
+TEST_F (TitleFormattingTests, test_SelectRightmost_EvalsToSelectedValue) {
+    char *bc = tf_compile ("$select(5,10,20,30,40,50)");
     tf_eval (&ctx, bc, buffer, sizeof (buffer));
     tf_free (bc);
-    EXPECT_TRUE(!strcmp ("50", buffer));
+    EXPECT_TRUE (!strcmp ("50", buffer));
 }
 
-TEST_F(TitleFormattingTests, test_SelectOutOfBoundsLeft_EvalsToFalse) {
-    char *bc = tf_compile("$select(0,10,20,30,40,50)");
+TEST_F (TitleFormattingTests, test_SelectOutOfBoundsLeft_EvalsToFalse) {
+    char *bc = tf_compile ("$select(0,10,20,30,40,50)");
     tf_eval (&ctx, bc, buffer, sizeof (buffer));
     tf_free (bc);
-    EXPECT_TRUE(!buffer[0]);
+    EXPECT_TRUE (!buffer[0]);
 }
 
-TEST_F(TitleFormattingTests, test_SelectOutOfBoundsRight_EvalsToFalse) {
-    char *bc = tf_compile("$select(6,10,20,30,40,50)");
+TEST_F (TitleFormattingTests, test_SelectOutOfBoundsRight_EvalsToFalse) {
+    char *bc = tf_compile ("$select(6,10,20,30,40,50)");
     tf_eval (&ctx, bc, buffer, sizeof (buffer));
     tf_free (bc);
-    EXPECT_TRUE(!buffer[0]);
+    EXPECT_TRUE (!buffer[0]);
 }
 
-TEST_F(TitleFormattingTests, test_InvalidPercentExpression_WithNullTrack_NoCrash) {
-    char *bc = tf_compile("begin - %version% - end");
+TEST_F (TitleFormattingTests, test_InvalidPercentExpression_WithNullTrack_NoCrash) {
+    char *bc = tf_compile ("begin - %version% - end");
 
     ctx.it = NULL;
     tf_eval (&ctx, bc, buffer, 1000);
     tf_free (bc);
-    EXPECT_TRUE(!strcmp ("begin -  - end", buffer));
+    EXPECT_TRUE (!strcmp ("begin -  - end", buffer));
 }
 
-TEST_F(TitleFormattingTests, test_InvalidPercentExpression_WithNullTrackAccessingMetadata_NoCrash) {
-    char *bc = tf_compile("begin - %title% - end");
+TEST_F (TitleFormattingTests, test_InvalidPercentExpression_WithNullTrackAccessingMetadata_NoCrash) {
+    char *bc = tf_compile ("begin - %title% - end");
     ctx.it = NULL;
     tf_eval (&ctx, bc, buffer, 1000);
     tf_free (bc);
-    EXPECT_TRUE(!strcmp ("begin -  - end", buffer));
+    EXPECT_TRUE (!strcmp ("begin -  - end", buffer));
 }
 
-TEST_F(TitleFormattingTests, test_Index_WithNullPlaylist_NoCrash) {
-    char *bc = tf_compile("begin - %list_index% - end");
+TEST_F (TitleFormattingTests, test_Index_WithNullPlaylist_NoCrash) {
+    char *bc = tf_compile ("begin - %list_index% - end");
     ctx.it = NULL;
     tf_eval (&ctx, bc, buffer, 1000);
     tf_free (bc);
-    EXPECT_TRUE(!strcmp ("begin - 0 - end", buffer));
+    EXPECT_TRUE (!strcmp ("begin - 0 - end", buffer));
 }
 
-TEST_F(TitleFormattingTests, test_Div5by2_Gives3) {
-    char *bc = tf_compile("$div(5,2)");
+TEST_F (TitleFormattingTests, test_Div5by2_Gives3) {
+    char *bc = tf_compile ("$div(5,2)");
     ctx.it = NULL;
     tf_eval (&ctx, bc, buffer, 1000);
     tf_free (bc);
-    EXPECT_TRUE(!strcmp ("3", buffer));
+    EXPECT_TRUE (!strcmp ("3", buffer));
 }
 
-TEST_F(TitleFormattingTests, test_Div4pt9by1pt9_Gives4) {
-    char *bc = tf_compile("$div(4.9,1.9)");
+TEST_F (TitleFormattingTests, test_Div4pt9by1pt9_Gives4) {
+    char *bc = tf_compile ("$div(4.9,1.9)");
     ctx.it = NULL;
     tf_eval (&ctx, bc, buffer, 1000);
     tf_free (bc);
-    EXPECT_TRUE(!strcmp ("4", buffer));
+    EXPECT_TRUE (!strcmp ("4", buffer));
 }
 
-TEST_F(TitleFormattingTests, test_Div20by2by5_Gives2) {
-    char *bc = tf_compile("$div(20,2,5)");
+TEST_F (TitleFormattingTests, test_Div20by2by5_Gives2) {
+    char *bc = tf_compile ("$div(20,2,5)");
     ctx.it = NULL;
     tf_eval (&ctx, bc, buffer, 1000);
     tf_free (bc);
-    EXPECT_TRUE(!strcmp ("2", buffer));
+    EXPECT_TRUE (!strcmp ("2", buffer));
 }
 
-TEST_F(TitleFormattingTests, test_DivBy0_GivesEmpty) {
-    char *bc = tf_compile("$div(5,0)");
+TEST_F (TitleFormattingTests, test_DivBy0_GivesEmpty) {
+    char *bc = tf_compile ("$div(5,0)");
     ctx.it = NULL;
     tf_eval (&ctx, bc, buffer, 1000);
     tf_free (bc);
-    EXPECT_TRUE(!buffer[0]);
+    EXPECT_TRUE (!buffer[0]);
 }
 
-TEST_F(TitleFormattingTests, test_Max0Arguments_GivesEmpty) {
-    char *bc = tf_compile("$max()");
+TEST_F (TitleFormattingTests, test_Max0Arguments_GivesEmpty) {
+    char *bc = tf_compile ("$max()");
     ctx.it = NULL;
     tf_eval (&ctx, bc, buffer, 1000);
     tf_free (bc);
-    EXPECT_TRUE(!buffer[0]);
+    EXPECT_TRUE (!buffer[0]);
 }
 
-TEST_F(TitleFormattingTests, test_MaxOf1and2_Gives2) {
-    char *bc = tf_compile("$max(1,2)");
+TEST_F (TitleFormattingTests, test_MaxOf1and2_Gives2) {
+    char *bc = tf_compile ("$max(1,2)");
     ctx.it = NULL;
     tf_eval (&ctx, bc, buffer, 1000);
     tf_free (bc);
-    EXPECT_TRUE(!strcmp ("2", buffer));
+    EXPECT_TRUE (!strcmp ("2", buffer));
 }
 
-TEST_F(TitleFormattingTests, test_MaxOf30and50and20_Gives50) {
-    char *bc = tf_compile("$max(30,50,20)");
+TEST_F (TitleFormattingTests, test_MaxOf30and50and20_Gives50) {
+    char *bc = tf_compile ("$max(30,50,20)");
     ctx.it = NULL;
     tf_eval (&ctx, bc, buffer, 1000);
     tf_free (bc);
-    EXPECT_TRUE(!strcmp ("50", buffer));
+    EXPECT_TRUE (!strcmp ("50", buffer));
 }
 
-TEST_F(TitleFormattingTests, test_MinOf1and2_Gives1) {
-    char *bc = tf_compile("$min(1,2)");
+TEST_F (TitleFormattingTests, test_MinOf1and2_Gives1) {
+    char *bc = tf_compile ("$min(1,2)");
     ctx.it = NULL;
     tf_eval (&ctx, bc, buffer, 1000);
     tf_free (bc);
-    EXPECT_TRUE(!strcmp ("1", buffer));
+    EXPECT_TRUE (!strcmp ("1", buffer));
 }
 
-TEST_F(TitleFormattingTests, test_MinOf30and50and20_Gives20) {
-    char *bc = tf_compile("$min(30,50,20)");
+TEST_F (TitleFormattingTests, test_MinOf30and50and20_Gives20) {
+    char *bc = tf_compile ("$min(30,50,20)");
     ctx.it = NULL;
     tf_eval (&ctx, bc, buffer, 1000);
     tf_free (bc);
-    EXPECT_TRUE(!strcmp ("20", buffer));
+    EXPECT_TRUE (!strcmp ("20", buffer));
 }
 
-TEST_F(TitleFormattingTests, test_ModOf3and2_Gives1) {
-    char *bc = tf_compile("$mod(3,2)");
+TEST_F (TitleFormattingTests, test_ModOf3and2_Gives1) {
+    char *bc = tf_compile ("$mod(3,2)");
     ctx.it = NULL;
     tf_eval (&ctx, bc, buffer, 1000);
     tf_free (bc);
-    EXPECT_TRUE(!strcmp ("1", buffer));
+    EXPECT_TRUE (!strcmp ("1", buffer));
 }
 
-TEST_F(TitleFormattingTests, test_ModOf6and3_Gives0) {
-    char *bc = tf_compile("$mod(6,3)");
+TEST_F (TitleFormattingTests, test_ModOf6and3_Gives0) {
+    char *bc = tf_compile ("$mod(6,3)");
     ctx.it = NULL;
     tf_eval (&ctx, bc, buffer, 1000);
     tf_free (bc);
-    EXPECT_TRUE(!strcmp ("0", buffer));
+    EXPECT_TRUE (!strcmp ("0", buffer));
 }
 
-TEST_F(TitleFormattingTests, test_ModOf16and18and9_Gives7) {
-    char *bc = tf_compile("$mod(16,18,9)");
+TEST_F (TitleFormattingTests, test_ModOf16and18and9_Gives7) {
+    char *bc = tf_compile ("$mod(16,18,9)");
     ctx.it = NULL;
     tf_eval (&ctx, bc, buffer, 1000);
     tf_free (bc);
-    EXPECT_TRUE(!strcmp ("7", buffer));
+    EXPECT_TRUE (!strcmp ("7", buffer));
 }
 
-TEST_F(TitleFormattingTests, test_Mul2and5_Gives10) {
-    char *bc = tf_compile("$mul(2,5)");
+TEST_F (TitleFormattingTests, test_Mul2and5_Gives10) {
+    char *bc = tf_compile ("$mul(2,5)");
     ctx.it = NULL;
     tf_eval (&ctx, bc, buffer, 1000);
     tf_free (bc);
-    EXPECT_TRUE(!strcmp ("10", buffer));
+    EXPECT_TRUE (!strcmp ("10", buffer));
 }
 
-TEST_F(TitleFormattingTests, test_MulOf2and3and4_Gives24) {
-    char *bc = tf_compile("$mul(2,3,4)");
+TEST_F (TitleFormattingTests, test_MulOf2and3and4_Gives24) {
+    char *bc = tf_compile ("$mul(2,3,4)");
     ctx.it = NULL;
     tf_eval (&ctx, bc, buffer, 1000);
     tf_free (bc);
-    EXPECT_TRUE(!strcmp ("24", buffer));
+    EXPECT_TRUE (!strcmp ("24", buffer));
 }
 
-TEST_F(TitleFormattingTests, test_MulDiv2and10and4_Gives5) {
-    char *bc = tf_compile("$muldiv(2,10,4)");
+TEST_F (TitleFormattingTests, test_MulDiv2and10and4_Gives5) {
+    char *bc = tf_compile ("$muldiv(2,10,4)");
     ctx.it = NULL;
     tf_eval (&ctx, bc, buffer, 1000);
     tf_free (bc);
-    EXPECT_TRUE(!strcmp ("5", buffer));
+    EXPECT_TRUE (!strcmp ("5", buffer));
 }
 
-TEST_F(TitleFormattingTests, test_MulDiv2and10and0_GivesEmpty) {
-    char *bc = tf_compile("$muldiv(2,10,0)");
+TEST_F (TitleFormattingTests, test_MulDiv2and10and0_GivesEmpty) {
+    char *bc = tf_compile ("$muldiv(2,10,0)");
     ctx.it = NULL;
     tf_eval (&ctx, bc, buffer, 1000);
     tf_free (bc);
-    EXPECT_TRUE(!buffer[0]);
+    EXPECT_TRUE (!buffer[0]);
 }
 
-TEST_F(TitleFormattingTests, test_MulDiv2and3and4_Gives2) {
-    char *bc = tf_compile("$muldiv(2,3,4)");
+TEST_F (TitleFormattingTests, test_MulDiv2and3and4_Gives2) {
+    char *bc = tf_compile ("$muldiv(2,3,4)");
     ctx.it = NULL;
     tf_eval (&ctx, bc, buffer, 1000);
     tf_free (bc);
-    EXPECT_TRUE(!strcmp ("2", buffer));
+    EXPECT_TRUE (!strcmp ("2", buffer));
 }
 
-TEST_F(TitleFormattingTests, test_Rand_GivesANumber) {
-    char *bc = tf_compile("$rand()");
+TEST_F (TitleFormattingTests, test_Rand_GivesANumber) {
+    char *bc = tf_compile ("$rand()");
     ctx.it = NULL;
     tf_eval (&ctx, bc, buffer, 1000);
     tf_free (bc);
     int num_digits = 0;
     for (int i = 0; buffer[i]; i++) {
-        if (isdigit(buffer[i])) {
+        if (isdigit (buffer[i])) {
             num_digits++;
         }
     }
-    EXPECT_TRUE(num_digits == strlen (buffer));
+    EXPECT_TRUE (num_digits == strlen (buffer));
 }
 
-TEST_F(TitleFormattingTests, test_RandWithArgs_GivesEmpty) {
-    char *bc = tf_compile("$rand(1)");
+TEST_F (TitleFormattingTests, test_RandWithArgs_GivesEmpty) {
+    char *bc = tf_compile ("$rand(1)");
     ctx.it = NULL;
     tf_eval (&ctx, bc, buffer, 1000);
     tf_free (bc);
     int num_digits = 0;
     for (int i = 0; buffer[i]; i++) {
-        if (isdigit(buffer[i])) {
+        if (isdigit (buffer[i])) {
             num_digits++;
         }
     }
-    EXPECT_TRUE(!strcmp (buffer, ""));
+    EXPECT_TRUE (!strcmp (buffer, ""));
 }
 
-TEST_F(TitleFormattingTests, test_SubWithoutArgs_GivesEmpty) {
-    char *bc = tf_compile("$sub()");
+TEST_F (TitleFormattingTests, test_SubWithoutArgs_GivesEmpty) {
+    char *bc = tf_compile ("$sub()");
     ctx.it = NULL;
     tf_eval (&ctx, bc, buffer, 1000);
     tf_free (bc);
     int num_digits = 0;
     for (int i = 0; buffer[i]; i++) {
-        if (isdigit(buffer[i])) {
+        if (isdigit (buffer[i])) {
             num_digits++;
         }
     }
-    EXPECT_TRUE(!strcmp (buffer, ""));
+    EXPECT_TRUE (!strcmp (buffer, ""));
 }
 
-TEST_F(TitleFormattingTests, test_SubWith1Arg_GivesEmpty) {
-    char *bc = tf_compile("$sub(2)");
+TEST_F (TitleFormattingTests, test_SubWith1Arg_GivesEmpty) {
+    char *bc = tf_compile ("$sub(2)");
     ctx.it = NULL;
     tf_eval (&ctx, bc, buffer, 1000);
     tf_free (bc);
     int num_digits = 0;
     for (int i = 0; buffer[i]; i++) {
-        if (isdigit(buffer[i])) {
+        if (isdigit (buffer[i])) {
             num_digits++;
         }
     }
-    EXPECT_TRUE(!strcmp (buffer, ""));
+    EXPECT_TRUE (!strcmp (buffer, ""));
 }
 
-TEST_F(TitleFormattingTests, test_SubWith3and2_Gives1) {
-    char *bc = tf_compile("$sub(3,2)");
+TEST_F (TitleFormattingTests, test_SubWith3and2_Gives1) {
+    char *bc = tf_compile ("$sub(3,2)");
     ctx.it = NULL;
     tf_eval (&ctx, bc, buffer, 1000);
     tf_free (bc);
     int num_digits = 0;
     for (int i = 0; buffer[i]; i++) {
-        if (isdigit(buffer[i])) {
+        if (isdigit (buffer[i])) {
             num_digits++;
         }
     }
-    EXPECT_TRUE(!strcmp (buffer, "1"));
+    EXPECT_TRUE (!strcmp (buffer, "1"));
 }
 
-TEST_F(TitleFormattingTests, test_SubWith10and5and2_Gives3) {
-    char *bc = tf_compile("$sub(10,5,2)");
+TEST_F (TitleFormattingTests, test_SubWith10and5and2_Gives3) {
+    char *bc = tf_compile ("$sub(10,5,2)");
     ctx.it = NULL;
     tf_eval (&ctx, bc, buffer, 1000);
     tf_free (bc);
     int num_digits = 0;
     for (int i = 0; buffer[i]; i++) {
-        if (isdigit(buffer[i])) {
+        if (isdigit (buffer[i])) {
             num_digits++;
         }
     }
-    EXPECT_TRUE(!strcmp (buffer, "3"));
+    EXPECT_TRUE (!strcmp (buffer, "3"));
 }
 
-TEST_F(TitleFormattingTests, test_ChannelsFor3ChTrack_Gives3) {
+TEST_F (TitleFormattingTests, test_ChannelsFor3ChTrack_Gives3) {
     pl_replace_meta (it, ":CHANNELS", "3");
-    char *bc = tf_compile("%channels%");
+    char *bc = tf_compile ("%channels%");
     tf_eval (&ctx, bc, buffer, 1000);
     tf_free (bc);
-    EXPECT_TRUE(!strcmp (buffer, "3"));
+    EXPECT_TRUE (!strcmp (buffer, "3"));
 }
 
-TEST_F(TitleFormattingTests, test_ChannelsFuncForMonoTrack_GivesMono) {
+TEST_F (TitleFormattingTests, test_ChannelsFuncForMonoTrack_GivesMono) {
     pl_replace_meta (it, ":CHANNELS", "1");
-    char *bc = tf_compile("$channels()");
+    char *bc = tf_compile ("$channels()");
     tf_eval (&ctx, bc, buffer, 1000);
     tf_free (bc);
-    EXPECT_TRUE(!strcmp (buffer, "mono"));
+    EXPECT_TRUE (!strcmp (buffer, "mono"));
 }
 
-TEST_F(TitleFormattingTests, test_ChannelsFuncForUnsetChannels_GivesStereo) {
-    char *bc = tf_compile("$channels()");
+TEST_F (TitleFormattingTests, test_ChannelsFuncForUnsetChannels_GivesStereo) {
+    char *bc = tf_compile ("$channels()");
     tf_eval (&ctx, bc, buffer, 1000);
     tf_free (bc);
-    EXPECT_TRUE(!strcmp (buffer, "stereo"));
+    EXPECT_TRUE (!strcmp (buffer, "stereo"));
 }
 
-TEST_F(TitleFormattingTests, test_AndTrueArgsWithElse_ReturnsTrue) {
+TEST_F (TitleFormattingTests, test_AndTrueArgsWithElse_ReturnsTrue) {
     pl_replace_meta (it, "artist", "artist");
     pl_replace_meta (it, "album", "album");
 
-    char *bc = tf_compile("$if($and(%artist%,%album%),true,false)");
+    char *bc = tf_compile ("$if($and(%artist%,%album%),true,false)");
     tf_eval (&ctx, bc, buffer, 1000);
     tf_free (bc);
-    EXPECT_TRUE(!strcmp (buffer, "true"));
+    EXPECT_TRUE (!strcmp (buffer, "true"));
 }
 
-TEST_F(TitleFormattingTests, test_AndTrueArgs_ReturnsTrue) {
+TEST_F (TitleFormattingTests, test_AndTrueArgs_ReturnsTrue) {
     pl_replace_meta (it, "artist", "artist");
     pl_replace_meta (it, "album", "album");
 
-    char *bc = tf_compile("$if($and(%artist%,%album%),true)");
+    char *bc = tf_compile ("$if($and(%artist%,%album%),true)");
     tf_eval (&ctx, bc, buffer, 1000);
     tf_free (bc);
-    EXPECT_TRUE(!strcmp (buffer, "true"));
+    EXPECT_TRUE (!strcmp (buffer, "true"));
 }
 
-TEST_F(TitleFormattingTests, test_AndTrueArgs_ReturnsArtistAlbum) {
+TEST_F (TitleFormattingTests, test_AndTrueArgs_ReturnsArtistAlbum) {
     pl_replace_meta (it, "artist", "artist");
     pl_replace_meta (it, "album", "album");
 
-    char *bc = tf_compile("$if($and(%artist%,%album%),%artist% - %album%)");
+    char *bc = tf_compile ("$if($and(%artist%,%album%),%artist% - %album%)");
     tf_eval (&ctx, bc, buffer, 1000);
     tf_free (bc);
-    EXPECT_TRUE(!strcmp (buffer, "artist - album"));
+    EXPECT_TRUE (!strcmp (buffer, "artist - album"));
 }
 
-TEST_F(TitleFormattingTests, test_AndTrueAndFalseArgs_ReturnsFalse) {
+TEST_F (TitleFormattingTests, test_AndTrueAndFalseArgs_ReturnsFalse) {
     pl_replace_meta (it, "artist", "artist");
 
-    char *bc = tf_compile("$if($and(%artist%,%album%),true,false)");
+    char *bc = tf_compile ("$if($and(%artist%,%album%),true,false)");
     tf_eval (&ctx, bc, buffer, 1000);
     tf_free (bc);
-    EXPECT_TRUE(!strcmp (buffer, "false"));
+    EXPECT_TRUE (!strcmp (buffer, "false"));
 }
 
-TEST_F(TitleFormattingTests, test_AndFalseArgs_ReturnsFalse) {
-    char *bc = tf_compile("$if($and(%artist%,%album%),true,false)");
+TEST_F (TitleFormattingTests, test_AndFalseArgs_ReturnsFalse) {
+    char *bc = tf_compile ("$if($and(%artist%,%album%),true,false)");
     tf_eval (&ctx, bc, buffer, 1000);
     tf_free (bc);
-    EXPECT_TRUE(!strcmp (buffer, "false"));
+    EXPECT_TRUE (!strcmp (buffer, "false"));
 }
 
-TEST_F(TitleFormattingTests, test_OrTrueAndFalseArgs_ReturnsTrue) {
+TEST_F (TitleFormattingTests, test_OrTrueAndFalseArgs_ReturnsTrue) {
     pl_replace_meta (it, "artist", "artist");
 
-    char *bc = tf_compile("$if($or(%artist%,%album%),true,false)");
+    char *bc = tf_compile ("$if($or(%artist%,%album%),true,false)");
     tf_eval (&ctx, bc, buffer, 1000);
     tf_free (bc);
-    EXPECT_TRUE(!strcmp (buffer, "true"));
+    EXPECT_TRUE (!strcmp (buffer, "true"));
 }
 
-TEST_F(TitleFormattingTests, test_OrTrueArgs_ReturnsTrue) {
-    pl_replace_meta (it, "artist", "artist");
-    pl_replace_meta (it, "album", "album");
-
-    char *bc = tf_compile("$if($or(%artist%,%album%),true,false)");
-    tf_eval (&ctx, bc, buffer, 1000);
-    tf_free (bc);
-    EXPECT_TRUE(!strcmp (buffer, "true"));
-}
-
-TEST_F(TitleFormattingTests, test_OrFalseArgs_ReturnsFalse) {
-    char *bc = tf_compile("$if($or(%artist%,%album%),true,false)");
-    tf_eval (&ctx, bc, buffer, 1000);
-    tf_free (bc);
-    EXPECT_TRUE(!strcmp (buffer, "false"));
-}
-
-TEST_F(TitleFormattingTests, test_NotTrueArg_ReturnsFalse) {
-    pl_replace_meta (it, "artist", "artist");
-    char *bc = tf_compile("$if($not(%artist%),true,false)");
-    tf_eval (&ctx, bc, buffer, 1000);
-    tf_free (bc);
-    EXPECT_TRUE(!strcmp (buffer, "false"));
-}
-
-TEST_F(TitleFormattingTests, test_NotFalseArg_ReturnsTrue) {
-    char *bc = tf_compile("$if($not(%artist%),true,false)");
-    tf_eval (&ctx, bc, buffer, 1000);
-    tf_free (bc);
-    EXPECT_TRUE(!strcmp (buffer, "true"));
-}
-
-TEST_F(TitleFormattingTests, test_XorTrueAndTrue_ReturnsFalse) {
+TEST_F (TitleFormattingTests, test_OrTrueArgs_ReturnsTrue) {
     pl_replace_meta (it, "artist", "artist");
     pl_replace_meta (it, "album", "album");
-    char *bc = tf_compile("$if($xor(%artist%,%album%),true,false)");
+
+    char *bc = tf_compile ("$if($or(%artist%,%album%),true,false)");
     tf_eval (&ctx, bc, buffer, 1000);
     tf_free (bc);
-    EXPECT_TRUE(!strcmp (buffer, "false"));
+    EXPECT_TRUE (!strcmp (buffer, "true"));
 }
 
-TEST_F(TitleFormattingTests, test_XorTrueAndFalse_ReturnsTrue) {
+TEST_F (TitleFormattingTests, test_OrFalseArgs_ReturnsFalse) {
+    char *bc = tf_compile ("$if($or(%artist%,%album%),true,false)");
+    tf_eval (&ctx, bc, buffer, 1000);
+    tf_free (bc);
+    EXPECT_TRUE (!strcmp (buffer, "false"));
+}
+
+TEST_F (TitleFormattingTests, test_NotTrueArg_ReturnsFalse) {
     pl_replace_meta (it, "artist", "artist");
-    char *bc = tf_compile("$if($xor(%artist%,%album%),true,false)");
+    char *bc = tf_compile ("$if($not(%artist%),true,false)");
     tf_eval (&ctx, bc, buffer, 1000);
     tf_free (bc);
-    EXPECT_TRUE(!strcmp (buffer, "true"));
+    EXPECT_TRUE (!strcmp (buffer, "false"));
 }
 
-TEST_F(TitleFormattingTests, test_XorFalseTrueFalse_ReturnsTrue) {
+TEST_F (TitleFormattingTests, test_NotFalseArg_ReturnsTrue) {
+    char *bc = tf_compile ("$if($not(%artist%),true,false)");
+    tf_eval (&ctx, bc, buffer, 1000);
+    tf_free (bc);
+    EXPECT_TRUE (!strcmp (buffer, "true"));
+}
+
+TEST_F (TitleFormattingTests, test_XorTrueAndTrue_ReturnsFalse) {
     pl_replace_meta (it, "artist", "artist");
-    char *bc = tf_compile("$if($xor(%album%,%artist%,%album%),true,false)");
+    pl_replace_meta (it, "album", "album");
+    char *bc = tf_compile ("$if($xor(%artist%,%album%),true,false)");
     tf_eval (&ctx, bc, buffer, 1000);
     tf_free (bc);
-    EXPECT_TRUE(!strcmp (buffer, "true"));
+    EXPECT_TRUE (!strcmp (buffer, "false"));
 }
 
-TEST_F(TitleFormattingTests, test_PlayingColumnWithEmptyFormat_GivesQueueIndexes) {
+TEST_F (TitleFormattingTests, test_XorTrueAndFalse_ReturnsTrue) {
+    pl_replace_meta (it, "artist", "artist");
+    char *bc = tf_compile ("$if($xor(%artist%,%album%),true,false)");
+    tf_eval (&ctx, bc, buffer, 1000);
+    tf_free (bc);
+    EXPECT_TRUE (!strcmp (buffer, "true"));
+}
+
+TEST_F (TitleFormattingTests, test_XorFalseTrueFalse_ReturnsTrue) {
+    pl_replace_meta (it, "artist", "artist");
+    char *bc = tf_compile ("$if($xor(%album%,%artist%,%album%),true,false)");
+    tf_eval (&ctx, bc, buffer, 1000);
+    tf_free (bc);
+    EXPECT_TRUE (!strcmp (buffer, "true"));
+}
+
+TEST_F (TitleFormattingTests, test_PlayingColumnWithEmptyFormat_GivesQueueIndexes) {
     playqueue_push (it);
     ctx.id = DB_COLUMN_PLAYING;
     ctx.flags |= DDB_TF_CONTEXT_HAS_ID;
     tf_eval (&ctx, NULL, buffer, 1000);
-    EXPECT_TRUE(!strcmp (buffer, "(1)"));
+    EXPECT_TRUE (!strcmp (buffer, "(1)"));
     playqueue_pop ();
 }
 
-TEST_F(TitleFormattingTests, test_LengthSamplesOf100Start300End_Returns200) {
+TEST_F (TitleFormattingTests, test_LengthSamplesOf100Start300End_Returns200) {
     pl_item_set_startsample (it, 100);
     pl_item_set_endsample (it, 300);
-    char *bc = tf_compile("%length_samples%");
+    char *bc = tf_compile ("%length_samples%");
     tf_eval (&ctx, bc, buffer, 1000);
-    EXPECT_TRUE(!strcmp (buffer, "200"));
+    EXPECT_TRUE (!strcmp (buffer, "200"));
 }
 
-TEST_F(TitleFormattingTests, test_AbbrTestString_ReturnsAbbreviatedString) {
+TEST_F (TitleFormattingTests, test_AbbrTestString_ReturnsAbbreviatedString) {
     pl_item_set_startsample (it, 100);
     pl_item_set_endsample (it, 300);
-    char *bc = tf_compile("$abbr('This is a Long Title (12-inch version) [needs tags]')");
+    char *bc = tf_compile ("$abbr('This is a Long Title (12-inch version) [needs tags]')");
     tf_eval (&ctx, bc, buffer, 1000);
-    EXPECT_TRUE(!strcmp (buffer, "TiaLT1v[needst"));
+    EXPECT_TRUE (!strcmp (buffer, "TiaLT1v[needst"));
 }
 
-TEST_F(TitleFormattingTests, test_AbbrTestUnicodeString_ReturnsAbbreviatedString) {
+TEST_F (TitleFormattingTests, test_AbbrTestUnicodeString_ReturnsAbbreviatedString) {
     pl_item_set_startsample (it, 100);
     pl_item_set_endsample (it, 300);
-    char *bc = tf_compile("$abbr('This ɀHİJ a русский Title (12-inch version) [needs tags]')");
+    char *bc = tf_compile ("$abbr('This ɀHİJ a русский Title (12-inch version) [needs tags]')");
     tf_eval (&ctx, bc, buffer, 1000);
-    EXPECT_TRUE(!strcmp (buffer, "TɀaрT1v[needst"));
+    EXPECT_TRUE (!strcmp (buffer, "TɀaрT1v[needst"));
 }
 
-TEST_F(TitleFormattingTests, test_AnsiTestString_ReturnsTheSameString) {
-    char *bc = tf_compile("$ansi(ABCDабвг)");
+TEST_F (TitleFormattingTests, test_AnsiTestString_ReturnsTheSameString) {
+    char *bc = tf_compile ("$ansi(ABCDабвг)");
     tf_eval (&ctx, bc, buffer, 1000);
-    EXPECT_TRUE(!strcmp (buffer, "ABCDабвг"));
+    EXPECT_TRUE (!strcmp (buffer, "ABCDабвг"));
 }
 
-TEST_F(TitleFormattingTests, test_AsciiTestString_ReturnsAsciiSameStringWithInvalidCharsStripped) {
-    char *bc = tf_compile("$ascii(олдABCDабвг)");
+TEST_F (TitleFormattingTests, test_AsciiTestString_ReturnsAsciiSameStringWithInvalidCharsStripped) {
+    char *bc = tf_compile ("$ascii(олдABCDабвг)");
     tf_eval (&ctx, bc, buffer, 1000);
-    EXPECT_TRUE(!strcmp (buffer, "ABCD"));
+    EXPECT_TRUE (!strcmp (buffer, "ABCD"));
 }
 
-
-TEST_F(TitleFormattingTests, test_CapsTestAsciiString_ReturnsCapitalizeEachWordString) {
-    char *bc = tf_compile("$caps(MY TEST STRING)");
+TEST_F (TitleFormattingTests, test_CapsTestAsciiString_ReturnsCapitalizeEachWordString) {
+    char *bc = tf_compile ("$caps(MY TEST STRING)");
     tf_eval (&ctx, bc, buffer, 1000);
-    EXPECT_TRUE(!strcmp (buffer, "My Test String"));
+    EXPECT_TRUE (!strcmp (buffer, "My Test String"));
 }
 
-
-TEST_F(TitleFormattingTests, test_CapsTestAsciiRandomizedString_ReturnsCapitalizeEachWordString) {
-    char *bc = tf_compile("$caps(MY TesT STriNG)");
+TEST_F (TitleFormattingTests, test_CapsTestAsciiRandomizedString_ReturnsCapitalizeEachWordString) {
+    char *bc = tf_compile ("$caps(MY TesT STriNG)");
     tf_eval (&ctx, bc, buffer, 1000);
-    EXPECT_TRUE(!strcmp (buffer, "My Test String"));
+    EXPECT_TRUE (!strcmp (buffer, "My Test String"));
 }
 
-TEST_F(TitleFormattingTests, test_CapsTestUnicodeRandomizedString_ReturnsCapitalizeEachWordString) {
-    char *bc = tf_compile("$caps(AsciiAlbumName РуССкоЕНазВАние ΠΥΘΑΓΌΡΑΣ)");
+TEST_F (TitleFormattingTests, test_CapsTestUnicodeRandomizedString_ReturnsCapitalizeEachWordString) {
+    char *bc = tf_compile ("$caps(AsciiAlbumName РуССкоЕНазВАние ΠΥΘΑΓΌΡΑΣ)");
     tf_eval (&ctx, bc, buffer, 1000);
-    EXPECT_TRUE(!strcmp (buffer, "Asciialbumname Русскоеназвание Πυθαγόρασ"));
+    EXPECT_TRUE (!strcmp (buffer, "Asciialbumname Русскоеназвание Πυθαγόρασ"));
 }
 
-TEST_F(TitleFormattingTests, test_CapsTestUnicodeStringWithNonMatchinByteLengthsForLowerUpperCaseChars_ReturnsCapitalizeEachWordString) {
-    char *bc = tf_compile("$caps(ɑBCD ɀHİJ)");
+TEST_F (
+    TitleFormattingTests,
+    test_CapsTestUnicodeStringWithNonMatchinByteLengthsForLowerUpperCaseChars_ReturnsCapitalizeEachWordString) {
+    char *bc = tf_compile ("$caps(ɑBCD ɀHİJ)");
     tf_eval (&ctx, bc, buffer, 1000);
-    EXPECT_TRUE(!strcmp (buffer, "Ɑbcd Ɀhij"));
+    EXPECT_TRUE (!strcmp (buffer, "Ɑbcd Ɀhij"));
 }
 
-TEST_F(TitleFormattingTests, test_Caps2TestUnicodeRandomizedString_ReturnsCapitalizeEachWordString) {
-    char *bc = tf_compile("$caps2(ɑBCD ɀHİJ)");
+TEST_F (TitleFormattingTests, test_Caps2TestUnicodeRandomizedString_ReturnsCapitalizeEachWordString) {
+    char *bc = tf_compile ("$caps2(ɑBCD ɀHİJ)");
     tf_eval (&ctx, bc, buffer, 1000);
-    EXPECT_TRUE(!strcmp (buffer, "ⱭBCD ⱿHİJ"));
+    EXPECT_TRUE (!strcmp (buffer, "ⱭBCD ⱿHİJ"));
 }
 
-TEST_F(TitleFormattingTests, test_Char1055And88And38899_ReturnsCorrespondingUTF8Chars) {
-    char *bc = tf_compile("$char(1055)$char(88)$char(38899)");
+TEST_F (TitleFormattingTests, test_Char1055And88And38899_ReturnsCorrespondingUTF8Chars) {
+    char *bc = tf_compile ("$char(1055)$char(88)$char(38899)");
     tf_eval (&ctx, bc, buffer, 1000);
-    EXPECT_TRUE(!strcmp (buffer, "ПX音"));
+    EXPECT_TRUE (!strcmp (buffer, "ПX音"));
 }
 
-TEST_F(TitleFormattingTests, test_Crc32Of123456789_Returns3421780262) {
-    char *bc = tf_compile("$crc32(123456789)");
+TEST_F (TitleFormattingTests, test_Crc32Of123456789_Returns3421780262) {
+    char *bc = tf_compile ("$crc32(123456789)");
     tf_eval (&ctx, bc, buffer, 1000);
-    EXPECT_TRUE(!strcmp (buffer, "3421780262"));
+    EXPECT_TRUE (!strcmp (buffer, "3421780262"));
 }
 
-TEST_F(TitleFormattingTests, test_CrLf_InsertsLinebreak) {
+TEST_F (TitleFormattingTests, test_CrLf_InsertsLinebreak) {
     ctx.flags |= DDB_TF_CONTEXT_MULTILINE;
-    char *bc = tf_compile("$crlf()");
+    char *bc = tf_compile ("$crlf()");
     tf_eval (&ctx, bc, buffer, 1000);
-    EXPECT_TRUE(!strcmp (buffer, "\n"));
+    EXPECT_TRUE (!strcmp (buffer, "\n"));
 }
 
-TEST_F(TitleFormattingTests, test_DirectoryOnFilePath_ReturnsDirectory) {
-    char *bc = tf_compile("$directory(/directory/file.path)");
+TEST_F (TitleFormattingTests, test_DirectoryOnFilePath_ReturnsDirectory) {
+    char *bc = tf_compile ("$directory(/directory/file.path)");
     tf_eval (&ctx, bc, buffer, 1000);
-    EXPECT_TRUE(!strcmp (buffer, "directory"));
+    EXPECT_TRUE (!strcmp (buffer, "directory"));
 }
 
-TEST_F(TitleFormattingTests, test_DirectoryOnFilePathWithMultipleSlashes_ReturnsDirectory) {
-    char *bc = tf_compile("$directory(/directory///file.path)");
+TEST_F (TitleFormattingTests, test_DirectoryOnFilePathWithMultipleSlashes_ReturnsDirectory) {
+    char *bc = tf_compile ("$directory(/directory///file.path)");
     tf_eval (&ctx, bc, buffer, 1000);
-    EXPECT_TRUE(!strcmp (buffer, "directory"));
+    EXPECT_TRUE (!strcmp (buffer, "directory"));
 }
 
-TEST_F(TitleFormattingTests, test_DirectoryOnFilePathWithoutFrontSlash_ReturnsDirectory) {
-    char *bc = tf_compile("$directory(directory/file.path)");
+TEST_F (TitleFormattingTests, test_DirectoryOnFilePathWithoutFrontSlash_ReturnsDirectory) {
+    char *bc = tf_compile ("$directory(directory/file.path)");
     tf_eval (&ctx, bc, buffer, 1000);
-    EXPECT_TRUE(!strcmp (buffer, "directory"));
+    EXPECT_TRUE (!strcmp (buffer, "directory"));
 }
 
-TEST_F(TitleFormattingTests, test_DirectoryOnFilePathWithMoreNestedness_ReturnsDirectory) {
-    char *bc = tf_compile("$directory(/path/directory/file.path)");
+TEST_F (TitleFormattingTests, test_DirectoryOnFilePathWithMoreNestedness_ReturnsDirectory) {
+    char *bc = tf_compile ("$directory(/path/directory/file.path)");
     tf_eval (&ctx, bc, buffer, 1000);
-    EXPECT_TRUE(!strcmp (buffer, "directory"));
+    EXPECT_TRUE (!strcmp (buffer, "directory"));
 }
 
-TEST_F(TitleFormattingTests, test_DirectoryOnFilePathWithoutDirectory_ReturnsEmpty) {
-    char *bc = tf_compile("$directory(file.path)");
+TEST_F (TitleFormattingTests, test_DirectoryOnFilePathWithoutDirectory_ReturnsEmpty) {
+    char *bc = tf_compile ("$directory(file.path)");
     tf_eval (&ctx, bc, buffer, 1000);
-    EXPECT_TRUE(!strcmp (buffer, ""));
+    EXPECT_TRUE (!strcmp (buffer, ""));
 }
 
-TEST_F(TitleFormattingTests, test_DirectoryOnFilePathAtRoot_ReturnsEmpty) {
-    char *bc = tf_compile("$directory(/file.path)");
+TEST_F (TitleFormattingTests, test_DirectoryOnFilePathAtRoot_ReturnsEmpty) {
+    char *bc = tf_compile ("$directory(/file.path)");
     tf_eval (&ctx, bc, buffer, 1000);
-    EXPECT_TRUE(!strcmp (buffer, ""));
+    EXPECT_TRUE (!strcmp (buffer, ""));
 }
 
-TEST_F(TitleFormattingTests, test_DirectoryOnEmptyAtRoot_ReturnsEmpty) {
-    char *bc = tf_compile("$directory(/)");
+TEST_F (TitleFormattingTests, test_DirectoryOnEmptyAtRoot_ReturnsEmpty) {
+    char *bc = tf_compile ("$directory(/)");
     tf_eval (&ctx, bc, buffer, 1000);
-    EXPECT_TRUE(!strcmp (buffer, ""));
+    EXPECT_TRUE (!strcmp (buffer, ""));
 }
 
-TEST_F(TitleFormattingTests, test_DirectoryOnEmpty_ReturnsEmpty) {
-    char *bc = tf_compile("$directory()");
-    tf_eval (&ctx, bc, buffer, 1000);
-    tf_free (bc);
-    EXPECT_TRUE(!strcmp (buffer, ""));
-}
-
-TEST_F(TitleFormattingTests, test_DirectoryOnFilePathLevel0_ReturnsEmpty) {
-    char *bc = tf_compile("$directory(/directory/file.path,0)");
+TEST_F (TitleFormattingTests, test_DirectoryOnEmpty_ReturnsEmpty) {
+    char *bc = tf_compile ("$directory()");
     tf_eval (&ctx, bc, buffer, 1000);
     tf_free (bc);
-    EXPECT_TRUE(!strcmp (buffer, ""));
+    EXPECT_TRUE (!strcmp (buffer, ""));
 }
 
-TEST_F(TitleFormattingTests, test_DirectoryOnFilePathLevel1_ReturnsDirectory1) {
-    char *bc = tf_compile("$directory(/directory3/directory2/directory1/file.path,1)");
+TEST_F (TitleFormattingTests, test_DirectoryOnFilePathLevel0_ReturnsEmpty) {
+    char *bc = tf_compile ("$directory(/directory/file.path,0)");
     tf_eval (&ctx, bc, buffer, 1000);
     tf_free (bc);
-    EXPECT_TRUE(!strcmp (buffer, "directory1"));
+    EXPECT_TRUE (!strcmp (buffer, ""));
 }
 
-TEST_F(TitleFormattingTests, test_DirectoryOnFilePathLevel2_ReturnsDirectory2) {
-    char *bc = tf_compile("$directory(/directory3/directory2/directory1/file.path,2)");
+TEST_F (TitleFormattingTests, test_DirectoryOnFilePathLevel1_ReturnsDirectory1) {
+    char *bc = tf_compile ("$directory(/directory3/directory2/directory1/file.path,1)");
     tf_eval (&ctx, bc, buffer, 1000);
     tf_free (bc);
-    EXPECT_TRUE(!strcmp (buffer, "directory2"));
+    EXPECT_TRUE (!strcmp (buffer, "directory1"));
 }
 
-TEST_F(TitleFormattingTests, test_DirectoryOnFilePathLevel4_ReturnsEmpty) {
-    char *bc = tf_compile("$directory(/directory3/directory2/directory/file.path,4)");
+TEST_F (TitleFormattingTests, test_DirectoryOnFilePathLevel2_ReturnsDirectory2) {
+    char *bc = tf_compile ("$directory(/directory3/directory2/directory1/file.path,2)");
     tf_eval (&ctx, bc, buffer, 1000);
     tf_free (bc);
-    EXPECT_TRUE(!strcmp (buffer, ""));
+    EXPECT_TRUE (!strcmp (buffer, "directory2"));
 }
 
-TEST_F(TitleFormattingTests, test_DirectoryOnFilePathLevel2MultipleSlashes_ReturnsDirectory2) {
-    char *bc = tf_compile("$directory(////directory3////directory2////directory////file.path,2)");
+TEST_F (TitleFormattingTests, test_DirectoryOnFilePathLevel4_ReturnsEmpty) {
+    char *bc = tf_compile ("$directory(/directory3/directory2/directory/file.path,4)");
     tf_eval (&ctx, bc, buffer, 1000);
     tf_free (bc);
-    EXPECT_TRUE(!strcmp (buffer, "directory2"));
+    EXPECT_TRUE (!strcmp (buffer, ""));
 }
 
-TEST_F(TitleFormattingTests, test_MultiLine_LineBreaksIgnored) {
-    char *bc = tf_compile("hello\nworld");
+TEST_F (TitleFormattingTests, test_DirectoryOnFilePathLevel2MultipleSlashes_ReturnsDirectory2) {
+    char *bc = tf_compile ("$directory(////directory3////directory2////directory////file.path,2)");
     tf_eval (&ctx, bc, buffer, 1000);
     tf_free (bc);
-    EXPECT_TRUE(!strcmp (buffer, "helloworld"));
+    EXPECT_TRUE (!strcmp (buffer, "directory2"));
 }
 
-TEST_F(TitleFormattingTests, test_MultiLineWithComments_LineBreaksAndCommentedLinesIgnored) {
-    char *bc = tf_compile("// this is a comment\nhello\nworld\n//another comment\nmore text");
+TEST_F (TitleFormattingTests, test_MultiLine_LineBreaksIgnored) {
+    char *bc = tf_compile ("hello\nworld");
     tf_eval (&ctx, bc, buffer, 1000);
     tf_free (bc);
-    EXPECT_TRUE(!strcmp (buffer, "helloworldmore text"));
+    EXPECT_TRUE (!strcmp (buffer, "helloworld"));
 }
 
-TEST_F(TitleFormattingTests, test_QuotedSpecialChars_TreatedLiterally) {
-    char *bc = tf_compile("'blah$blah%blah[][]'");
+TEST_F (TitleFormattingTests, test_MultiLineWithComments_LineBreaksAndCommentedLinesIgnored) {
+    char *bc = tf_compile ("// this is a comment\nhello\nworld\n//another comment\nmore text");
     tf_eval (&ctx, bc, buffer, 1000);
     tf_free (bc);
-    EXPECT_TRUE(!strcmp (buffer, "blah$blah%blah[][]"));
+    EXPECT_TRUE (!strcmp (buffer, "helloworldmore text"));
 }
 
-TEST_F(TitleFormattingTests, test_FunctionArgumentsOnMultipleLinesWithComments_LinebreaksAndCommentsIgnored) {
-    char *bc = tf_compile("$add(1,\n2,\n3,//4,\n5)");
+TEST_F (TitleFormattingTests, test_QuotedSpecialChars_TreatedLiterally) {
+    char *bc = tf_compile ("'blah$blah%blah[][]'");
     tf_eval (&ctx, bc, buffer, 1000);
     tf_free (bc);
-    EXPECT_TRUE(!strcmp (buffer, "11"));
+    EXPECT_TRUE (!strcmp (buffer, "blah$blah%blah[][]"));
 }
 
-TEST_F(TitleFormattingTests, test_DirectoryPathOnFilePath_ReturnsDirectoryPath) {
-    char *bc = tf_compile("$directory_path('/a/b/c/d.mp3')");
+TEST_F (TitleFormattingTests, test_FunctionArgumentsOnMultipleLinesWithComments_LinebreaksAndCommentsIgnored) {
+    char *bc = tf_compile ("$add(1,\n2,\n3,//4,\n5)");
     tf_eval (&ctx, bc, buffer, 1000);
     tf_free (bc);
-    EXPECT_TRUE(!strcmp (buffer, "/a/b/c"));
+    EXPECT_TRUE (!strcmp (buffer, "11"));
 }
 
-TEST_F(TitleFormattingTests, test_DirectoryPathOnPathWithoutFile_ReturnsDirectoryPath) {
-    char *bc = tf_compile("$directory_path('/a/b/c/d/')");
+TEST_F (TitleFormattingTests, test_DirectoryPathOnFilePath_ReturnsDirectoryPath) {
+    char *bc = tf_compile ("$directory_path('/a/b/c/d.mp3')");
     tf_eval (&ctx, bc, buffer, 1000);
     tf_free (bc);
-    EXPECT_TRUE(!strcmp (buffer, "/a/b/c/d"));
+    EXPECT_TRUE (!strcmp (buffer, "/a/b/c"));
 }
 
-TEST_F(TitleFormattingTests, test_ExtOnFilePath_ReturnsExt) {
-    char *bc = tf_compile("$ext('/a/b/c/d/file.mp3')");
+TEST_F (TitleFormattingTests, test_DirectoryPathOnPathWithoutFile_ReturnsDirectoryPath) {
+    char *bc = tf_compile ("$directory_path('/a/b/c/d/')");
     tf_eval (&ctx, bc, buffer, 1000);
     tf_free (bc);
-    EXPECT_TRUE(!strcmp (buffer, "mp3"));
+    EXPECT_TRUE (!strcmp (buffer, "/a/b/c/d"));
 }
 
-TEST_F(TitleFormattingTests, test_ExtOnFileWithoutExtPath_ReturnsEmpty) {
-    char *bc = tf_compile("$ext('/a/b/c/d/file')");
+TEST_F (TitleFormattingTests, test_ExtOnFilePath_ReturnsExt) {
+    char *bc = tf_compile ("$ext('/a/b/c/d/file.mp3')");
     tf_eval (&ctx, bc, buffer, 1000);
     tf_free (bc);
-    EXPECT_TRUE(!strcmp (buffer, ""));
+    EXPECT_TRUE (!strcmp (buffer, "mp3"));
 }
 
-TEST_F(TitleFormattingTests, test_ExtOnFilePathWithoutFilename_ReturnsEmpty) {
-    char *bc = tf_compile("$ext('/a/b/c/d/')");
+TEST_F (TitleFormattingTests, test_ExtOnFileWithoutExtPath_ReturnsEmpty) {
+    char *bc = tf_compile ("$ext('/a/b/c/d/file')");
     tf_eval (&ctx, bc, buffer, 1000);
     tf_free (bc);
-    EXPECT_TRUE(!strcmp (buffer, ""));
+    EXPECT_TRUE (!strcmp (buffer, ""));
 }
 
-TEST_F(TitleFormattingTests, test_ExtOnFilePathEndingWithDot_ReturnsEmpty) {
-    char *bc = tf_compile("$ext('/a/b/c/d/file.')");
+TEST_F (TitleFormattingTests, test_ExtOnFilePathWithoutFilename_ReturnsEmpty) {
+    char *bc = tf_compile ("$ext('/a/b/c/d/')");
     tf_eval (&ctx, bc, buffer, 1000);
     tf_free (bc);
-    EXPECT_TRUE(!strcmp (buffer, ""));
+    EXPECT_TRUE (!strcmp (buffer, ""));
 }
 
-TEST_F(TitleFormattingTests, test_ExtOnFilePathDotFile_ReturnsExt) {
-    char *bc = tf_compile("$ext('/a/b/c/d/.ext')");
+TEST_F (TitleFormattingTests, test_ExtOnFilePathEndingWithDot_ReturnsEmpty) {
+    char *bc = tf_compile ("$ext('/a/b/c/d/file.')");
     tf_eval (&ctx, bc, buffer, 1000);
     tf_free (bc);
-    EXPECT_TRUE(!strcmp (buffer, "ext"));
+    EXPECT_TRUE (!strcmp (buffer, ""));
 }
 
-TEST_F(TitleFormattingTests, test_ExtOnFileExtWithMultiplePeriod_ReturnsExt) {
-    char *bc = tf_compile("$ext('/a/b/c/d/file.iso.wv')");
+TEST_F (TitleFormattingTests, test_ExtOnFilePathDotFile_ReturnsExt) {
+    char *bc = tf_compile ("$ext('/a/b/c/d/.ext')");
     tf_eval (&ctx, bc, buffer, 1000);
     tf_free (bc);
-    EXPECT_TRUE(!strcmp (buffer, "wv"));
+    EXPECT_TRUE (!strcmp (buffer, "ext"));
 }
 
-TEST_F(TitleFormattingTests, test_FilenameOnFilePath_ReturnsFilename) {
-    char *bc = tf_compile("$filename('/a/b/c/d/file.mp3')");
+TEST_F (TitleFormattingTests, test_ExtOnFileExtWithMultiplePeriod_ReturnsExt) {
+    char *bc = tf_compile ("$ext('/a/b/c/d/file.iso.wv')");
     tf_eval (&ctx, bc, buffer, 1000);
     tf_free (bc);
-    EXPECT_TRUE(!strcmp (buffer, "file.mp3"));
+    EXPECT_TRUE (!strcmp (buffer, "wv"));
 }
 
-TEST_F(TitleFormattingTests, test_FilenameOnFilePathWithoutFile_ReturnsEmpty) {
-    char *bc = tf_compile("$filename('/a/b/c/d/')");
+TEST_F (TitleFormattingTests, test_FilenameOnFilePath_ReturnsFilename) {
+    char *bc = tf_compile ("$filename('/a/b/c/d/file.mp3')");
     tf_eval (&ctx, bc, buffer, 1000);
     tf_free (bc);
-    EXPECT_TRUE(!strcmp (buffer, ""));
+    EXPECT_TRUE (!strcmp (buffer, "file.mp3"));
 }
 
-TEST_F(TitleFormattingTests, test_FilenameOnFilenameWithoutPath_ReturnsFilename) {
-    char *bc = tf_compile("$filename('file.iso.wv')");
+TEST_F (TitleFormattingTests, test_FilenameOnFilePathWithoutFile_ReturnsEmpty) {
+    char *bc = tf_compile ("$filename('/a/b/c/d/')");
     tf_eval (&ctx, bc, buffer, 1000);
     tf_free (bc);
-    EXPECT_TRUE(!strcmp (buffer, "file.iso.wv"));
+    EXPECT_TRUE (!strcmp (buffer, ""));
 }
 
-TEST_F(TitleFormattingTests, test_FilenameMeta_ReturnsFilename) {
+TEST_F (TitleFormattingTests, test_FilenameOnFilenameWithoutPath_ReturnsFilename) {
+    char *bc = tf_compile ("$filename('file.iso.wv')");
+    tf_eval (&ctx, bc, buffer, 1000);
+    tf_free (bc);
+    EXPECT_TRUE (!strcmp (buffer, "file.iso.wv"));
+}
+
+TEST_F (TitleFormattingTests, test_FilenameMeta_ReturnsFilename) {
     pl_replace_meta (it, ":URI", "/path/file.mp3");
-    char *bc = tf_compile("%filename%");
+    char *bc = tf_compile ("%filename%");
     tf_eval (&ctx, bc, buffer, 1000);
     tf_free (bc);
-    EXPECT_TRUE(!strcmp (buffer, "file"));
+    EXPECT_TRUE (!strcmp (buffer, "file"));
 }
 
-TEST_F(TitleFormattingTests, test_Date_ReturnsYearValue) {
+TEST_F (TitleFormattingTests, test_Date_ReturnsYearValue) {
     pl_replace_meta (it, "year", "1980");
-    char *bc = tf_compile("%date%");
+    char *bc = tf_compile ("%date%");
     tf_eval (&ctx, bc, buffer, 1000);
     tf_free (bc);
-    EXPECT_TRUE(!strcmp (buffer, "1980"));
+    EXPECT_TRUE (!strcmp (buffer, "1980"));
 }
 
-TEST_F(TitleFormattingTests, test_CustomField_ReturnsTheFieldValue) {
+TEST_F (TitleFormattingTests, test_CustomField_ReturnsTheFieldValue) {
     pl_replace_meta (it, "random_name", "random value");
-    char *bc = tf_compile("%random_name%");
+    char *bc = tf_compile ("%random_name%");
     tf_eval (&ctx, bc, buffer, 1000);
     tf_free (bc);
-    EXPECT_TRUE(!strcmp (buffer, "random value"));
+    EXPECT_TRUE (!strcmp (buffer, "random value"));
 }
 
-TEST_F(TitleFormattingTests, test_MultipleArtists_ReturnsArtistsSeparatedByCommas) {
+TEST_F (TitleFormattingTests, test_MultipleArtists_ReturnsArtistsSeparatedByCommas) {
     pl_append_meta (it, "artist", "Artist1");
     pl_append_meta (it, "artist", "Artist2");
-    char *bc = tf_compile("%artist%");
+    char *bc = tf_compile ("%artist%");
     tf_eval (&ctx, bc, buffer, 1000);
     tf_free (bc);
-    EXPECT_STREQ(buffer, "Artist1, Artist2");
+    EXPECT_STREQ (buffer, "Artist1, Artist2");
 }
 
-TEST_F(TitleFormattingTests, test_EmptyTitle_YieldsFilename) {
+TEST_F (TitleFormattingTests, test_EmptyTitle_YieldsFilename) {
     pl_replace_meta (it, ":URI", "/home/user/filename.mp3");
-    char *bc = tf_compile("%title%");
+    char *bc = tf_compile ("%title%");
     tf_eval (&ctx, bc, buffer, 1000);
     tf_free (bc);
-    EXPECT_STREQ(buffer, "filename");
+    EXPECT_STREQ (buffer, "filename");
 }
 
-TEST_F(TitleFormattingTests, test_DoublingPercentDollarApostrophe_OutputsSinglePercentDollarApostrophe) {
-    char *bc = tf_compile("''$$%%");
+TEST_F (TitleFormattingTests, test_DoublingPercentDollarApostrophe_OutputsSinglePercentDollarApostrophe) {
+    char *bc = tf_compile ("''$$%%");
     tf_eval (&ctx, bc, buffer, 1000);
     tf_free (bc);
-    EXPECT_STREQ(buffer, "'$%");
+    EXPECT_STREQ (buffer, "'$%");
 }
 
-TEST_F(TitleFormattingTests, test_PlaybackTime_OutputsPlaybackTime) {
+TEST_F (TitleFormattingTests, test_PlaybackTime_OutputsPlaybackTime) {
     streamer_set_playing_track (it);
-    char *bc = tf_compile("%playback_time%");
+    char *bc = tf_compile ("%playback_time%");
     tf_eval (&ctx, bc, buffer, 1000);
     tf_free (bc);
-    EXPECT_TRUE(!strcmp (buffer, "0:00"));
+    EXPECT_TRUE (!strcmp (buffer, "0:00"));
 }
 
-TEST_F(TitleFormattingTests, test_PlaybackTime_OutputsPlaybackTimeMs) {
+TEST_F (TitleFormattingTests, test_PlaybackTime_OutputsPlaybackTimeMs) {
     streamer_set_playing_track (it);
-    char *bc = tf_compile("%playback_time_ms%");
+    char *bc = tf_compile ("%playback_time_ms%");
     tf_eval (&ctx, bc, buffer, 1000);
     tf_free (bc);
-    EXPECT_TRUE(!strcmp (buffer, "0:00.000"));
+    EXPECT_TRUE (!strcmp (buffer, "0:00.000"));
 }
 
-TEST_F(TitleFormattingTests, test_NoDynamicFlag_SkipsDynamicFields) {
-    char *bc = tf_compile("header|%playback_time%|footer");
+TEST_F (TitleFormattingTests, test_NoDynamicFlag_SkipsDynamicFields) {
+    char *bc = tf_compile ("header|%playback_time%|footer");
     ctx.flags |= DDB_TF_CONTEXT_NO_DYNAMIC;
     tf_eval (&ctx, bc, buffer, 1000);
     tf_free (bc);
-    EXPECT_TRUE(!strcmp (buffer, "header||footer"));
+    EXPECT_TRUE (!strcmp (buffer, "header||footer"));
 }
 
-TEST_F(TitleFormattingTests, test_Track_Number_SingleDigit_ReturnsNonZeroPaddedTrackNumber) {
+TEST_F (TitleFormattingTests, test_Track_Number_SingleDigit_ReturnsNonZeroPaddedTrackNumber) {
     pl_replace_meta (it, "track", "5");
-    char *bc = tf_compile("%track number%");
+    char *bc = tf_compile ("%track number%");
     tf_eval (&ctx, bc, buffer, 1000);
     tf_free (bc);
-    EXPECT_TRUE(!strcmp (buffer, "5"));
+    EXPECT_TRUE (!strcmp (buffer, "5"));
 }
 
-TEST_F(TitleFormattingTests, test_Track_Number_NonNumerical_ReturnsUnmodified) {
+TEST_F (TitleFormattingTests, test_Track_Number_NonNumerical_ReturnsUnmodified) {
     pl_replace_meta (it, "track", "A01");
-    char *bc = tf_compile("%track number%");
+    char *bc = tf_compile ("%track number%");
     tf_eval (&ctx, bc, buffer, 1000);
     tf_free (bc);
-    EXPECT_TRUE(!strcmp (buffer, "A01"));
+    EXPECT_TRUE (!strcmp (buffer, "A01"));
 }
 
-TEST_F(TitleFormattingTests, test_Track_Number_PaddingZero_ReturnsUnmodified) {
+TEST_F (TitleFormattingTests, test_Track_Number_PaddingZero_ReturnsUnmodified) {
     pl_replace_meta (it, "track", "001");
-    char *bc = tf_compile("%track number%");
+    char *bc = tf_compile ("%track number%");
     tf_eval (&ctx, bc, buffer, 1000);
     tf_free (bc);
-    EXPECT_TRUE(!strcmp (buffer, "001"));
+    EXPECT_TRUE (!strcmp (buffer, "001"));
 }
 
-TEST_F(TitleFormattingTests, test_TrackNumber_SingleDigit_PaddingZeroAdded) {
+TEST_F (TitleFormattingTests, test_TrackNumber_SingleDigit_PaddingZeroAdded) {
     pl_replace_meta (it, "track", "1");
-    char *bc = tf_compile("%tracknumber%");
+    char *bc = tf_compile ("%tracknumber%");
     tf_eval (&ctx, bc, buffer, 1000);
     tf_free (bc);
-    EXPECT_TRUE(!strcmp (buffer, "01"));
+    EXPECT_TRUE (!strcmp (buffer, "01"));
 }
 
-TEST_F(TitleFormattingTests, test_TrackNumber_PaddingZero_ReturnsUnmodified) {
+TEST_F (TitleFormattingTests, test_TrackNumber_PaddingZero_ReturnsUnmodified) {
     pl_replace_meta (it, "track", "001");
-    char *bc = tf_compile("%tracknumber%");
+    char *bc = tf_compile ("%tracknumber%");
     tf_eval (&ctx, bc, buffer, 1000);
     tf_free (bc);
-    EXPECT_TRUE(!strcmp (buffer, "001"));
+    EXPECT_TRUE (!strcmp (buffer, "001"));
 }
 
-TEST_F(TitleFormattingTests, test_Length_DoesntGetPaddedWithSpace) {
-    plt_set_item_duration(NULL, it, 130);
-    char *bc = tf_compile("%length%");
+TEST_F (TitleFormattingTests, test_Length_DoesntGetPaddedWithSpace) {
+    plt_set_item_duration (NULL, it, 130);
+    char *bc = tf_compile ("%length%");
     tf_eval (&ctx, bc, buffer, 1000);
     tf_free (bc);
-    EXPECT_TRUE(!strcmp (buffer, "2:10"));
+    EXPECT_TRUE (!strcmp (buffer, "2:10"));
 }
 
-TEST_F(TitleFormattingTests, test_ImportLegacyDirectAccess_ProducesExpectedData) {
+TEST_F (TitleFormattingTests, test_ImportLegacyDirectAccess_ProducesExpectedData) {
     const char *old = "%@disc@";
     char buf[100];
     tf_import_legacy (old, buf, sizeof (buf));
-    EXPECT_TRUE(!strcmp (buf, "%disc%"));
+    EXPECT_TRUE (!strcmp (buf, "%disc%"));
 }
 
-TEST_F(TitleFormattingTests, test_NestedSquareBracketsWithUndefVarsAndLiteralData_ReturnEmpty) {
+TEST_F (TitleFormattingTests, test_NestedSquareBracketsWithUndefVarsAndLiteralData_ReturnEmpty) {
     pl_replace_meta (it, "title", "title");
-    char *bc = tf_compile("[[%discnumber%]a] normaltext [%title%] [[%title%]a]");
+    char *bc = tf_compile ("[[%discnumber%]a] normaltext [%title%] [[%title%]a]");
     tf_eval (&ctx, bc, buffer, 1000);
     tf_free (bc);
-    EXPECT_TRUE(!strcmp (buffer, " normaltext title titlea"));
+    EXPECT_TRUE (!strcmp (buffer, " normaltext title titlea"));
 }
 
-TEST_F(TitleFormattingTests, test_FixEof_PutsIndicatorAfterLineBreak) {
+TEST_F (TitleFormattingTests, test_FixEof_PutsIndicatorAfterLineBreak) {
     pl_replace_meta (it, "title", "line1\nline2\n");
-    char *bc = tf_compile("$fix_eol(%title%)");
+    char *bc = tf_compile ("$fix_eol(%title%)");
     tf_eval (&ctx, bc, buffer, 1000);
     tf_free (bc);
-    EXPECT_TRUE(!strcmp (buffer, "line1 (...)"));
+    EXPECT_TRUE (!strcmp (buffer, "line1 (...)"));
 }
 
-TEST_F(TitleFormattingTests, test_FixEofTwoArgs_PutsCustomIndicatorAfterLineBreak) {
+TEST_F (TitleFormattingTests, test_FixEofTwoArgs_PutsCustomIndicatorAfterLineBreak) {
     pl_replace_meta (it, "title", "line1\nline2\n");
-    char *bc = tf_compile("$fix_eol(%title%, _..._)");
+    char *bc = tf_compile ("$fix_eol(%title%, _..._)");
     tf_eval (&ctx, bc, buffer, 1000);
     tf_free (bc);
-    EXPECT_TRUE(!strcmp (buffer, "line1 _..._"));
+    EXPECT_TRUE (!strcmp (buffer, "line1 _..._"));
 }
 
-TEST_F(TitleFormattingTests, test_FixEofTwoArgsWithSmallBuffer_DoesntOverflowOffByOne) {
+TEST_F (TitleFormattingTests, test_FixEofTwoArgsWithSmallBuffer_DoesntOverflowOffByOne) {
     pl_replace_meta (it, "title", "hello\n");
-    char *bc = tf_compile("$fix_eol(%title%, _..._)");
+    char *bc = tf_compile ("$fix_eol(%title%, _..._)");
     tf_eval (&ctx, bc, buffer, 12);
-    EXPECT_TRUE(!strcmp (buffer, "hello _..._"));
+    EXPECT_TRUE (!strcmp (buffer, "hello _..._"));
     tf_eval (&ctx, bc, buffer, 11);
     tf_free (bc);
-    EXPECT_TRUE(!strcmp (buffer, ""));
+    EXPECT_TRUE (!strcmp (buffer, ""));
 }
 
-TEST_F(TitleFormattingTests, test_Hex_ReturnsHexConvertedNumber) {
-    char *bc = tf_compile("$hex(11259375)");
+TEST_F (TitleFormattingTests, test_Hex_ReturnsHexConvertedNumber) {
+    char *bc = tf_compile ("$hex(11259375)");
     tf_eval (&ctx, bc, buffer, 1000);
     tf_free (bc);
-    EXPECT_TRUE(!strcmp (buffer, "abcdef"));
+    EXPECT_TRUE (!strcmp (buffer, "abcdef"));
 }
 
-TEST_F(TitleFormattingTests, test_HexPadded_ReturnsHexConvertedNumberWithPadding) {
-    char *bc = tf_compile("$hex(11259375,10)");
+TEST_F (TitleFormattingTests, test_HexPadded_ReturnsHexConvertedNumberWithPadding) {
+    char *bc = tf_compile ("$hex(11259375,10)");
     tf_eval (&ctx, bc, buffer, 10);
-    EXPECT_TRUE(!strcmp (buffer, ""));
+    EXPECT_TRUE (!strcmp (buffer, ""));
     tf_eval (&ctx, bc, buffer, 11);
     tf_free (bc);
-    EXPECT_TRUE(!strcmp (buffer, "0000abcdef"));
+    EXPECT_TRUE (!strcmp (buffer, "0000abcdef"));
 }
 
-TEST_F(TitleFormattingTests, test_HexZero_ReturnsZero) {
-    char *bc = tf_compile("$hex(0)");
+TEST_F (TitleFormattingTests, test_HexZero_ReturnsZero) {
+    char *bc = tf_compile ("$hex(0)");
     tf_eval (&ctx, bc, buffer, 1000);
     tf_free (bc);
-    EXPECT_TRUE(!strcmp (buffer, "0"));
+    EXPECT_TRUE (!strcmp (buffer, "0"));
 }
 
-TEST_F(TitleFormattingTests, test_QuotedSquareBrackets_ReturnsSquareBrackets) {
-    char *bc = tf_compile("'['']'");
+TEST_F (TitleFormattingTests, test_QuotedSquareBrackets_ReturnsSquareBrackets) {
+    char *bc = tf_compile ("'['']'");
     tf_eval (&ctx, bc, buffer, 1000);
     tf_free (bc);
-    EXPECT_TRUE(!strcmp (buffer, "[]"));
+    EXPECT_TRUE (!strcmp (buffer, "[]"));
 }
 
-TEST_F(TitleFormattingTests, test_ImportLegacySquareBrackets_ProducesQuotedSquareBrackets) {
+TEST_F (TitleFormattingTests, test_ImportLegacySquareBrackets_ProducesQuotedSquareBrackets) {
     const char *old = "[%y]";
     char buf[100];
     tf_import_legacy (old, buf, sizeof (buf));
-    EXPECT_TRUE(!strcmp (buf, "'['%date%']'"));
+    EXPECT_TRUE (!strcmp (buf, "'['%date%']'"));
 }
 
-TEST_F(TitleFormattingTests, test_Num_123_5_Returns_00123) {
-    char *bc = tf_compile("$num(123,5)");
+TEST_F (TitleFormattingTests, test_Num_123_5_Returns_00123) {
+    char *bc = tf_compile ("$num(123,5)");
     tf_eval (&ctx, bc, buffer, 1000);
     tf_free (bc);
-    EXPECT_TRUE(!strcmp (buffer, "00123"));
+    EXPECT_TRUE (!strcmp (buffer, "00123"));
 }
 
-TEST_F(TitleFormattingTests, test_Num_Minus123_5_Returns__0123) {
-    char *bc = tf_compile("$num(-123,5)");
+TEST_F (TitleFormattingTests, test_Num_Minus123_5_Returns__0123) {
+    char *bc = tf_compile ("$num(-123,5)");
     tf_eval (&ctx, bc, buffer, 1000);
     tf_free (bc);
-    EXPECT_TRUE(!strcmp (buffer, "-0123"));
+    EXPECT_TRUE (!strcmp (buffer, "-0123"));
 }
 
-TEST_F(TitleFormattingTests, test_NumFractional_ReturnsIntegerFloor) {
-    char *bc = tf_compile("$num(4.8,5)");
+TEST_F (TitleFormattingTests, test_NumFractional_ReturnsIntegerFloor) {
+    char *bc = tf_compile ("$num(4.8,5)");
     tf_eval (&ctx, bc, buffer, 1000);
     tf_free (bc);
-    EXPECT_TRUE(!strcmp (buffer, "00004"));
+    EXPECT_TRUE (!strcmp (buffer, "00004"));
 }
 
-TEST_F(TitleFormattingTests, test_NumNonNumber_ReturnsZero) {
-    char *bc = tf_compile("$num(A1,5)");
+TEST_F (TitleFormattingTests, test_NumNonNumber_ReturnsZero) {
+    char *bc = tf_compile ("$num(A1,5)");
     tf_eval (&ctx, bc, buffer, 1000);
     tf_free (bc);
-    EXPECT_TRUE(!strcmp (buffer, "00000"));
+    EXPECT_TRUE (!strcmp (buffer, "00000"));
 }
 
-TEST_F(TitleFormattingTests, test_NumLargeNumber_DoesntTruncate) {
-    char *bc = tf_compile("$num(1234,3)");
+TEST_F (TitleFormattingTests, test_NumLargeNumber_DoesntTruncate) {
+    char *bc = tf_compile ("$num(1234,3)");
     tf_eval (&ctx, bc, buffer, 1000);
     tf_free (bc);
-    EXPECT_TRUE(!strcmp (buffer, "1234"));
+    EXPECT_TRUE (!strcmp (buffer, "1234"));
 }
 
-TEST_F(TitleFormattingTests, test_NumNegativePadding_GivesZeroPadding) {
-    char *bc = tf_compile("$num(1,-3)");
+TEST_F (TitleFormattingTests, test_NumNegativePadding_GivesZeroPadding) {
+    char *bc = tf_compile ("$num(1,-3)");
     tf_eval (&ctx, bc, buffer, 1000);
-    EXPECT_TRUE(!strcmp (buffer, "1"));
+    EXPECT_TRUE (!strcmp (buffer, "1"));
 }
 
-TEST_F(TitleFormattingTests, test_isPlaying_StatePlayingAndStreamerTrackNotSameAsCtxTrack_ReturnsNone) {
+TEST_F (TitleFormattingTests, test_isPlaying_StatePlayingAndStreamerTrackNotSameAsCtxTrack_ReturnsNone) {
     streamer_set_playing_track (it);
     ctx.it = NULL;
     fake_out_state_value = DDB_PLAYBACK_STATE_PLAYING;
-    char *bc = tf_compile("$if(%isplaying%,YES,NO) %isplaying%");
+    char *bc = tf_compile ("$if(%isplaying%,YES,NO) %isplaying%");
     tf_eval (&ctx, bc, buffer, 1000);
     tf_free (bc);
-    EXPECT_TRUE(!strcmp (buffer, "NO "));
+    EXPECT_TRUE (!strcmp (buffer, "NO "));
 }
 
-TEST_F(TitleFormattingTests, test_isPlaying_StatePlayingAndStreamerTrackSameAsCtxTrack_Returns1) {
+TEST_F (TitleFormattingTests, test_isPlaying_StatePlayingAndStreamerTrackSameAsCtxTrack_Returns1) {
     streamer_set_playing_track (it);
     fake_out_state_value = DDB_PLAYBACK_STATE_PLAYING;
-    char *bc = tf_compile("$if(%isplaying%,YES,NO) %isplaying%");
+    char *bc = tf_compile ("$if(%isplaying%,YES,NO) %isplaying%");
     tf_eval (&ctx, bc, buffer, 1000);
     tf_free (bc);
-    EXPECT_TRUE(!strcmp (buffer, "YES 1"));
+    EXPECT_TRUE (!strcmp (buffer, "YES 1"));
 }
 
-TEST_F(TitleFormattingTests, test_IsPlaying_StateStopped_ReturnsNone) {
+TEST_F (TitleFormattingTests, test_IsPlaying_StateStopped_ReturnsNone) {
     fake_out_state_value = DDB_PLAYBACK_STATE_STOPPED;
-    char *bc = tf_compile("$if(%isplaying%,YES,NO) %isplaying%");
+    char *bc = tf_compile ("$if(%isplaying%,YES,NO) %isplaying%");
     tf_eval (&ctx, bc, buffer, 1000);
     tf_free (bc);
-    EXPECT_TRUE(!strcmp (buffer, "NO "));
+    EXPECT_TRUE (!strcmp (buffer, "NO "));
 }
 
-TEST_F(TitleFormattingTests, test_isPaused_StatePlayingAndStreamerTrackNotSameAsCtxTrack_ReturnsNone) {
+TEST_F (TitleFormattingTests, test_isPaused_StatePlayingAndStreamerTrackNotSameAsCtxTrack_ReturnsNone) {
     streamer_set_playing_track (it);
     ctx.it = NULL;
     fake_out_state_value = DDB_PLAYBACK_STATE_PLAYING;
-    char *bc = tf_compile("$if(%ispaused%,YES,NO) %ispaused%");
+    char *bc = tf_compile ("$if(%ispaused%,YES,NO) %ispaused%");
     tf_eval (&ctx, bc, buffer, 1000);
     tf_free (bc);
-    EXPECT_TRUE(!strcmp (buffer, "NO "));
+    EXPECT_TRUE (!strcmp (buffer, "NO "));
 }
 
-TEST_F(TitleFormattingTests, test_isPaused_StatePlayingAndStreamerTrackSameAsCtxTrack_ReturnsNone) {
+TEST_F (TitleFormattingTests, test_isPaused_StatePlayingAndStreamerTrackSameAsCtxTrack_ReturnsNone) {
     streamer_set_playing_track (it);
     fake_out_state_value = DDB_PLAYBACK_STATE_PLAYING;
-    char *bc = tf_compile("$if(%ispaused%,YES,NO) %ispaused%");
+    char *bc = tf_compile ("$if(%ispaused%,YES,NO) %ispaused%");
     tf_eval (&ctx, bc, buffer, 1000);
     tf_free (bc);
-    EXPECT_TRUE(!strcmp (buffer, "NO "));
+    EXPECT_TRUE (!strcmp (buffer, "NO "));
 }
 
-TEST_F(TitleFormattingTests, test_isPaused_StatePausedAndStreamerTrackNotSameAsCtxTrack_ReturnsNone) {
+TEST_F (TitleFormattingTests, test_isPaused_StatePausedAndStreamerTrackNotSameAsCtxTrack_ReturnsNone) {
     streamer_set_playing_track (it);
     ctx.it = NULL;
     fake_out_state_value = DDB_PLAYBACK_STATE_PAUSED;
-    char *bc = tf_compile("$if(%ispaused%,YES,NO) %ispaused%");
+    char *bc = tf_compile ("$if(%ispaused%,YES,NO) %ispaused%");
     tf_eval (&ctx, bc, buffer, 1000);
     tf_free (bc);
-    EXPECT_TRUE(!strcmp (buffer, "NO "));
+    EXPECT_TRUE (!strcmp (buffer, "NO "));
 }
 
-TEST_F(TitleFormattingTests, test_isPaused_StatePausedAndStreamerTrackSameAsCtxTrack_Returns1) {
+TEST_F (TitleFormattingTests, test_isPaused_StatePausedAndStreamerTrackSameAsCtxTrack_Returns1) {
     streamer_set_playing_track (it);
     fake_out_state_value = DDB_PLAYBACK_STATE_PAUSED;
-    char *bc = tf_compile("$if(%ispaused%,YES,NO) %ispaused%");
+    char *bc = tf_compile ("$if(%ispaused%,YES,NO) %ispaused%");
     tf_eval (&ctx, bc, buffer, 1000);
     tf_free (bc);
-    EXPECT_TRUE(!strcmp (buffer, "YES 1"));
+    EXPECT_TRUE (!strcmp (buffer, "YES 1"));
 }
 
-TEST_F(TitleFormattingTests, test_MultiValueField_OutputAsCommaSeparated) {
-    pl_append_meta(it, "artist", "Value1");
-    pl_append_meta(it, "artist", "Value2");
-    pl_append_meta(it, "artist", "Value3");
-    char *bc = tf_compile("%artist%");
+TEST_F (TitleFormattingTests, test_MultiValueField_OutputAsCommaSeparated) {
+    pl_append_meta (it, "artist", "Value1");
+    pl_append_meta (it, "artist", "Value2");
+    pl_append_meta (it, "artist", "Value3");
+    char *bc = tf_compile ("%artist%");
     tf_eval (&ctx, bc, buffer, 1000);
     tf_free (bc);
-    EXPECT_TRUE(!strcmp (buffer, "Value1, Value2, Value3"));
+    EXPECT_TRUE (!strcmp (buffer, "Value1, Value2, Value3"));
 }
 
-TEST_F(TitleFormattingTests, test_LinebreaksAndTabs_OutputAsUnderscores) {
-    pl_append_meta(it, "artist", "Text1\r\nText2\tText3");
-    char *bc = tf_compile("%artist%");
+TEST_F (TitleFormattingTests, test_LinebreaksAndTabs_OutputAsUnderscores) {
+    pl_append_meta (it, "artist", "Text1\r\nText2\tText3");
+    char *bc = tf_compile ("%artist%");
     tf_eval (&ctx, bc, buffer, 1000);
     tf_free (bc);
-    EXPECT_TRUE(!strcmp (buffer, "Text1__Text2_Text3"));
+    EXPECT_TRUE (!strcmp (buffer, "Text1__Text2_Text3"));
 }
 
-TEST_F(TitleFormattingTests, test_NestedSquareBracketsWithDefinedAndUndefinedVars_ReturnNonEmpty) {
+TEST_F (TitleFormattingTests, test_NestedSquareBracketsWithDefinedAndUndefinedVars_ReturnNonEmpty) {
     pl_replace_meta (it, "title", "title");
-    char *bc = tf_compile("header [[%discnumber%][%title%] a] footer");
+    char *bc = tf_compile ("header [[%discnumber%][%title%] a] footer");
     tf_eval (&ctx, bc, buffer, 1000);
     tf_free (bc);
-    EXPECT_TRUE(!strcmp (buffer, "header title a footer"));
+    EXPECT_TRUE (!strcmp (buffer, "header title a footer"));
 }
 
-TEST_F(TitleFormattingTests, test_PathStripFileUriScheme_ReturnStripped) {
+TEST_F (TitleFormattingTests, test_PathStripFileUriScheme_ReturnStripped) {
     pl_replace_meta (it, ":URI", "file:///home/user/filename.mp3");
-    char *bc = tf_compile("%path%");
+    char *bc = tf_compile ("%path%");
     tf_eval (&ctx, bc, buffer, 1000);
     tf_free (bc);
-    EXPECT_TRUE(!strcmp (buffer, "/home/user/filename.mp3"));
+    EXPECT_TRUE (!strcmp (buffer, "/home/user/filename.mp3"));
 }
 
-TEST_F(TitleFormattingTests, test_PathStripHTTPUriScheme_ReturnUnStripped) {
+TEST_F (TitleFormattingTests, test_PathStripHTTPUriScheme_ReturnUnStripped) {
     pl_replace_meta (it, ":URI", "http://example.com/filename.mp3");
-    char *bc = tf_compile("%path%");
+    char *bc = tf_compile ("%path%");
     tf_eval (&ctx, bc, buffer, 1000);
     tf_free (bc);
-    EXPECT_TRUE(!strcmp (buffer, "http://example.com/filename.mp3"));
+    EXPECT_TRUE (!strcmp (buffer, "http://example.com/filename.mp3"));
 }
 
-TEST_F(TitleFormattingTests, test_RawPathWithFileUriScheme_ReturnUnStripped) {
+TEST_F (TitleFormattingTests, test_RawPathWithFileUriScheme_ReturnUnStripped) {
     pl_replace_meta (it, ":URI", "file:///home/user/filename.mp3");
-    char *bc = tf_compile("%_path_raw%");
+    char *bc = tf_compile ("%_path_raw%");
     tf_eval (&ctx, bc, buffer, 1000);
     tf_free (bc);
-    EXPECT_TRUE(!strcmp (buffer, "file:///home/user/filename.mp3"));
+    EXPECT_TRUE (!strcmp (buffer, "file:///home/user/filename.mp3"));
 }
 
-TEST_F(TitleFormattingTests, test_RawPathWithHttpUriScheme_ReturnUnStripped) {
+TEST_F (TitleFormattingTests, test_RawPathWithHttpUriScheme_ReturnUnStripped) {
     pl_replace_meta (it, ":URI", "http://example.com/filename.mp3");
-    char *bc = tf_compile("%_path_raw%");
+    char *bc = tf_compile ("%_path_raw%");
     tf_eval (&ctx, bc, buffer, 1000);
     tf_free (bc);
-    EXPECT_TRUE(!strcmp (buffer, "http://example.com/filename.mp3"));
+    EXPECT_TRUE (!strcmp (buffer, "http://example.com/filename.mp3"));
 }
 
-TEST_F(TitleFormattingTests, test_RawPathAbsolutePath_ReturnsExpected) {
+TEST_F (TitleFormattingTests, test_RawPathAbsolutePath_ReturnsExpected) {
     pl_replace_meta (it, ":URI", "/path/to/filename.mp3");
-    char *bc = tf_compile("%_path_raw%");
+    char *bc = tf_compile ("%_path_raw%");
     tf_eval (&ctx, bc, buffer, 1000);
     tf_free (bc);
-    EXPECT_TRUE(!strcmp (buffer, "file:///path/to/filename.mp3"));
+    EXPECT_TRUE (!strcmp (buffer, "file:///path/to/filename.mp3"));
 }
 
-TEST_F(TitleFormattingTests, test_RawPathRelativePath_ReturnsEmpty) {
+TEST_F (TitleFormattingTests, test_RawPathRelativePath_ReturnsEmpty) {
     pl_replace_meta (it, ":URI", "relative/path/to/filename.mp3");
-    char *bc = tf_compile("%_path_raw%");
+    char *bc = tf_compile ("%_path_raw%");
     tf_eval (&ctx, bc, buffer, 1000);
     tf_free (bc);
-    EXPECT_TRUE(!strcmp (buffer, ""));
+    EXPECT_TRUE (!strcmp (buffer, ""));
 }
 
-TEST_F(TitleFormattingTests, test_PlaylistName_ReturnsPlaylistName) {
-    char *bc = tf_compile("%_playlist_name%");
-    playlist_t plt = {0};
+TEST_F (TitleFormattingTests, test_PlaylistName_ReturnsPlaylistName) {
+    char *bc = tf_compile ("%_playlist_name%");
+    playlist_t plt = { 0 };
     plt.title = (char *)"Test Playlist";
     ctx.plt = (ddb_playlist_t *)&plt;
     tf_eval (&ctx, bc, buffer, 1000);
     tf_free (bc);
-    EXPECT_TRUE(!strcmp (buffer, "Test Playlist"));
+    EXPECT_TRUE (!strcmp (buffer, "Test Playlist"));
 }
 
-TEST_F(TitleFormattingTests, test_ReplaceWith3Arguments_ReturnsExpectedValue) {
-    char *bc = tf_compile("$replace(ab,a,b,b,c)");
+TEST_F (TitleFormattingTests, test_ReplaceWith3Arguments_ReturnsExpectedValue) {
+    char *bc = tf_compile ("$replace(ab,a,b,b,c)");
     tf_eval (&ctx, bc, buffer, 1000);
     tf_free (bc);
-    EXPECT_TRUE(!strcmp (buffer, "bc"));
+    EXPECT_TRUE (!strcmp (buffer, "bc"));
 }
 
-TEST_F(TitleFormattingTests, test_ReplaceWith3ArgumentsNested_ReturnsExpectedValue) {
-    char *bc = tf_compile("$replace($replace(ab,a,b),b,c)");
+TEST_F (TitleFormattingTests, test_ReplaceWith3ArgumentsNested_ReturnsExpectedValue) {
+    char *bc = tf_compile ("$replace($replace(ab,a,b),b,c)");
     tf_eval (&ctx, bc, buffer, 1000);
     tf_free (bc);
-    EXPECT_TRUE(!strcmp (buffer, "cc"));
+    EXPECT_TRUE (!strcmp (buffer, "cc"));
 }
 
-TEST_F(TitleFormattingTests, test_ReplaceWith1Argument_ReturnsEmpty) {
-    char *bc = tf_compile("$replace(ab)");
+TEST_F (TitleFormattingTests, test_ReplaceWith1Argument_ReturnsEmpty) {
+    char *bc = tf_compile ("$replace(ab)");
     tf_eval (&ctx, bc, buffer, 1000);
     tf_free (bc);
-    EXPECT_TRUE(!strcmp (buffer, ""));
+    EXPECT_TRUE (!strcmp (buffer, ""));
 }
 
-TEST_F(TitleFormattingTests, test_ReplaceWith2Arguments_ReturnsEmpty) {
-    char *bc = tf_compile("$replace(ab,a)");
+TEST_F (TitleFormattingTests, test_ReplaceWith2Arguments_ReturnsEmpty) {
+    char *bc = tf_compile ("$replace(ab,a)");
     tf_eval (&ctx, bc, buffer, 1000);
     tf_free (bc);
-    EXPECT_TRUE(!strcmp (buffer, ""));
+    EXPECT_TRUE (!strcmp (buffer, ""));
 }
 
-TEST_F(TitleFormattingTests, test_ReplaceWith4Arguments_ReturnsEmpty) {
-    char *bc = tf_compile("$replace(ab,a,c,d)");
+TEST_F (TitleFormattingTests, test_ReplaceWith4Arguments_ReturnsEmpty) {
+    char *bc = tf_compile ("$replace(ab,a,c,d)");
     tf_eval (&ctx, bc, buffer, 1000);
     tf_free (bc);
-    EXPECT_TRUE(!strcmp (buffer, ""));
+    EXPECT_TRUE (!strcmp (buffer, ""));
 }
 
-TEST_F(TitleFormattingTests, test_ReplaceLongerSubstring_ReturnsExpected) {
-    char *bc = tf_compile("$replace(foobar,foo,DeaD,bar,BeeF)");
+TEST_F (TitleFormattingTests, test_ReplaceLongerSubstring_ReturnsExpected) {
+    char *bc = tf_compile ("$replace(foobar,foo,DeaD,bar,BeeF)");
     tf_eval (&ctx, bc, buffer, 1000);
     tf_free (bc);
-    EXPECT_TRUE(!strcmp (buffer, "DeaDBeeF"));
+    EXPECT_TRUE (!strcmp (buffer, "DeaDBeeF"));
 }
 
-TEST_F(TitleFormattingTests, test_replace_emptyStringWithEmpty_shouldComplete) {
-    char *bc = tf_compile("$replace(foobar,,)");
-    tf_eval (&ctx, bc, buffer, 1000);
-    tf_free (bc);
-
-    EXPECT_STREQ(buffer, "foobar");
-}
-
-TEST_F(TitleFormattingTests, test_replace_emptyStringWithSomething_shouldProduceOriginalString) {
-    char *bc = tf_compile("$replace(foobar,,bar)");
-
+TEST_F (TitleFormattingTests, test_replace_emptyStringWithEmpty_shouldComplete) {
+    char *bc = tf_compile ("$replace(foobar,,)");
     tf_eval (&ctx, bc, buffer, 1000);
     tf_free (bc);
 
-    EXPECT_TRUE(!strcmp (buffer, "foobar"));
+    EXPECT_STREQ (buffer, "foobar");
 }
 
-TEST_F(TitleFormattingTests, test_FilenameExt_ReturnsFilenameWithExt) {
+TEST_F (TitleFormattingTests, test_replace_emptyStringWithSomething_shouldProduceOriginalString) {
+    char *bc = tf_compile ("$replace(foobar,,bar)");
+
+    tf_eval (&ctx, bc, buffer, 1000);
+    tf_free (bc);
+
+    EXPECT_TRUE (!strcmp (buffer, "foobar"));
+}
+
+TEST_F (TitleFormattingTests, test_FilenameExt_ReturnsFilenameWithExt) {
     pl_replace_meta (it, ":URI", "/Users/User/MyFile.mod");
-    char *bc = tf_compile("%filename_ext%");
+    char *bc = tf_compile ("%filename_ext%");
     tf_eval (&ctx, bc, buffer, 1000);
     tf_free (bc);
-    EXPECT_TRUE(!strcmp (buffer, "MyFile.mod"));
+    EXPECT_TRUE (!strcmp (buffer, "MyFile.mod"));
 }
 
-TEST_F(TitleFormattingTests, test_UpperForAllLowerCase_ReturnsUppercase) {
-    char *bc = tf_compile("$upper(abcd)");
+TEST_F (TitleFormattingTests, test_UpperForAllLowerCase_ReturnsUppercase) {
+    char *bc = tf_compile ("$upper(abcd)");
     tf_eval (&ctx, bc, buffer, 1000);
     tf_free (bc);
-    EXPECT_TRUE(!strcmp (buffer, "ABCD"));
+    EXPECT_TRUE (!strcmp (buffer, "ABCD"));
 }
 
-TEST_F(TitleFormattingTests, test_UpperForAllUpperCase_ReturnsUppercase) {
-    char *bc = tf_compile("$upper(ABCD)");
+TEST_F (TitleFormattingTests, test_UpperForAllUpperCase_ReturnsUppercase) {
+    char *bc = tf_compile ("$upper(ABCD)");
     tf_eval (&ctx, bc, buffer, 1000);
     tf_free (bc);
-    EXPECT_TRUE(!strcmp (buffer, "ABCD"));
+    EXPECT_TRUE (!strcmp (buffer, "ABCD"));
 }
 
-TEST_F(TitleFormattingTests, test_UpperForMixed_ReturnsUppercase) {
-    char *bc = tf_compile("$upper(aBcD)");
+TEST_F (TitleFormattingTests, test_UpperForMixed_ReturnsUppercase) {
+    char *bc = tf_compile ("$upper(aBcD)");
     tf_eval (&ctx, bc, buffer, 1000);
     tf_free (bc);
-    EXPECT_TRUE(!strcmp (buffer, "ABCD"));
+    EXPECT_TRUE (!strcmp (buffer, "ABCD"));
 }
 
-TEST_F(TitleFormattingTests, test_UpperForAllLowerCaseNonAscii_ReturnsUppercase) {
-    char *bc = tf_compile("$upper(абвгд)");
+TEST_F (TitleFormattingTests, test_UpperForAllLowerCaseNonAscii_ReturnsUppercase) {
+    char *bc = tf_compile ("$upper(абвгд)");
     tf_eval (&ctx, bc, buffer, 1000);
     tf_free (bc);
-    EXPECT_TRUE(!strcmp (buffer, "АБВГД"));
+    EXPECT_TRUE (!strcmp (buffer, "АБВГД"));
 }
 
-TEST_F(TitleFormattingTests, test_LowerForAllUpperCase_ReturnsLowercase) {
-    char *bc = tf_compile("$lower(ABCD)");
+TEST_F (TitleFormattingTests, test_LowerForAllUpperCase_ReturnsLowercase) {
+    char *bc = tf_compile ("$lower(ABCD)");
     tf_eval (&ctx, bc, buffer, 1000);
     tf_free (bc);
-    EXPECT_TRUE(!strcmp (buffer, "abcd"));
+    EXPECT_TRUE (!strcmp (buffer, "abcd"));
 }
 
-TEST_F(TitleFormattingTests, test_LowerForAllLowerCase_ReturnsLowercase) {
-    char *bc = tf_compile("$lower(abcd)");
+TEST_F (TitleFormattingTests, test_LowerForAllLowerCase_ReturnsLowercase) {
+    char *bc = tf_compile ("$lower(abcd)");
     tf_eval (&ctx, bc, buffer, 1000);
     tf_free (bc);
-    EXPECT_TRUE(!strcmp (buffer, "abcd"));
+    EXPECT_TRUE (!strcmp (buffer, "abcd"));
 }
 
-TEST_F(TitleFormattingTests, test_LowerForMixed_ReturnsLowercase) {
-    char *bc = tf_compile("$lower(aBcD)");
+TEST_F (TitleFormattingTests, test_LowerForMixed_ReturnsLowercase) {
+    char *bc = tf_compile ("$lower(aBcD)");
     tf_eval (&ctx, bc, buffer, 1000);
     tf_free (bc);
-    EXPECT_TRUE(!strcmp (buffer, "abcd"));
+    EXPECT_TRUE (!strcmp (buffer, "abcd"));
 }
 
-TEST_F(TitleFormattingTests, test_LowerForAllUpperCaseNonAscii_ReturnsLowercase) {
-    char *bc = tf_compile("$lower(АБВГД)");
+TEST_F (TitleFormattingTests, test_LowerForAllUpperCaseNonAscii_ReturnsLowercase) {
+    char *bc = tf_compile ("$lower(АБВГД)");
     tf_eval (&ctx, bc, buffer, 1000);
     tf_free (bc);
-    EXPECT_TRUE(!strcmp (buffer, "абвгд"));
+    EXPECT_TRUE (!strcmp (buffer, "абвгд"));
 }
 
-TEST_F(TitleFormattingTests, test_PathWithNullUri_ReturnsEmpty) {
+TEST_F (TitleFormattingTests, test_PathWithNullUri_ReturnsEmpty) {
     pl_delete_meta (it, ":URI");
-    char *bc = tf_compile("%path%");
+    char *bc = tf_compile ("%path%");
     tf_eval (&ctx, bc, buffer, 1000);
     tf_free (bc);
-    EXPECT_TRUE(!strcmp (buffer, ""));
+    EXPECT_TRUE (!strcmp (buffer, ""));
 }
 
-TEST_F(TitleFormattingTests, test_RawPathWithNullUri_ReturnsEmpty) {
+TEST_F (TitleFormattingTests, test_RawPathWithNullUri_ReturnsEmpty) {
     pl_delete_meta (it, ":URI");
-    char *bc = tf_compile("%_path_raw%");
+    char *bc = tf_compile ("%_path_raw%");
     tf_eval (&ctx, bc, buffer, 1000);
     tf_free (bc);
-    EXPECT_TRUE(!strcmp (buffer, ""));
+    EXPECT_TRUE (!strcmp (buffer, ""));
 }
 
-TEST_F(TitleFormattingTests, test_VfsPathTitle_GivesCorrectTitle) {
+TEST_F (TitleFormattingTests, test_VfsPathTitle_GivesCorrectTitle) {
     pl_replace_meta (it, ":URI", "/path/file/myfile.zip:mytrack.mp3");
-    char *bc = tf_compile("%title%");
+    char *bc = tf_compile ("%title%");
     tf_eval (&ctx, bc, buffer, 1000);
     tf_free (bc);
-    EXPECT_TRUE(!strcmp (buffer, "mytrack"));
+    EXPECT_TRUE (!strcmp (buffer, "mytrack"));
 }
 
-TEST_F(TitleFormattingTests, test_RepeatSingleChar11Times_Gives11Chars) {
-    char *bc = tf_compile("$repeat(x,11)");
+TEST_F (TitleFormattingTests, test_RepeatSingleChar11Times_Gives11Chars) {
+    char *bc = tf_compile ("$repeat(x,11)");
     tf_eval (&ctx, bc, buffer, 1000);
     tf_free (bc);
-    EXPECT_TRUE(!strcmp (buffer, "xxxxxxxxxxx"));
+    EXPECT_TRUE (!strcmp (buffer, "xxxxxxxxxxx"));
 }
 
-TEST_F(TitleFormattingTests, test_RepeatTwoChars3Times_Gives3DoubleChars) {
-    char *bc = tf_compile("$repeat(xy,3)");
+TEST_F (TitleFormattingTests, test_RepeatTwoChars3Times_Gives3DoubleChars) {
+    char *bc = tf_compile ("$repeat(xy,3)");
     tf_eval (&ctx, bc, buffer, 1000);
     tf_free (bc);
-    EXPECT_TRUE(!strcmp (buffer, "xyxyxy"));
+    EXPECT_TRUE (!strcmp (buffer, "xyxyxy"));
 }
 
-TEST_F(TitleFormattingTests, test_RepeatCalculatedExpr2Times_Gives2Exprs) {
+TEST_F (TitleFormattingTests, test_RepeatCalculatedExpr2Times_Gives2Exprs) {
     pl_replace_meta (it, "title", "abc");
-    char *bc = tf_compile("$repeat(%title%,2)");
+    char *bc = tf_compile ("$repeat(%title%,2)");
     tf_eval (&ctx, bc, buffer, 1000);
     tf_free (bc);
-    EXPECT_TRUE(!strcmp (buffer, "abcabc"));
+    EXPECT_TRUE (!strcmp (buffer, "abcabc"));
 }
 
-TEST_F(TitleFormattingTests, test_RepeatCalculatedExprNTimes_GivesNExprs) {
+TEST_F (TitleFormattingTests, test_RepeatCalculatedExprNTimes_GivesNExprs) {
     pl_replace_meta (it, "title", "abc");
     pl_replace_meta (it, "count", "3");
-    char *bc = tf_compile("$repeat(%title%,%count%)");
+    char *bc = tf_compile ("$repeat(%title%,%count%)");
     tf_eval (&ctx, bc, buffer, 1000);
     tf_free (bc);
-    EXPECT_TRUE(!strcmp (buffer, "abcabcabc"));
+    EXPECT_TRUE (!strcmp (buffer, "abcabcabc"));
 }
 
-TEST_F(TitleFormattingTests, test_RepeatSingleCharZeroTimes_GivesZeroChars) {
-    char *bc = tf_compile("pre$repeat(x,0)post");
+TEST_F (TitleFormattingTests, test_RepeatSingleCharZeroTimes_GivesZeroChars) {
+    char *bc = tf_compile ("pre$repeat(x,0)post");
     tf_eval (&ctx, bc, buffer, 1000);
     tf_free (bc);
-    EXPECT_TRUE(!strcmp (buffer, "prepost"));
+    EXPECT_TRUE (!strcmp (buffer, "prepost"));
 }
 
-TEST_F(TitleFormattingTests, test_InsertStrMiddle_GivesInsertedStr) {
+TEST_F (TitleFormattingTests, test_InsertStrMiddle_GivesInsertedStr) {
     pl_replace_meta (it, "title", "Insert [] Here");
     pl_replace_meta (it, "album", "Value");
-    char *bc = tf_compile("$insert(%title%,%album%,8)");
+    char *bc = tf_compile ("$insert(%title%,%album%,8)");
     tf_eval (&ctx, bc, buffer, 1000);
     tf_free (bc);
-    EXPECT_TRUE(!strcmp (buffer, "Insert [Value] Here"));
+    EXPECT_TRUE (!strcmp (buffer, "Insert [Value] Here"));
 }
 
-TEST_F(TitleFormattingTests, test_InsertStrMiddleUnicode_GivesInsertedStr) {
+TEST_F (TitleFormattingTests, test_InsertStrMiddleUnicode_GivesInsertedStr) {
     pl_replace_meta (it, "title", "Вставить [] сюда");
     pl_replace_meta (it, "album", "Значение");
-    char *bc = tf_compile("$insert(%title%,%album%,10)");
+    char *bc = tf_compile ("$insert(%title%,%album%,10)");
     tf_eval (&ctx, bc, buffer, 1000);
     tf_free (bc);
-    EXPECT_TRUE(!strcmp (buffer, "Вставить [Значение] сюда"));
+    EXPECT_TRUE (!strcmp (buffer, "Вставить [Значение] сюда"));
 }
 
-TEST_F(TitleFormattingTests, test_InsertStrEnd_GivesAppendedStr) {
+TEST_F (TitleFormattingTests, test_InsertStrEnd_GivesAppendedStr) {
     pl_replace_meta (it, "title", "Insert Here:");
     pl_replace_meta (it, "album", "Value");
-    char *bc = tf_compile("$insert(%title%,%album%,12)");
+    char *bc = tf_compile ("$insert(%title%,%album%,12)");
     tf_eval (&ctx, bc, buffer, 1000);
     tf_free (bc);
-    EXPECT_TRUE(!strcmp (buffer, "Insert Here:Value"));
+    EXPECT_TRUE (!strcmp (buffer, "Insert Here:Value"));
 }
 
-TEST_F(TitleFormattingTests, test_InsertStrOutOfBounds_GivesAppendedStr) {
+TEST_F (TitleFormattingTests, test_InsertStrOutOfBounds_GivesAppendedStr) {
     pl_replace_meta (it, "title", "Insert Here:");
     pl_replace_meta (it, "album", "Value");
-    char *bc = tf_compile("$insert(%title%,%album%,13)");
+    char *bc = tf_compile ("$insert(%title%,%album%,13)");
     tf_eval (&ctx, bc, buffer, 1000);
     tf_free (bc);
-    EXPECT_TRUE(!strcmp (buffer, "Insert Here:Value"));
+    EXPECT_TRUE (!strcmp (buffer, "Insert Here:Value"));
 }
 
-TEST_F(TitleFormattingTests, test_InsertStrBufferTooSmallUnicode_GivesTruncatedAtBeforeStr) {
+TEST_F (TitleFormattingTests, test_InsertStrBufferTooSmallUnicode_GivesTruncatedAtBeforeStr) {
     pl_replace_meta (it, "title", "Вставить [] сюда");
     pl_replace_meta (it, "album", "Значение");
-    char *bc = tf_compile("$insert(%title%,%album%,10)");
+    char *bc = tf_compile ("$insert(%title%,%album%,10)");
     tf_eval (&ctx, bc, buffer, 5);
     tf_free (bc);
-    EXPECT_TRUE(!strcmp (buffer, "Вс"));
+    EXPECT_TRUE (!strcmp (buffer, "Вс"));
 }
 
-TEST_F(TitleFormattingTests, test_InsertStrBufferTooSmallUnicode_GivesTruncatedAtMiddleStr) {
+TEST_F (TitleFormattingTests, test_InsertStrBufferTooSmallUnicode_GivesTruncatedAtMiddleStr) {
     pl_replace_meta (it, "title", "Вставить [] сюда");
     pl_replace_meta (it, "album", "Значение");
-    char *bc = tf_compile("$insert(%title%,%album%,10)");
+    char *bc = tf_compile ("$insert(%title%,%album%,10)");
     tf_eval (&ctx, bc, buffer, 27);
     tf_free (bc);
-    EXPECT_TRUE(!strcmp (buffer, "Вставить [Знач"));
+    EXPECT_TRUE (!strcmp (buffer, "Вставить [Знач"));
 }
 
-TEST_F(TitleFormattingTests, test_InsertStrBufferTooSmallUnicode_GivesTruncatedAtAfterStr) {
+TEST_F (TitleFormattingTests, test_InsertStrBufferTooSmallUnicode_GivesTruncatedAtAfterStr) {
     pl_replace_meta (it, "title", "Вставить [] сюда");
     pl_replace_meta (it, "album", "Значение");
-    char *bc = tf_compile("$insert(%title%,%album%,10)");
+    char *bc = tf_compile ("$insert(%title%,%album%,10)");
     tf_eval (&ctx, bc, buffer, 41);
     tf_free (bc);
-    EXPECT_TRUE(!strcmp (buffer, "Вставить [Значение] сю"));
+    EXPECT_TRUE (!strcmp (buffer, "Вставить [Значение] сю"));
 }
 
-TEST_F(TitleFormattingTests, test_InsertStrBegin_GivesPrependedStr) {
+TEST_F (TitleFormattingTests, test_InsertStrBegin_GivesPrependedStr) {
     pl_replace_meta (it, "title", ":Insert Before");
     pl_replace_meta (it, "album", "Value");
-    char *bc = tf_compile("$insert(%title%,%album%,0)");
+    char *bc = tf_compile ("$insert(%title%,%album%,0)");
     tf_eval (&ctx, bc, buffer, 1000);
     tf_free (bc);
-    EXPECT_TRUE(!strcmp (buffer, "Value:Insert Before"));
+    EXPECT_TRUE (!strcmp (buffer, "Value:Insert Before"));
 }
 
-TEST_F(TitleFormattingTests, test_LeftOfUnicodeString_Takes2Chars) {
-    char *bc = tf_compile("$left(АБВГД,2)");
+TEST_F (TitleFormattingTests, test_LeftOfUnicodeString_Takes2Chars) {
+    char *bc = tf_compile ("$left(АБВГД,2)");
     tf_eval (&ctx, bc, buffer, 1000);
     tf_free (bc);
-    EXPECT_TRUE(!strcmp (buffer, "АБ"));
+    EXPECT_TRUE (!strcmp (buffer, "АБ"));
 }
 
-TEST_F(TitleFormattingTests, test_Left2OfUnicodeStringBufFor1Char_Takes1Char) {
-    char *bc = tf_compile("$left(АБВГД,2)");
+TEST_F (TitleFormattingTests, test_Left2OfUnicodeStringBufFor1Char_Takes1Char) {
+    char *bc = tf_compile ("$left(АБВГД,2)");
     tf_eval (&ctx, bc, buffer, 3);
     tf_free (bc);
-    EXPECT_TRUE(!strcmp (buffer, "А"));
+    EXPECT_TRUE (!strcmp (buffer, "А"));
 }
 
-TEST_F(TitleFormattingTests, test_LenOfUnicodeString_ReturnsLengthInChars) {
-    char *bc = tf_compile("$len(АБВГД)");
+TEST_F (TitleFormattingTests, test_LenOfUnicodeString_ReturnsLengthInChars) {
+    char *bc = tf_compile ("$len(АБВГД)");
     tf_eval (&ctx, bc, buffer, 1000);
     tf_free (bc);
-    EXPECT_TRUE(!strcmp (buffer, "5"));
+    EXPECT_TRUE (!strcmp (buffer, "5"));
 }
 
-TEST_F(TitleFormattingTests, test_DimTextExpression_ReturnsPlainText) {
-    char *bc = tf_compile("<<<dim this text>>>");
+TEST_F (TitleFormattingTests, test_DimTextExpression_ReturnsPlainText) {
+    char *bc = tf_compile ("<<<dim this text>>>");
     tf_eval (&ctx, bc, buffer, 1000);
     tf_free (bc);
-    EXPECT_TRUE(!ctx.dimmed);
-    EXPECT_TRUE(!strcmp (buffer, "dim this text"));
+    EXPECT_TRUE (!ctx.dimmed);
+    EXPECT_TRUE (!strcmp (buffer, "dim this text"));
 }
 
-TEST_F(TitleFormattingTests, test_DimTextExpression_ReturnsTextWithDimEscSequence) {
-    char *bc = tf_compile("<<<dim this text>>>");
+TEST_F (TitleFormattingTests, test_DimTextExpression_ReturnsTextWithDimEscSequence) {
+    char *bc = tf_compile ("<<<dim this text>>>");
     ctx.flags |= DDB_TF_CONTEXT_TEXT_DIM;
     tf_eval (&ctx, bc, buffer, 1000);
     ctx.flags &= ~DDB_TF_CONTEXT_TEXT_DIM;
     tf_free (bc);
-    EXPECT_TRUE(ctx.dimmed);
-    EXPECT_STREQ(buffer, "\0331;-3mdim this text\0331;3m");
+    EXPECT_TRUE (ctx.dimmed);
+    EXPECT_STREQ (buffer, "\0331;-3mdim this text\0331;3m");
 }
 
-TEST_F(TitleFormattingTests, test_DimInsideCut_ReturnsTextWithDimEscSequence) {
-    pl_add_meta(it, "year", "1980");
-    char *bc = tf_compile("$cut(<%year%>,4)");
+TEST_F (TitleFormattingTests, test_DimInsideCut_ReturnsTextWithDimEscSequence) {
+    pl_add_meta (it, "year", "1980");
+    char *bc = tf_compile ("$cut(<%year%>,4)");
     ctx.flags |= DDB_TF_CONTEXT_TEXT_DIM;
     tf_eval (&ctx, bc, buffer, 1000);
     ctx.flags &= ~DDB_TF_CONTEXT_TEXT_DIM;
     tf_free (bc);
-    EXPECT_TRUE(ctx.dimmed);
-    EXPECT_STREQ(buffer, "\0331;-1m1980\0331;1m");
+    EXPECT_TRUE (ctx.dimmed);
+    EXPECT_STREQ (buffer, "\0331;-1m1980\0331;1m");
 }
 
-TEST_F(TitleFormattingTests, test_BrightenTextExpression_ReturnsTextWithBrightenEscSequence) {
-    char *bc = tf_compile(">>>brighten this text<<<");
+TEST_F (TitleFormattingTests, test_BrightenTextExpression_ReturnsTextWithBrightenEscSequence) {
+    char *bc = tf_compile (">>>brighten this text<<<");
     ctx.flags |= DDB_TF_CONTEXT_TEXT_DIM;
     tf_eval (&ctx, bc, buffer, 1000);
     ctx.flags &= ~DDB_TF_CONTEXT_TEXT_DIM;
     tf_free (bc);
-    EXPECT_TRUE(ctx.dimmed);
-    EXPECT_TRUE(!strcmp (buffer, "\0331;3mbrighten this text\0331;-3m"));
+    EXPECT_TRUE (ctx.dimmed);
+    EXPECT_TRUE (!strcmp (buffer, "\0331;3mbrighten this text\0331;-3m"));
 }
 
-TEST_F(TitleFormattingTests, test_BrightenInfiniteLengthTextExpression_ReturnsTextWithBrightenEscSequence) {
-    plt_set_item_duration(NULL, it, -1);
-    char *bc = tf_compile("xxx>>>aaa%length%bbb<<<yyy");
+TEST_F (TitleFormattingTests, test_BrightenInfiniteLengthTextExpression_ReturnsTextWithBrightenEscSequence) {
+    plt_set_item_duration (NULL, it, -1);
+    char *bc = tf_compile ("xxx>>>aaa%length%bbb<<<yyy");
     ctx.flags |= DDB_TF_CONTEXT_TEXT_DIM;
     tf_eval (&ctx, bc, buffer, 1000);
     ctx.flags &= ~DDB_TF_CONTEXT_TEXT_DIM;
     tf_free (bc);
-    EXPECT_TRUE(ctx.dimmed);
-    EXPECT_TRUE(!strcmp (buffer, "xxx\0331;3maaabbb\0331;-3myyy"));
+    EXPECT_TRUE (ctx.dimmed);
+    EXPECT_TRUE (!strcmp (buffer, "xxx\0331;3maaabbb\0331;-3myyy"));
 }
 
-TEST_F(TitleFormattingTests, test_0_7_2_ContextSizeCheck_ReturnsResult) {
-    char *bc = tf_compile("test");
+TEST_F (TitleFormattingTests, test_0_7_2_ContextSizeCheck_ReturnsResult) {
+    char *bc = tf_compile ("test");
     ctx._size = (int)((char *)&ctx.dimmed - (char *)&ctx);
     tf_eval (&ctx, bc, buffer, 1000);
     ctx._size = sizeof (ctx);
-    EXPECT_TRUE(!strcmp (buffer, "test"));
+    EXPECT_TRUE (!strcmp (buffer, "test"));
 }
 
-TEST_F(TitleFormattingTests, test_InvalidContextSizeCheck_ReturnsEmpty) {
-    char *bc = tf_compile("test");
+TEST_F (TitleFormattingTests, test_InvalidContextSizeCheck_ReturnsEmpty) {
+    char *bc = tf_compile ("test");
     ctx._size = (int)((char *)&ctx.dimmed - (char *)&ctx - 1);
     tf_eval (&ctx, bc, buffer, 1000);
     ctx._size = sizeof (ctx);
-    EXPECT_STREQ(buffer, "");
+    EXPECT_STREQ (buffer, "");
 }
 
-TEST_F(TitleFormattingTests, test_PadHelloWith5_GivesHello) {
-    char *bc = tf_compile("$pad(Hello,5)");
+TEST_F (TitleFormattingTests, test_PadHelloWith5_GivesHello) {
+    char *bc = tf_compile ("$pad(Hello,5)");
     tf_eval (&ctx, bc, buffer, 1000);
     tf_free (bc);
-    EXPECT_TRUE(!strcmp (buffer, "Hello"));
+    EXPECT_TRUE (!strcmp (buffer, "Hello"));
 }
 
-TEST_F(TitleFormattingTests, test_PadHelloWith5Xs_GivesHello) {
-    char *bc = tf_compile("$pad(Hello,5,X)");
+TEST_F (TitleFormattingTests, test_PadHelloWith5Xs_GivesHello) {
+    char *bc = tf_compile ("$pad(Hello,5,X)");
     tf_eval (&ctx, bc, buffer, 1000);
     tf_free (bc);
-    EXPECT_TRUE(!strcmp (buffer, "Hello"));
+    EXPECT_TRUE (!strcmp (buffer, "Hello"));
 }
 
-TEST_F(TitleFormattingTests, test_PadHelloWith10_Gives_Hello_____) {
-    char *bc = tf_compile("$pad(Hello,10)");
+TEST_F (TitleFormattingTests, test_PadHelloWith10_Gives_Hello_____) {
+    char *bc = tf_compile ("$pad(Hello,10)");
     tf_eval (&ctx, bc, buffer, 1000);
     tf_free (bc);
-    EXPECT_TRUE(!strcmp (buffer, "Hello     "));
+    EXPECT_TRUE (!strcmp (buffer, "Hello     "));
 }
 
-TEST_F(TitleFormattingTests, test_PadHelloWith10Xs_GivesHelloXXXXX) {
-    char *bc = tf_compile("$pad(Hello,10,X)");
+TEST_F (TitleFormattingTests, test_PadHelloWith10Xs_GivesHelloXXXXX) {
+    char *bc = tf_compile ("$pad(Hello,10,X)");
     tf_eval (&ctx, bc, buffer, 1000);
     tf_free (bc);
-    EXPECT_TRUE(!strcmp (buffer, "HelloXXXXX"));
+    EXPECT_TRUE (!strcmp (buffer, "HelloXXXXX"));
 }
 
-TEST_F(TitleFormattingTests, test_PadHelloWith10XYs_GivesHelloXXXXX) {
-    char *bc = tf_compile("$pad(Hello,10,XY)");
+TEST_F (TitleFormattingTests, test_PadHelloWith10XYs_GivesHelloXXXXX) {
+    char *bc = tf_compile ("$pad(Hello,10,XY)");
     tf_eval (&ctx, bc, buffer, 1000);
     tf_free (bc);
-    EXPECT_TRUE(!strcmp (buffer, "HelloXXXXX"));
+    EXPECT_TRUE (!strcmp (buffer, "HelloXXXXX"));
 }
 
-TEST_F(TitleFormattingTests, test_PadUnicodeStringWith10UnicodeChars_GivesExpectedOutput) {
-    char *bc = tf_compile("$pad(АБВГД,10,Ё)");
+TEST_F (TitleFormattingTests, test_PadUnicodeStringWith10UnicodeChars_GivesExpectedOutput) {
+    char *bc = tf_compile ("$pad(АБВГД,10,Ё)");
     tf_eval (&ctx, bc, buffer, 1000);
     tf_free (bc);
-    EXPECT_TRUE(!strcmp (buffer, "АБВГДЁЁЁЁЁ"));
+    EXPECT_TRUE (!strcmp (buffer, "АБВГДЁЁЁЁЁ"));
 }
 
-TEST_F(TitleFormattingTests, test_PadRightHelloWith5_GivesHello) {
-    char *bc = tf_compile("$pad_right(Hello,5)");
+TEST_F (TitleFormattingTests, test_PadRightHelloWith5_GivesHello) {
+    char *bc = tf_compile ("$pad_right(Hello,5)");
     tf_eval (&ctx, bc, buffer, 1000);
     tf_free (bc);
-    EXPECT_TRUE(!strcmp (buffer, "Hello"));
+    EXPECT_TRUE (!strcmp (buffer, "Hello"));
 }
 
-TEST_F(TitleFormattingTests, test_PadRightHelloWith5Xs_GivesHello) {
-    char *bc = tf_compile("$pad_right(Hello,5,X)");
+TEST_F (TitleFormattingTests, test_PadRightHelloWith5Xs_GivesHello) {
+    char *bc = tf_compile ("$pad_right(Hello,5,X)");
     tf_eval (&ctx, bc, buffer, 1000);
     tf_free (bc);
-    EXPECT_TRUE(!strcmp (buffer, "Hello"));
+    EXPECT_TRUE (!strcmp (buffer, "Hello"));
 }
 
-TEST_F(TitleFormattingTests, test_PadRightHelloWith10_Gives______Hello) {
-    char *bc = tf_compile("$pad_right(Hello,10)");
+TEST_F (TitleFormattingTests, test_PadRightHelloWith10_Gives______Hello) {
+    char *bc = tf_compile ("$pad_right(Hello,10)");
     tf_eval (&ctx, bc, buffer, 1000);
     tf_free (bc);
-    EXPECT_TRUE(!strcmp (buffer, "     Hello"));
+    EXPECT_TRUE (!strcmp (buffer, "     Hello"));
 }
 
-TEST_F(TitleFormattingTests, test_PadRightHelloWith10Xs_GivesXXXXXHello) {
-    char *bc = tf_compile("$pad_right(Hello,10,X)");
+TEST_F (TitleFormattingTests, test_PadRightHelloWith10Xs_GivesXXXXXHello) {
+    char *bc = tf_compile ("$pad_right(Hello,10,X)");
     tf_eval (&ctx, bc, buffer, 1000);
     tf_free (bc);
-    EXPECT_TRUE(!strcmp (buffer, "XXXXXHello"));
+    EXPECT_TRUE (!strcmp (buffer, "XXXXXHello"));
 }
 
-TEST_F(TitleFormattingTests, test_PadRightHelloWith10XYs_GivesXXXXXHello) {
-    char *bc = tf_compile("$pad_right(Hello,10,XY)");
+TEST_F (TitleFormattingTests, test_PadRightHelloWith10XYs_GivesXXXXXHello) {
+    char *bc = tf_compile ("$pad_right(Hello,10,XY)");
     tf_eval (&ctx, bc, buffer, 1000);
     tf_free (bc);
-    EXPECT_TRUE(!strcmp (buffer, "XXXXXHello"));
+    EXPECT_TRUE (!strcmp (buffer, "XXXXXHello"));
 }
 
-TEST_F(TitleFormattingTests, test_PadRightUnicodeStringWith10UnicodeChars_GivesExpectedOutput) {
-    char *bc = tf_compile("$pad_right(АБВГД,10,Ё)");
+TEST_F (TitleFormattingTests, test_PadRightUnicodeStringWith10UnicodeChars_GivesExpectedOutput) {
+    char *bc = tf_compile ("$pad_right(АБВГД,10,Ё)");
     tf_eval (&ctx, bc, buffer, 1000);
     tf_free (bc);
-    EXPECT_TRUE(!strcmp (buffer, "ЁЁЁЁЁАБВГД"));
+    EXPECT_TRUE (!strcmp (buffer, "ЁЁЁЁЁАБВГД"));
 }
 
-TEST_F(TitleFormattingTests, test_StripPrefix_NoArgs_Fail) {
-    char *bc = tf_compile("$stripprefix()");
+TEST_F (TitleFormattingTests, test_StripPrefix_NoArgs_Fail) {
+    char *bc = tf_compile ("$stripprefix()");
     tf_eval (&ctx, bc, buffer, 1000);
     tf_free (bc);
-    EXPECT_TRUE(!strcmp (buffer, ""));
+    EXPECT_TRUE (!strcmp (buffer, ""));
 }
 
-TEST_F(TitleFormattingTests, test_StripPrefix_NoArticle_PassThrough) {
-    char *bc = tf_compile("$stripprefix(Hello)");
+TEST_F (TitleFormattingTests, test_StripPrefix_NoArticle_PassThrough) {
+    char *bc = tf_compile ("$stripprefix(Hello)");
     tf_eval (&ctx, bc, buffer, 1000);
     tf_free (bc);
-    EXPECT_TRUE(!strcmp (buffer, "Hello"));
+    EXPECT_TRUE (!strcmp (buffer, "Hello"));
 }
 
-TEST_F(TitleFormattingTests, test_StripPrefix_JoinedA_PassThrough) {
-    char *bc = tf_compile("$stripprefix(AA)");
+TEST_F (TitleFormattingTests, test_StripPrefix_JoinedA_PassThrough) {
+    char *bc = tf_compile ("$stripprefix(AA)");
     tf_eval (&ctx, bc, buffer, 1000);
     tf_free (bc);
-    EXPECT_TRUE(!strcmp (buffer, "AA"));
+    EXPECT_TRUE (!strcmp (buffer, "AA"));
 }
 
-TEST_F(TitleFormattingTests, test_StripPrefix_JoinedThe_PassThrough) {
-    char *bc = tf_compile("$stripprefix(TheThe)");
+TEST_F (TitleFormattingTests, test_StripPrefix_JoinedThe_PassThrough) {
+    char *bc = tf_compile ("$stripprefix(TheThe)");
     tf_eval (&ctx, bc, buffer, 1000);
     tf_free (bc);
-    EXPECT_TRUE(!strcmp (buffer, "TheThe"));
+    EXPECT_TRUE (!strcmp (buffer, "TheThe"));
 }
 
-TEST_F(TitleFormattingTests, test_StripPrefix_MultipleA_OneStripped) {
-    char *bc = tf_compile("$stripprefix(A A)");
+TEST_F (TitleFormattingTests, test_StripPrefix_MultipleA_OneStripped) {
+    char *bc = tf_compile ("$stripprefix(A A)");
     tf_eval (&ctx, bc, buffer, 1000);
     tf_free (bc);
-    EXPECT_TRUE(!strcmp (buffer, "A"));
+    EXPECT_TRUE (!strcmp (buffer, "A"));
 }
 
-TEST_F(TitleFormattingTests, test_StripPrefix_MultipleThe_OneStripped) {
-    char *bc = tf_compile("$stripprefix(The The)");
+TEST_F (TitleFormattingTests, test_StripPrefix_MultipleThe_OneStripped) {
+    char *bc = tf_compile ("$stripprefix(The The)");
     tf_eval (&ctx, bc, buffer, 1000);
     tf_free (bc);
-    EXPECT_TRUE(!strcmp (buffer, "The"));
+    EXPECT_TRUE (!strcmp (buffer, "The"));
 }
 
-TEST_F(TitleFormattingTests, test_StripPrefix_MultipleSpaces_AllSpacesSkipped) {
-    char *bc = tf_compile("$stripprefix(A  Word)");
+TEST_F (TitleFormattingTests, test_StripPrefix_MultipleSpaces_AllSpacesSkipped) {
+    char *bc = tf_compile ("$stripprefix(A  Word)");
     tf_eval (&ctx, bc, buffer, 1000);
     tf_free (bc);
-    EXPECT_TRUE(!strcmp (buffer, " Word"));
+    EXPECT_TRUE (!strcmp (buffer, " Word"));
 }
 
-TEST_F(TitleFormattingTests, test_StripPrefix_CustomPrefixList_PrefixStripped) {
-    char *bc = tf_compile("$stripprefix(Some Word,The,A,Some,Word)");
+TEST_F (TitleFormattingTests, test_StripPrefix_CustomPrefixList_PrefixStripped) {
+    char *bc = tf_compile ("$stripprefix(Some Word,The,A,Some,Word)");
     tf_eval (&ctx, bc, buffer, 1000);
     tf_free (bc);
-    EXPECT_TRUE(!strcmp (buffer, "Word"));
+    EXPECT_TRUE (!strcmp (buffer, "Word"));
 }
 
-TEST_F(TitleFormattingTests, test_SwapPrefix_NoArticle_PassThrough) {
-    char *bc = tf_compile("$swapprefix(Hello)");
+TEST_F (TitleFormattingTests, test_SwapPrefix_NoArticle_PassThrough) {
+    char *bc = tf_compile ("$swapprefix(Hello)");
     tf_eval (&ctx, bc, buffer, 1000);
     tf_free (bc);
-    EXPECT_TRUE(!strcmp (buffer, "Hello"));
+    EXPECT_TRUE (!strcmp (buffer, "Hello"));
 }
 
-TEST_F(TitleFormattingTests, test_SwapPrefix_JoinedA_PassThrough) {
-    char *bc = tf_compile("$swapprefix(AA)");
+TEST_F (TitleFormattingTests, test_SwapPrefix_JoinedA_PassThrough) {
+    char *bc = tf_compile ("$swapprefix(AA)");
     tf_eval (&ctx, bc, buffer, 1000);
     tf_free (bc);
-    EXPECT_TRUE(!strcmp (buffer, "AA"));
+    EXPECT_TRUE (!strcmp (buffer, "AA"));
 }
 
-TEST_F(TitleFormattingTests, test_SwapPrefix_JoinedThe_PassThrough) {
-    char *bc = tf_compile("$swapprefix(TheThe)");
+TEST_F (TitleFormattingTests, test_SwapPrefix_JoinedThe_PassThrough) {
+    char *bc = tf_compile ("$swapprefix(TheThe)");
     tf_eval (&ctx, bc, buffer, 1000);
     tf_free (bc);
-    EXPECT_TRUE(!strcmp (buffer, "TheThe"));
+    EXPECT_TRUE (!strcmp (buffer, "TheThe"));
 }
 
-TEST_F(TitleFormattingTests, test_SwapPrefix_MultipleA_CommaAdded) {
-    char *bc = tf_compile("$swapprefix(A A)");
+TEST_F (TitleFormattingTests, test_SwapPrefix_MultipleA_CommaAdded) {
+    char *bc = tf_compile ("$swapprefix(A A)");
     tf_eval (&ctx, bc, buffer, 1000);
     tf_free (bc);
-    EXPECT_TRUE(!strcmp (buffer, "A, A"));
+    EXPECT_TRUE (!strcmp (buffer, "A, A"));
 }
 
-TEST_F(TitleFormattingTests, test_SwapPrefix_MultipleThe_CommaAdded) {
-    char *bc = tf_compile("$swapprefix(The The)");
+TEST_F (TitleFormattingTests, test_SwapPrefix_MultipleThe_CommaAdded) {
+    char *bc = tf_compile ("$swapprefix(The The)");
     tf_eval (&ctx, bc, buffer, 1000);
     tf_free (bc);
-    EXPECT_TRUE(!strcmp (buffer, "The, The"));
+    EXPECT_TRUE (!strcmp (buffer, "The, The"));
 }
 
-TEST_F(TitleFormattingTests, test_SwapPrefix_MultipleSpaces_SpacePreservedWithComma) {
-    char *bc = tf_compile("$swapprefix(A  Word)");
+TEST_F (TitleFormattingTests, test_SwapPrefix_MultipleSpaces_SpacePreservedWithComma) {
+    char *bc = tf_compile ("$swapprefix(A  Word)");
     tf_eval (&ctx, bc, buffer, 1000);
     tf_free (bc);
-    EXPECT_TRUE(!strcmp (buffer, " Word, A"));
+    EXPECT_TRUE (!strcmp (buffer, " Word, A"));
 }
 
-TEST_F(TitleFormattingTests, test_SwapPrefix_CustomPrefixList_PrefixSwapped) {
-    char *bc = tf_compile("$swapprefix(Some Word,The,A,Some,Word)");
+TEST_F (TitleFormattingTests, test_SwapPrefix_CustomPrefixList_PrefixSwapped) {
+    char *bc = tf_compile ("$swapprefix(Some Word,The,A,Some,Word)");
     tf_eval (&ctx, bc, buffer, 1000);
     tf_free (bc);
-    EXPECT_TRUE(!strcmp (buffer, "Word, Some"));
+    EXPECT_TRUE (!strcmp (buffer, "Word, Some"));
 }
 
-TEST_F(TitleFormattingTests, test_StricmpEqual_ReturnsYes) {
-    char *bc = tf_compile("$if($stricmp(AbCd,AbCd),YES)");
+TEST_F (TitleFormattingTests, test_StricmpEqual_ReturnsYes) {
+    char *bc = tf_compile ("$if($stricmp(AbCd,AbCd),YES)");
     tf_eval (&ctx, bc, buffer, 1000);
     tf_free (bc);
-    EXPECT_TRUE(!strcmp (buffer, "YES"));
+    EXPECT_TRUE (!strcmp (buffer, "YES"));
 }
 
-TEST_F(TitleFormattingTests, test_StricmpUnequal_ReturnsEmpty) {
-    char *bc = tf_compile("$if($stricmp(AbCd,EfGh),YES)");
+TEST_F (TitleFormattingTests, test_StricmpUnequal_ReturnsEmpty) {
+    char *bc = tf_compile ("$if($stricmp(AbCd,EfGh),YES)");
     tf_eval (&ctx, bc, buffer, 1000);
     tf_free (bc);
-    EXPECT_TRUE(!strcmp (buffer, ""));
+    EXPECT_TRUE (!strcmp (buffer, ""));
 }
 
-TEST_F(TitleFormattingTests, test_StricmpEqualWithDifferentCase_ReturnsYES) {
-    char *bc = tf_compile("$if($stricmp(ABCD,abcd),YES)");
+TEST_F (TitleFormattingTests, test_StricmpEqualWithDifferentCase_ReturnsYES) {
+    char *bc = tf_compile ("$if($stricmp(ABCD,abcd),YES)");
     tf_eval (&ctx, bc, buffer, 1000);
     tf_free (bc);
-    EXPECT_TRUE(!strcmp (buffer, "YES"));
+    EXPECT_TRUE (!strcmp (buffer, "YES"));
 }
 
-TEST_F(TitleFormattingTests, test_Len2AsciiChars_ReturnsNumberOfChars) {
-    char *bc = tf_compile("$len2(ABCDE)");
+TEST_F (TitleFormattingTests, test_Len2AsciiChars_ReturnsNumberOfChars) {
+    char *bc = tf_compile ("$len2(ABCDE)");
     tf_eval (&ctx, bc, buffer, 1000);
     tf_free (bc);
-    EXPECT_TRUE(!strcmp (buffer, "5"));
+    EXPECT_TRUE (!strcmp (buffer, "5"));
 }
 
-TEST_F(TitleFormattingTests, test_Len2UnicodeSingleWidthChars_ReturnsNumberOfChars) {
-    char *bc = tf_compile("$len2(АБВГД)");
+TEST_F (TitleFormattingTests, test_Len2UnicodeSingleWidthChars_ReturnsNumberOfChars) {
+    char *bc = tf_compile ("$len2(АБВГД)");
     tf_eval (&ctx, bc, buffer, 1000);
     tf_free (bc);
-    EXPECT_TRUE(!strcmp (buffer, "5"));
+    EXPECT_TRUE (!strcmp (buffer, "5"));
 }
 
-TEST_F(TitleFormattingTests, test_Len2UnicodeDoubleWidthChars_ReturnsNumberOfCharsDoubled) {
-    char *bc = tf_compile("$len2(全形)");
+TEST_F (TitleFormattingTests, test_Len2UnicodeDoubleWidthChars_ReturnsNumberOfCharsDoubled) {
+    char *bc = tf_compile ("$len2(全形)");
     tf_eval (&ctx, bc, buffer, 1000);
     tf_free (bc);
-    EXPECT_TRUE(!strcmp (buffer, "4"));
+    EXPECT_TRUE (!strcmp (buffer, "4"));
 }
 
-TEST_F(TitleFormattingTests, test_ShortestFirst_ReturnsFirst) {
-    char *bc = tf_compile("$shortest(1,22,333)");
+TEST_F (TitleFormattingTests, test_ShortestFirst_ReturnsFirst) {
+    char *bc = tf_compile ("$shortest(1,22,333)");
     tf_eval (&ctx, bc, buffer, 1000);
     tf_free (bc);
-    EXPECT_TRUE(!strcmp (buffer, "1"));
+    EXPECT_TRUE (!strcmp (buffer, "1"));
 }
 
-TEST_F(TitleFormattingTests, test_ShortestLast_ReturnsLast) {
-    char *bc = tf_compile("$shortest(333,22,1)");
+TEST_F (TitleFormattingTests, test_ShortestLast_ReturnsLast) {
+    char *bc = tf_compile ("$shortest(333,22,1)");
     tf_eval (&ctx, bc, buffer, 1000);
     tf_free (bc);
-    EXPECT_TRUE(!strcmp (buffer, "1"));
+    EXPECT_TRUE (!strcmp (buffer, "1"));
 }
 
-TEST_F(TitleFormattingTests, test_ShortestMid_ReturnsMid) {
-    char *bc = tf_compile("$shortest(333,1,22)");
+TEST_F (TitleFormattingTests, test_ShortestMid_ReturnsMid) {
+    char *bc = tf_compile ("$shortest(333,1,22)");
     tf_eval (&ctx, bc, buffer, 1000);
     tf_free (bc);
-    EXPECT_TRUE(!strcmp (buffer, "1"));
+    EXPECT_TRUE (!strcmp (buffer, "1"));
 }
 
-TEST_F(TitleFormattingTests, test_LongestFirst_ReturnsFirst) {
-    char *bc = tf_compile("$longest(333,22,1)");
+TEST_F (TitleFormattingTests, test_LongestFirst_ReturnsFirst) {
+    char *bc = tf_compile ("$longest(333,22,1)");
     tf_eval (&ctx, bc, buffer, 1000);
     tf_free (bc);
-    EXPECT_TRUE(!strcmp (buffer, "333"));
+    EXPECT_TRUE (!strcmp (buffer, "333"));
 }
 
-TEST_F(TitleFormattingTests, test_LongestLast_ReturnsLast) {
-    char *bc = tf_compile("$longest(1,22,333)");
+TEST_F (TitleFormattingTests, test_LongestLast_ReturnsLast) {
+    char *bc = tf_compile ("$longest(1,22,333)");
     tf_eval (&ctx, bc, buffer, 1000);
     tf_free (bc);
-    EXPECT_TRUE(!strcmp (buffer, "333"));
+    EXPECT_TRUE (!strcmp (buffer, "333"));
 }
 
-TEST_F(TitleFormattingTests, test_LongestMid_ReturnsMid) {
-    char *bc = tf_compile("$longest(1,333,22)");
+TEST_F (TitleFormattingTests, test_LongestMid_ReturnsMid) {
+    char *bc = tf_compile ("$longest(1,333,22)");
     tf_eval (&ctx, bc, buffer, 1000);
     tf_free (bc);
-    EXPECT_TRUE(!strcmp (buffer, "333"));
+    EXPECT_TRUE (!strcmp (buffer, "333"));
 }
 
-TEST_F(TitleFormattingTests, test_LongerFirst_ReturnsTrue) {
-    char *bc = tf_compile("$if($longer(22,1),true,false)");
+TEST_F (TitleFormattingTests, test_LongerFirst_ReturnsTrue) {
+    char *bc = tf_compile ("$if($longer(22,1),true,false)");
     tf_eval (&ctx, bc, buffer, 1000);
     tf_free (bc);
-    EXPECT_TRUE(!strcmp (buffer, "true"));
+    EXPECT_TRUE (!strcmp (buffer, "true"));
 }
 
-TEST_F(TitleFormattingTests, test_LongerSecond_ReturnsFalse) {
-    char *bc = tf_compile("$if($longer(1,22),true,false)");
+TEST_F (TitleFormattingTests, test_LongerSecond_ReturnsFalse) {
+    char *bc = tf_compile ("$if($longer(1,22),true,false)");
     tf_eval (&ctx, bc, buffer, 1000);
     tf_free (bc);
-    EXPECT_TRUE(!strcmp (buffer, "false"));
+    EXPECT_TRUE (!strcmp (buffer, "false"));
 }
 
-TEST_F(TitleFormattingTests, test_PadcutStrLonger_ReturnsHeadOfStr) {
-    char *bc = tf_compile("$padcut(Hello,3)");
+TEST_F (TitleFormattingTests, test_PadcutStrLonger_ReturnsHeadOfStr) {
+    char *bc = tf_compile ("$padcut(Hello,3)");
     tf_eval (&ctx, bc, buffer, 1000);
     tf_free (bc);
-    EXPECT_TRUE(!strcmp (buffer, "Hel"));
+    EXPECT_TRUE (!strcmp (buffer, "Hel"));
 }
 
-
-TEST_F(TitleFormattingTests, test_PadcutStrShorter_ReturnsPaddedStr) {
-    char *bc = tf_compile("$padcut(Hello,8)");
+TEST_F (TitleFormattingTests, test_PadcutStrShorter_ReturnsPaddedStr) {
+    char *bc = tf_compile ("$padcut(Hello,8)");
     tf_eval (&ctx, bc, buffer, 1000);
     tf_free (bc);
-    EXPECT_TRUE(!strcmp (buffer, "Hello   "));
+    EXPECT_TRUE (!strcmp (buffer, "Hello   "));
 }
 
-
-TEST_F(TitleFormattingTests, test_PadcutStrCharLonger_ReturnsHeadOfStr) {
-    char *bc = tf_compile("$padcut(Hello,3,x)");
+TEST_F (TitleFormattingTests, test_PadcutStrCharLonger_ReturnsHeadOfStr) {
+    char *bc = tf_compile ("$padcut(Hello,3,x)");
     tf_eval (&ctx, bc, buffer, 1000);
     tf_free (bc);
-    EXPECT_TRUE(!strcmp (buffer, "Hel"));
+    EXPECT_TRUE (!strcmp (buffer, "Hel"));
 }
 
-TEST_F(TitleFormattingTests, test_PadcutStrCharShorter_ReturnsPaddedStr) {
-    char *bc = tf_compile("$padcut(Hello,8,x)");
+TEST_F (TitleFormattingTests, test_PadcutStrCharShorter_ReturnsPaddedStr) {
+    char *bc = tf_compile ("$padcut(Hello,8,x)");
     tf_eval (&ctx, bc, buffer, 1000);
     tf_free (bc);
-    EXPECT_TRUE(!strcmp (buffer, "Helloxxx"));
+    EXPECT_TRUE (!strcmp (buffer, "Helloxxx"));
 }
 
-TEST_F(TitleFormattingTests, test_PadcutRightStrLonger_ReturnsHeadOfStr) {
-    char *bc = tf_compile("$padcut_right(Hello,3)");
+TEST_F (TitleFormattingTests, test_PadcutRightStrLonger_ReturnsHeadOfStr) {
+    char *bc = tf_compile ("$padcut_right(Hello,3)");
     tf_eval (&ctx, bc, buffer, 1000);
     tf_free (bc);
-    EXPECT_TRUE(!strcmp (buffer, "Hel"));
+    EXPECT_TRUE (!strcmp (buffer, "Hel"));
 }
-
 
-TEST_F(TitleFormattingTests, test_PadcutRightStrShorter_ReturnsPaddedStr) {
-    char *bc = tf_compile("$padcut_right(Hello,8)");
+TEST_F (TitleFormattingTests, test_PadcutRightStrShorter_ReturnsPaddedStr) {
+    char *bc = tf_compile ("$padcut_right(Hello,8)");
     tf_eval (&ctx, bc, buffer, 1000);
     tf_free (bc);
-    EXPECT_TRUE(!strcmp (buffer, "   Hello"));
+    EXPECT_TRUE (!strcmp (buffer, "   Hello"));
 }
 
-
-TEST_F(TitleFormattingTests, test_PadcutRightStrCharLonger_ReturnsHeadOfStr) {
-    char *bc = tf_compile("$padcut_right(Hello,3,x)");
+TEST_F (TitleFormattingTests, test_PadcutRightStrCharLonger_ReturnsHeadOfStr) {
+    char *bc = tf_compile ("$padcut_right(Hello,3,x)");
     tf_eval (&ctx, bc, buffer, 1000);
     tf_free (bc);
-    EXPECT_TRUE(!strcmp (buffer, "Hel"));
+    EXPECT_TRUE (!strcmp (buffer, "Hel"));
 }
 
-TEST_F(TitleFormattingTests, test_PadcutRightStrCharShorter_ReturnsPaddedStr) {
-    char *bc = tf_compile("$padcut_right(Hello,8,x)");
+TEST_F (TitleFormattingTests, test_PadcutRightStrCharShorter_ReturnsPaddedStr) {
+    char *bc = tf_compile ("$padcut_right(Hello,8,x)");
     tf_eval (&ctx, bc, buffer, 1000);
     tf_free (bc);
-    EXPECT_TRUE(!strcmp (buffer, "xxxHello"));
+    EXPECT_TRUE (!strcmp (buffer, "xxxHello"));
 }
 
-TEST_F(TitleFormattingTests, test_ProgressPos0Range100Len10_ReturnsBar10CharsWithKnobAt0) {
-    char *bc = tf_compile("$progress(0,100,10,x,=)");
+TEST_F (TitleFormattingTests, test_ProgressPos0Range100Len10_ReturnsBar10CharsWithKnobAt0) {
+    char *bc = tf_compile ("$progress(0,100,10,x,=)");
     tf_eval (&ctx, bc, buffer, 1000);
     tf_free (bc);
-    EXPECT_TRUE(!strcmp (buffer, "x========="));
+    EXPECT_TRUE (!strcmp (buffer, "x========="));
 }
 
-TEST_F(TitleFormattingTests, test_ProgressPos100Range100Len10_ReturnsBar10CharsWithKnobAt9) {
-    char *bc = tf_compile("$progress(100,100,10,x,=)");
+TEST_F (TitleFormattingTests, test_ProgressPos100Range100Len10_ReturnsBar10CharsWithKnobAt9) {
+    char *bc = tf_compile ("$progress(100,100,10,x,=)");
     tf_eval (&ctx, bc, buffer, 1000);
     tf_free (bc);
-    EXPECT_TRUE(!strcmp (buffer, "=========x"));
+    EXPECT_TRUE (!strcmp (buffer, "=========x"));
 }
 
-TEST_F(TitleFormattingTests, test_ProgressPos50Range100Len10_ReturnsBar10CharsWithKnobAt5) {
-    char *bc = tf_compile("$progress(50,100,10,x,=)");
+TEST_F (TitleFormattingTests, test_ProgressPos50Range100Len10_ReturnsBar10CharsWithKnobAt5) {
+    char *bc = tf_compile ("$progress(50,100,10,x,=)");
     tf_eval (&ctx, bc, buffer, 1000);
     tf_free (bc);
-    EXPECT_TRUE(!strcmp (buffer, "=====x===="));
+    EXPECT_TRUE (!strcmp (buffer, "=====x===="));
 }
 
-TEST_F(TitleFormattingTests, test_ProgressRange0_ReturnsEmpty) {
-    char *bc = tf_compile("$progress(5,0,10,x,=)");
+TEST_F (TitleFormattingTests, test_ProgressRange0_ReturnsEmpty) {
+    char *bc = tf_compile ("$progress(5,0,10,x,=)");
     tf_eval (&ctx, bc, buffer, 1000);
     tf_free (bc);
-    EXPECT_TRUE(!strcmp (buffer, "=========x"));
+    EXPECT_TRUE (!strcmp (buffer, "=========x"));
 }
 
-TEST_F(TitleFormattingTests, test_ProgressLen0_ReturnsEmpty) {
-    char *bc = tf_compile("$progress(5,100,0,x,=)");
+TEST_F (TitleFormattingTests, test_ProgressLen0_ReturnsEmpty) {
+    char *bc = tf_compile ("$progress(5,100,0,x,=)");
     tf_eval (&ctx, bc, buffer, 1000);
     tf_free (bc);
-    EXPECT_TRUE(!strcmp (buffer, ""));
+    EXPECT_TRUE (!strcmp (buffer, ""));
 }
 
-TEST_F(TitleFormattingTests, test_ProgressCharEmpty_ReturnsEmpty) {
-    char *bc = tf_compile("$progress(5,100,0,x,)");
+TEST_F (TitleFormattingTests, test_ProgressCharEmpty_ReturnsEmpty) {
+    char *bc = tf_compile ("$progress(5,100,0,x,)");
     tf_eval (&ctx, bc, buffer, 1000);
     tf_free (bc);
-    EXPECT_TRUE(!strcmp (buffer, ""));
+    EXPECT_TRUE (!strcmp (buffer, ""));
 }
 
-TEST_F(TitleFormattingTests, test_ProgressKnobEmpty_ReturnsEmpty) {
-    char *bc = tf_compile("$progress(5,100,0,,=)");
+TEST_F (TitleFormattingTests, test_ProgressKnobEmpty_ReturnsEmpty) {
+    char *bc = tf_compile ("$progress(5,100,0,,=)");
     tf_eval (&ctx, bc, buffer, 1000);
     tf_free (bc);
-    EXPECT_TRUE(!strcmp (buffer, ""));
+    EXPECT_TRUE (!strcmp (buffer, ""));
 }
 
-TEST_F(TitleFormattingTests, test_ProgressRangeEmpty_ReturnsEmpty) {
-    char *bc = tf_compile("$progress(5,,0,x,=)");
+TEST_F (TitleFormattingTests, test_ProgressRangeEmpty_ReturnsEmpty) {
+    char *bc = tf_compile ("$progress(5,,0,x,=)");
     tf_eval (&ctx, bc, buffer, 1000);
     tf_free (bc);
-    EXPECT_TRUE(!strcmp (buffer, ""));
+    EXPECT_TRUE (!strcmp (buffer, ""));
 }
 
-TEST_F(TitleFormattingTests, test_ProgressAllArgsEmpty_ReturnsEmpty) {
-    char *bc = tf_compile("$progress(,,,,)");
+TEST_F (TitleFormattingTests, test_ProgressAllArgsEmpty_ReturnsEmpty) {
+    char *bc = tf_compile ("$progress(,,,,)");
     tf_eval (&ctx, bc, buffer, 1000);
     tf_free (bc);
-    EXPECT_TRUE(!strcmp (buffer, ""));
+    EXPECT_TRUE (!strcmp (buffer, ""));
 }
 
-TEST_F(TitleFormattingTests, test_Progress2Pos3Range5Len5WithUnicodeChars_ReturnsBar5CharsWithKnobAt3) {
-    char *bc = tf_compile("$progress2(3,5,5,★,☆)");
+TEST_F (TitleFormattingTests, test_Progress2Pos3Range5Len5WithUnicodeChars_ReturnsBar5CharsWithKnobAt3) {
+    char *bc = tf_compile ("$progress2(3,5,5,★,☆)");
     tf_eval (&ctx, bc, buffer, 1000);
     tf_free (bc);
-    EXPECT_TRUE(!strcmp (buffer, "★★★☆☆"));
+    EXPECT_TRUE (!strcmp (buffer, "★★★☆☆"));
 }
 
-TEST_F(TitleFormattingTests, test_Progress2Pos3Range5Len5WithMultpleUnicodeChars_ReturnsBar5CharsWithKnobAt3) {
-    char *bc = tf_compile("$progress2(3,5,5,⏣⌽,⚙︎⌬)");
+TEST_F (TitleFormattingTests, test_Progress2Pos3Range5Len5WithMultpleUnicodeChars_ReturnsBar5CharsWithKnobAt3) {
+    char *bc = tf_compile ("$progress2(3,5,5,⏣⌽,⚙︎⌬)");
     tf_eval (&ctx, bc, buffer, 1000);
     tf_free (bc);
-    EXPECT_TRUE(!strcmp (buffer, "⏣⌽⏣⌽⏣⌽⚙︎⌬⚙︎⌬"));
+    EXPECT_TRUE (!strcmp (buffer, "⏣⌽⏣⌽⏣⌽⚙︎⌬⚙︎⌬"));
 }
-
 
-TEST_F(TitleFormattingTests, test_Progress2Pos0Range100Len10_ReturnsBar10CharsWithKnobAt0) {
-    char *bc = tf_compile("$progress2(0,100,10,x,=)");
+TEST_F (TitleFormattingTests, test_Progress2Pos0Range100Len10_ReturnsBar10CharsWithKnobAt0) {
+    char *bc = tf_compile ("$progress2(0,100,10,x,=)");
     tf_eval (&ctx, bc, buffer, 1000);
     tf_free (bc);
-    EXPECT_TRUE(!strcmp (buffer, "=========="));
+    EXPECT_TRUE (!strcmp (buffer, "=========="));
 }
 
-TEST_F(TitleFormattingTests, test_Progress2Pos100Range100Len10_ReturnsBar10CharsWithKnobAt9) {
-    char *bc = tf_compile("$progress2(100,100,10,x,=)");
+TEST_F (TitleFormattingTests, test_Progress2Pos100Range100Len10_ReturnsBar10CharsWithKnobAt9) {
+    char *bc = tf_compile ("$progress2(100,100,10,x,=)");
     tf_eval (&ctx, bc, buffer, 1000);
     tf_free (bc);
-    EXPECT_TRUE(!strcmp (buffer, "xxxxxxxxxx"));
+    EXPECT_TRUE (!strcmp (buffer, "xxxxxxxxxx"));
 }
 
-TEST_F(TitleFormattingTests, test_Progress2Pos50Range100Len10_ReturnsBar10CharsWithKnobAt5) {
-    char *bc = tf_compile("$progress2(50,100,10,x,=)");
+TEST_F (TitleFormattingTests, test_Progress2Pos50Range100Len10_ReturnsBar10CharsWithKnobAt5) {
+    char *bc = tf_compile ("$progress2(50,100,10,x,=)");
     tf_eval (&ctx, bc, buffer, 1000);
     tf_free (bc);
-    EXPECT_TRUE(!strcmp (buffer, "xxxxx====="));
+    EXPECT_TRUE (!strcmp (buffer, "xxxxx====="));
 }
 
-TEST_F(TitleFormattingTests, test_Progress2Range0_ReturnsEmpty) {
-    char *bc = tf_compile("$progress2(5,0,10,x,=)");
+TEST_F (TitleFormattingTests, test_Progress2Range0_ReturnsEmpty) {
+    char *bc = tf_compile ("$progress2(5,0,10,x,=)");
     tf_eval (&ctx, bc, buffer, 1000);
     tf_free (bc);
-    EXPECT_TRUE(!strcmp (buffer, "xxxxxxxxxx"));
+    EXPECT_TRUE (!strcmp (buffer, "xxxxxxxxxx"));
 }
 
-TEST_F(TitleFormattingTests, test_Progress2Len0_ReturnsEmpty) {
-    char *bc = tf_compile("$progress2(5,100,0,x,=)");
+TEST_F (TitleFormattingTests, test_Progress2Len0_ReturnsEmpty) {
+    char *bc = tf_compile ("$progress2(5,100,0,x,=)");
     tf_eval (&ctx, bc, buffer, 1000);
     tf_free (bc);
-    EXPECT_TRUE(!strcmp (buffer, ""));
+    EXPECT_TRUE (!strcmp (buffer, ""));
 }
 
-TEST_F(TitleFormattingTests, test_Progress2CharEmpty_ReturnsEmpty) {
-    char *bc = tf_compile("$progress2(5,100,0,x,)");
+TEST_F (TitleFormattingTests, test_Progress2CharEmpty_ReturnsEmpty) {
+    char *bc = tf_compile ("$progress2(5,100,0,x,)");
     tf_eval (&ctx, bc, buffer, 1000);
     tf_free (bc);
-    EXPECT_TRUE(!strcmp (buffer, ""));
+    EXPECT_TRUE (!strcmp (buffer, ""));
 }
 
-TEST_F(TitleFormattingTests, test_Progress2KnobEmpty_ReturnsEmpty) {
-    char *bc = tf_compile("$progress2(5,100,0,,=)");
+TEST_F (TitleFormattingTests, test_Progress2KnobEmpty_ReturnsEmpty) {
+    char *bc = tf_compile ("$progress2(5,100,0,,=)");
     tf_eval (&ctx, bc, buffer, 1000);
     tf_free (bc);
-    EXPECT_TRUE(!strcmp (buffer, ""));
+    EXPECT_TRUE (!strcmp (buffer, ""));
 }
 
-TEST_F(TitleFormattingTests, test_Progress2RangeEmpty_ReturnsEmpty) {
-    char *bc = tf_compile("$progress2(5,,0,x,=)");
+TEST_F (TitleFormattingTests, test_Progress2RangeEmpty_ReturnsEmpty) {
+    char *bc = tf_compile ("$progress2(5,,0,x,=)");
     tf_eval (&ctx, bc, buffer, 1000);
     tf_free (bc);
-    EXPECT_TRUE(!strcmp (buffer, ""));
+    EXPECT_TRUE (!strcmp (buffer, ""));
 }
 
-TEST_F(TitleFormattingTests, test_Progress2AllArgsEmpty_ReturnsEmpty) {
-    char *bc = tf_compile("$progress2(,,,,)");
+TEST_F (TitleFormattingTests, test_Progress2AllArgsEmpty_ReturnsEmpty) {
+    char *bc = tf_compile ("$progress2(,,,,)");
     tf_eval (&ctx, bc, buffer, 1000);
     tf_free (bc);
-    EXPECT_TRUE(!strcmp (buffer, ""));
+    EXPECT_TRUE (!strcmp (buffer, ""));
 }
 
-TEST_F(TitleFormattingTests, test_Right5Chars_ReturnsLast5Chars) {
-    char *bc = tf_compile("$right(ABCDE12345,5)");
+TEST_F (TitleFormattingTests, test_Right5Chars_ReturnsLast5Chars) {
+    char *bc = tf_compile ("$right(ABCDE12345,5)");
     tf_eval (&ctx, bc, buffer, 1000);
     tf_free (bc);
-    EXPECT_TRUE(!strcmp (buffer, "12345"));
+    EXPECT_TRUE (!strcmp (buffer, "12345"));
 }
 
-TEST_F(TitleFormattingTests, test_Right5CharsShortStr_ReturnsWholeStr) {
-    char *bc = tf_compile("$right(ABC,5)");
+TEST_F (TitleFormattingTests, test_Right5CharsShortStr_ReturnsWholeStr) {
+    char *bc = tf_compile ("$right(ABC,5)");
     tf_eval (&ctx, bc, buffer, 1000);
     tf_free (bc);
-    EXPECT_TRUE(!strcmp (buffer, "ABC"));
+    EXPECT_TRUE (!strcmp (buffer, "ABC"));
 }
 
-TEST_F(TitleFormattingTests, test_Roman1_ReturnsI) {
-    char *bc = tf_compile("$roman(1)");
+TEST_F (TitleFormattingTests, test_Roman1_ReturnsI) {
+    char *bc = tf_compile ("$roman(1)");
     tf_eval (&ctx, bc, buffer, 1000);
     tf_free (bc);
-    EXPECT_TRUE(!strcmp (buffer, "I"));
+    EXPECT_TRUE (!strcmp (buffer, "I"));
 }
 
-TEST_F(TitleFormattingTests, test_Roman5_ReturnsV) {
-    char *bc = tf_compile("$roman(5)");
+TEST_F (TitleFormattingTests, test_Roman5_ReturnsV) {
+    char *bc = tf_compile ("$roman(5)");
     tf_eval (&ctx, bc, buffer, 1000);
     tf_free (bc);
-    EXPECT_TRUE(!strcmp (buffer, "V"));
+    EXPECT_TRUE (!strcmp (buffer, "V"));
 }
 
-TEST_F(TitleFormattingTests, test_Roman10_ReturnsX) {
-    char *bc = tf_compile("$roman(10)");
+TEST_F (TitleFormattingTests, test_Roman10_ReturnsX) {
+    char *bc = tf_compile ("$roman(10)");
     tf_eval (&ctx, bc, buffer, 1000);
     tf_free (bc);
-    EXPECT_TRUE(!strcmp (buffer, "X"));
+    EXPECT_TRUE (!strcmp (buffer, "X"));
 }
 
-
-TEST_F(TitleFormattingTests, test_Roman100500_ReturnsEmpty) {
-    char *bc = tf_compile("$roman(100500)");
+TEST_F (TitleFormattingTests, test_Roman100500_ReturnsEmpty) {
+    char *bc = tf_compile ("$roman(100500)");
     tf_eval (&ctx, bc, buffer, 1000);
     tf_free (bc);
-    EXPECT_TRUE(!strcmp (buffer, ""));
+    EXPECT_TRUE (!strcmp (buffer, ""));
 }
 
-TEST_F(TitleFormattingTests, test_Roman51880_Returns_MMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMDCCCLXXX) {
-    char *bc = tf_compile("$roman(51880)");
+TEST_F (TitleFormattingTests, test_Roman51880_Returns_MMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMDCCCLXXX) {
+    char *bc = tf_compile ("$roman(51880)");
     tf_eval (&ctx, bc, buffer, 1000);
     tf_free (bc);
-    EXPECT_TRUE(!strcmp (buffer, "MMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMDCCCLXXX"));
+    EXPECT_TRUE (!strcmp (buffer, "MMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMDCCCLXXX"));
 }
 
-TEST_F(TitleFormattingTests, test_Rot13DeaDBeeF12345_ReturnsQrnQOrrS12345) {
-    char *bc = tf_compile("$rot13(DeaDBeeF12345)");
+TEST_F (TitleFormattingTests, test_Rot13DeaDBeeF12345_ReturnsQrnQOrrS12345) {
+    char *bc = tf_compile ("$rot13(DeaDBeeF12345)");
     tf_eval (&ctx, bc, buffer, 1000);
     tf_free (bc);
-    EXPECT_TRUE(!strcmp (buffer, "QrnQOrrS12345"));
+    EXPECT_TRUE (!strcmp (buffer, "QrnQOrrS12345"));
 }
 
-TEST_F(TitleFormattingTests, test_StrchrDeaDBeeF_B_Returns5) {
-    char *bc = tf_compile("$strchr(DeaDBeeF,B)");
+TEST_F (TitleFormattingTests, test_StrchrDeaDBeeF_B_Returns5) {
+    char *bc = tf_compile ("$strchr(DeaDBeeF,B)");
     tf_eval (&ctx, bc, buffer, 1000);
     tf_free (bc);
-    EXPECT_TRUE(!strcmp (buffer, "5"));
+    EXPECT_TRUE (!strcmp (buffer, "5"));
 }
 
-TEST_F(TitleFormattingTests, test_StrchrDeaDBeeF_R_Returns0) {
-    char *bc = tf_compile("$strchr(DeaDBeeF,R)");
+TEST_F (TitleFormattingTests, test_StrchrDeaDBeeF_R_Returns0) {
+    char *bc = tf_compile ("$strchr(DeaDBeeF,R)");
     tf_eval (&ctx, bc, buffer, 1000);
     tf_free (bc);
-    EXPECT_TRUE(!strcmp (buffer, "0"));
+    EXPECT_TRUE (!strcmp (buffer, "0"));
 }
 
-TEST_F(TitleFormattingTests, test_StrrchrDeaDBeeF_B_Returns4) {
-    char *bc = tf_compile("$strrchr(DeaDBeeF,D)");
+TEST_F (TitleFormattingTests, test_StrrchrDeaDBeeF_B_Returns4) {
+    char *bc = tf_compile ("$strrchr(DeaDBeeF,D)");
     tf_eval (&ctx, bc, buffer, 1000);
     tf_free (bc);
-    EXPECT_TRUE(!strcmp (buffer, "4"));
+    EXPECT_TRUE (!strcmp (buffer, "4"));
 }
 
-TEST_F(TitleFormattingTests, test_StrrchrDeaDBeeF_R_Returns0) {
-    char *bc = tf_compile("$strrchr(DeaDBeeF,R)");
+TEST_F (TitleFormattingTests, test_StrrchrDeaDBeeF_R_Returns0) {
+    char *bc = tf_compile ("$strrchr(DeaDBeeF,R)");
     tf_eval (&ctx, bc, buffer, 1000);
     tf_free (bc);
-    EXPECT_TRUE(!strcmp (buffer, "0"));
+    EXPECT_TRUE (!strcmp (buffer, "0"));
 }
 
-TEST_F(TitleFormattingTests, test_NestingDirectoryInSubstr_HasNoIntermediateTruncation) {
-    pl_replace_meta (it, ":URI", "/media/Icy/Music/Long/Folder/Structure/2019.01.01 [Meta1] Meta2 [Meta3] Meta4 [Meta5] Meta6 [Meta7] Meta8 [Meta9]/some_reasonably_long_path.flac");
-    char *bc = tf_compile("$substr($directory(%path%,1),1,$sub($strstr($directory(%path%,1),' ['),1))");
+TEST_F (TitleFormattingTests, test_NestingDirectoryInSubstr_HasNoIntermediateTruncation) {
+    pl_replace_meta (
+        it,
+        ":URI",
+        "/media/Icy/Music/Long/Folder/Structure/2019.01.01 [Meta1] Meta2 [Meta3] Meta4 [Meta5] Meta6 [Meta7] Meta8 [Meta9]/some_reasonably_long_path.flac");
+    char *bc = tf_compile ("$substr($directory(%path%,1),1,$sub($strstr($directory(%path%,1),' ['),1))");
     tf_eval (&ctx, bc, buffer, 1000);
-    tf_free(bc);
-    EXPECT_TRUE(!strcmp (buffer, "2019.01.01"));
+    tf_free (bc);
+    EXPECT_TRUE (!strcmp (buffer, "2019.01.01"));
 }
 
-TEST_F(TitleFormattingTests, test_Tab_ProducesTabChar) {
+TEST_F (TitleFormattingTests, test_Tab_ProducesTabChar) {
     ctx.flags = DDB_TF_CONTEXT_MULTILINE;
-    char *bc = tf_compile("$tab()");
+    char *bc = tf_compile ("$tab()");
     tf_eval (&ctx, bc, buffer, 1000);
     tf_free (bc);
-    EXPECT_TRUE(!strcmp (buffer, "\t"));
+    EXPECT_TRUE (!strcmp (buffer, "\t"));
 }
 
-TEST_F(TitleFormattingTests, test_Tab5_Produces5TabChars) {
+TEST_F (TitleFormattingTests, test_Tab5_Produces5TabChars) {
     ctx.flags = DDB_TF_CONTEXT_MULTILINE;
-    char *bc = tf_compile("$tab(5)");
+    char *bc = tf_compile ("$tab(5)");
     tf_eval (&ctx, bc, buffer, 1000);
     tf_free (bc);
-    EXPECT_TRUE(!strcmp (buffer, "\t\t\t\t\t"));
+    EXPECT_TRUE (!strcmp (buffer, "\t\t\t\t\t"));
 }
 
-TEST_F(TitleFormattingTests, test_TrimNoLeadingTrailingSpaces_ReturnsOriginal) {
-    char *bc = tf_compile("$trim(hello)");
+TEST_F (TitleFormattingTests, test_TrimNoLeadingTrailingSpaces_ReturnsOriginal) {
+    char *bc = tf_compile ("$trim(hello)");
     tf_eval (&ctx, bc, buffer, 1000);
     tf_free (bc);
-    EXPECT_TRUE(!strcmp (buffer, "hello"));
+    EXPECT_TRUE (!strcmp (buffer, "hello"));
 }
 
-TEST_F(TitleFormattingTests, test_TrimLeadingSpaces_ReturnsTrimmedString) {
-    char *bc = tf_compile("$trim(   hello)");
+TEST_F (TitleFormattingTests, test_TrimLeadingSpaces_ReturnsTrimmedString) {
+    char *bc = tf_compile ("$trim(   hello)");
     tf_eval (&ctx, bc, buffer, 1000);
     tf_free (bc);
-    EXPECT_TRUE(!strcmp (buffer, "hello"));
+    EXPECT_TRUE (!strcmp (buffer, "hello"));
 }
 
-TEST_F(TitleFormattingTests, test_TrimTrailingSpaces_ReturnsTrimmedString) {
-    char *bc = tf_compile("$trim(hello   )");
+TEST_F (TitleFormattingTests, test_TrimTrailingSpaces_ReturnsTrimmedString) {
+    char *bc = tf_compile ("$trim(hello   )");
     tf_eval (&ctx, bc, buffer, 1000);
     tf_free (bc);
-    EXPECT_TRUE(!strcmp (buffer, "hello"));
+    EXPECT_TRUE (!strcmp (buffer, "hello"));
 }
 
-TEST_F(TitleFormattingTests, test_TrimLeadingAndTrailingSpaces_ReturnsTrimmedString) {
-    char *bc = tf_compile("$trim(    hello   )");
+TEST_F (TitleFormattingTests, test_TrimLeadingAndTrailingSpaces_ReturnsTrimmedString) {
+    char *bc = tf_compile ("$trim(    hello   )");
     tf_eval (&ctx, bc, buffer, 1000);
     tf_free (bc);
-    EXPECT_TRUE(!strcmp (buffer, "hello"));
+    EXPECT_TRUE (!strcmp (buffer, "hello"));
 }
 
-TEST_F(TitleFormattingTests, test_TrimLeadingAndTrailingSpacesWithTabs_ReturnsTrimmedToTabsString) {
+TEST_F (TitleFormattingTests, test_TrimLeadingAndTrailingSpacesWithTabs_ReturnsTrimmedToTabsString) {
     ctx.flags = DDB_TF_CONTEXT_MULTILINE;
-    char *bc = tf_compile("$trim( \t   hello  \t )");
+    char *bc = tf_compile ("$trim( \t   hello  \t )");
     tf_eval (&ctx, bc, buffer, 1000);
     tf_free (bc);
-    EXPECT_TRUE(!strcmp (buffer, "\t   hello  \t"));
+    EXPECT_TRUE (!strcmp (buffer, "\t   hello  \t"));
 }
 
 #pragma mark - Tint
 
-TEST_F(TitleFormattingTests, test_CalculateTintFromString_LeadingTint_Valid) {
+TEST_F (TitleFormattingTests, test_CalculateTintFromString_LeadingTint_Valid) {
     char str[] = "\0331;1mhello";
 
     tint_stop_t tintStops[100];
@@ -2466,14 +2467,14 @@ TEST_F(TitleFormattingTests, test_CalculateTintFromString_LeadingTint_Valid) {
     unsigned count = calculate_tint_stops_from_string (str, tintStops, 100, &output);
 
     EXPECT_EQ (count, 1);
-    EXPECT_TRUE(!strcmp(output,"hello"));
-    EXPECT_EQ(tintStops[0].tint, 1);
-    EXPECT_EQ(tintStops[0].index, 0);
+    EXPECT_TRUE (!strcmp (output, "hello"));
+    EXPECT_EQ (tintStops[0].tint, 1);
+    EXPECT_EQ (tintStops[0].index, 0);
 
     free (output);
 }
 
-TEST_F(TitleFormattingTests, test_CalculateTintFromString_TrailingTint_Valid) {
+TEST_F (TitleFormattingTests, test_CalculateTintFromString_TrailingTint_Valid) {
     char str[] = "hello\0331;1m";
 
     tint_stop_t tintStops[100];
@@ -2482,14 +2483,14 @@ TEST_F(TitleFormattingTests, test_CalculateTintFromString_TrailingTint_Valid) {
     unsigned count = calculate_tint_stops_from_string (str, tintStops, 100, &output);
 
     EXPECT_EQ (count, 1);
-    EXPECT_TRUE(!strcmp(output,"hello"));
-    EXPECT_EQ(tintStops[0].tint, 1);
-    EXPECT_EQ(tintStops[0].index, 5);
+    EXPECT_TRUE (!strcmp (output, "hello"));
+    EXPECT_EQ (tintStops[0].tint, 1);
+    EXPECT_EQ (tintStops[0].index, 5);
 
     free (output);
 }
 
-TEST_F(TitleFormattingTests, test_CalculateTintFromString_MultipleTintLeadingTrailing_Valid) {
+TEST_F (TitleFormattingTests, test_CalculateTintFromString_MultipleTintLeadingTrailing_Valid) {
     char str[] = "\0331;-1mhello\0331;1m";
 
     tint_stop_t tintStops[100];
@@ -2498,16 +2499,16 @@ TEST_F(TitleFormattingTests, test_CalculateTintFromString_MultipleTintLeadingTra
     unsigned count = calculate_tint_stops_from_string (str, tintStops, 100, &output);
 
     EXPECT_EQ (count, 2);
-    EXPECT_TRUE(!strcmp(output,"hello"));
-    EXPECT_EQ(tintStops[0].tint, -1);
-    EXPECT_EQ(tintStops[0].index, 0);
-    EXPECT_EQ(tintStops[1].tint, 0);
-    EXPECT_EQ(tintStops[1].index, 5);
+    EXPECT_TRUE (!strcmp (output, "hello"));
+    EXPECT_EQ (tintStops[0].tint, -1);
+    EXPECT_EQ (tintStops[0].index, 0);
+    EXPECT_EQ (tintStops[1].tint, 0);
+    EXPECT_EQ (tintStops[1].index, 5);
 
     free (output);
 }
 
-TEST_F(TitleFormattingTests, test_CalculateTintFromString_MultipleTintMiddle_Valid) {
+TEST_F (TitleFormattingTests, test_CalculateTintFromString_MultipleTintMiddle_Valid) {
     char str[] = "Leading\0331;-5mMiddle\0331;5mTrailing";
 
     tint_stop_t tintStops[100];
@@ -2516,18 +2517,18 @@ TEST_F(TitleFormattingTests, test_CalculateTintFromString_MultipleTintMiddle_Val
     unsigned count = calculate_tint_stops_from_string (str, tintStops, 100, &output);
 
     EXPECT_EQ (count, 2);
-    EXPECT_TRUE(!strcmp(output,"LeadingMiddleTrailing"));
-    EXPECT_EQ(tintStops[0].tint, -5);
-    EXPECT_EQ(tintStops[0].index, 7);
-    EXPECT_EQ(tintStops[1].tint, 0);
-    EXPECT_EQ(tintStops[1].index, 13);
+    EXPECT_TRUE (!strcmp (output, "LeadingMiddleTrailing"));
+    EXPECT_EQ (tintStops[0].tint, -5);
+    EXPECT_EQ (tintStops[0].index, 7);
+    EXPECT_EQ (tintStops[1].tint, 0);
+    EXPECT_EQ (tintStops[1].index, 13);
 
     free (output);
 }
 
 #pragma mark - RGB
 
-TEST_F(TitleFormattingTests, test_CalculateRGBFromString_LeadingRGB_Valid) {
+TEST_F (TitleFormattingTests, test_CalculateRGBFromString_LeadingRGB_Valid) {
     char str[] = "\0332;20;30;40mhello";
 
     tint_stop_t tintStops[100];
@@ -2536,16 +2537,16 @@ TEST_F(TitleFormattingTests, test_CalculateRGBFromString_LeadingRGB_Valid) {
     unsigned count = calculate_tint_stops_from_string (str, tintStops, 100, &output);
 
     EXPECT_EQ (count, 1);
-    EXPECT_TRUE(!strcmp(output,"hello"));
-    EXPECT_EQ(tintStops[0].has_rgb, 1);
-    EXPECT_EQ(tintStops[0].r, 20);
-    EXPECT_EQ(tintStops[0].g, 30);
-    EXPECT_EQ(tintStops[0].b, 40);
+    EXPECT_TRUE (!strcmp (output, "hello"));
+    EXPECT_EQ (tintStops[0].has_rgb, 1);
+    EXPECT_EQ (tintStops[0].r, 20);
+    EXPECT_EQ (tintStops[0].g, 30);
+    EXPECT_EQ (tintStops[0].b, 40);
 
     free (output);
 }
 
-TEST_F(TitleFormattingTests, test_CalculateRGBFromString_Unterminated_Invalid) {
+TEST_F (TitleFormattingTests, test_CalculateRGBFromString_Unterminated_Invalid) {
     char str[] = "\0332;20;30;40hello";
 
     tint_stop_t tintStops[100];
@@ -2554,12 +2555,12 @@ TEST_F(TitleFormattingTests, test_CalculateRGBFromString_Unterminated_Invalid) {
     unsigned count = calculate_tint_stops_from_string (str, tintStops, 100, &output);
 
     EXPECT_EQ (count, 0);
-    EXPECT_TRUE(!strcmp(output,"\0332;20;30;40hello"));
+    EXPECT_TRUE (!strcmp (output, "\0332;20;30;40hello"));
 
     free (output);
 }
 
-TEST_F(TitleFormattingTests, test_CalculateRGBFromString_Negative_Reset) {
+TEST_F (TitleFormattingTests, test_CalculateRGBFromString_Negative_Reset) {
     char str[] = "\0332;-20;30;-40mhello";
 
     tint_stop_t tintStops[100];
@@ -2568,13 +2569,13 @@ TEST_F(TitleFormattingTests, test_CalculateRGBFromString_Negative_Reset) {
     unsigned count = calculate_tint_stops_from_string (str, tintStops, 100, &output);
 
     EXPECT_EQ (count, 1);
-    EXPECT_EQ(tintStops[0].has_rgb, 0);
-    EXPECT_TRUE(!strcmp(output,"hello"));
+    EXPECT_EQ (tintStops[0].has_rgb, 0);
+    EXPECT_TRUE (!strcmp (output, "hello"));
 
     free (output);
 }
 
-TEST_F(TitleFormattingTests, test_CalculateRGBFromString_LargerThan255_Clamped) {
+TEST_F (TitleFormattingTests, test_CalculateRGBFromString_LargerThan255_Clamped) {
     char str[] = "\0332;1000;30;2000mhello";
 
     tint_stop_t tintStops[100];
@@ -2583,16 +2584,16 @@ TEST_F(TitleFormattingTests, test_CalculateRGBFromString_LargerThan255_Clamped) 
     unsigned count = calculate_tint_stops_from_string (str, tintStops, 100, &output);
 
     EXPECT_EQ (count, 1);
-    EXPECT_TRUE(!strcmp(output,"hello"));
-    EXPECT_EQ(tintStops[0].has_rgb, 1);
-    EXPECT_EQ(tintStops[0].r, 255);
-    EXPECT_EQ(tintStops[0].g, 30);
-    EXPECT_EQ(tintStops[0].b, 255);
+    EXPECT_TRUE (!strcmp (output, "hello"));
+    EXPECT_EQ (tintStops[0].has_rgb, 1);
+    EXPECT_EQ (tintStops[0].r, 255);
+    EXPECT_EQ (tintStops[0].g, 30);
+    EXPECT_EQ (tintStops[0].b, 255);
 
     free (output);
 }
 
-TEST_F(TitleFormattingTests, test_CalculateRGBFromString_TrailingRGB_Valid) {
+TEST_F (TitleFormattingTests, test_CalculateRGBFromString_TrailingRGB_Valid) {
     char str[] = "hello\0332;20;30;40m";
 
     tint_stop_t tintStops[100];
@@ -2601,16 +2602,16 @@ TEST_F(TitleFormattingTests, test_CalculateRGBFromString_TrailingRGB_Valid) {
     unsigned count = calculate_tint_stops_from_string (str, tintStops, 100, &output);
 
     EXPECT_EQ (count, 1);
-    EXPECT_TRUE(!strcmp(output,"hello"));
-    EXPECT_EQ(tintStops[0].has_rgb, 1);
-    EXPECT_EQ(tintStops[0].r, 20);
-    EXPECT_EQ(tintStops[0].g, 30);
-    EXPECT_EQ(tintStops[0].b, 40);
+    EXPECT_TRUE (!strcmp (output, "hello"));
+    EXPECT_EQ (tintStops[0].has_rgb, 1);
+    EXPECT_EQ (tintStops[0].r, 20);
+    EXPECT_EQ (tintStops[0].g, 30);
+    EXPECT_EQ (tintStops[0].b, 40);
 
     free (output);
 }
 
-TEST_F(TitleFormattingTests, test_CalculateRGBFromString_MultipleRGBLeadingTrailing_Valid) {
+TEST_F (TitleFormattingTests, test_CalculateRGBFromString_MultipleRGBLeadingTrailing_Valid) {
     char str[] = "\0332;20;30;40mhello\0332;50;60;70m";
 
     tint_stop_t tintStops[100];
@@ -2619,20 +2620,20 @@ TEST_F(TitleFormattingTests, test_CalculateRGBFromString_MultipleRGBLeadingTrail
     unsigned count = calculate_tint_stops_from_string (str, tintStops, 100, &output);
 
     EXPECT_EQ (count, 2);
-    EXPECT_TRUE(!strcmp(output,"hello"));
-    EXPECT_EQ(tintStops[0].has_rgb, 1);
-    EXPECT_EQ(tintStops[0].r, 20);
-    EXPECT_EQ(tintStops[0].g, 30);
-    EXPECT_EQ(tintStops[0].b, 40);
-    EXPECT_EQ(tintStops[1].has_rgb, 1);
-    EXPECT_EQ(tintStops[1].r, 50);
-    EXPECT_EQ(tintStops[1].g, 60);
-    EXPECT_EQ(tintStops[1].b, 70);
+    EXPECT_TRUE (!strcmp (output, "hello"));
+    EXPECT_EQ (tintStops[0].has_rgb, 1);
+    EXPECT_EQ (tintStops[0].r, 20);
+    EXPECT_EQ (tintStops[0].g, 30);
+    EXPECT_EQ (tintStops[0].b, 40);
+    EXPECT_EQ (tintStops[1].has_rgb, 1);
+    EXPECT_EQ (tintStops[1].r, 50);
+    EXPECT_EQ (tintStops[1].g, 60);
+    EXPECT_EQ (tintStops[1].b, 70);
 
     free (output);
 }
 
-TEST_F(TitleFormattingTests, test_CalculateRGBFromString_MultipleRGBMiddle_Valid) {
+TEST_F (TitleFormattingTests, test_CalculateRGBFromString_MultipleRGBMiddle_Valid) {
     char str[] = "Leading\0332;20;30;40mMiddle\0332;50;60;70mTrailing";
 
     tint_stop_t tintStops[100];
@@ -2641,22 +2642,22 @@ TEST_F(TitleFormattingTests, test_CalculateRGBFromString_MultipleRGBMiddle_Valid
     unsigned count = calculate_tint_stops_from_string (str, tintStops, 100, &output);
 
     EXPECT_EQ (count, 2);
-    EXPECT_TRUE(!strcmp(output,"LeadingMiddleTrailing"));
-    EXPECT_EQ(tintStops[0].has_rgb, 1);
-    EXPECT_EQ(tintStops[0].r, 20);
-    EXPECT_EQ(tintStops[0].g, 30);
-    EXPECT_EQ(tintStops[0].b, 40);
-    EXPECT_EQ(tintStops[1].has_rgb, 1);
-    EXPECT_EQ(tintStops[1].r, 50);
-    EXPECT_EQ(tintStops[1].g, 60);
-    EXPECT_EQ(tintStops[1].b, 70);
+    EXPECT_TRUE (!strcmp (output, "LeadingMiddleTrailing"));
+    EXPECT_EQ (tintStops[0].has_rgb, 1);
+    EXPECT_EQ (tintStops[0].r, 20);
+    EXPECT_EQ (tintStops[0].g, 30);
+    EXPECT_EQ (tintStops[0].b, 40);
+    EXPECT_EQ (tintStops[1].has_rgb, 1);
+    EXPECT_EQ (tintStops[1].r, 50);
+    EXPECT_EQ (tintStops[1].g, 60);
+    EXPECT_EQ (tintStops[1].b, 70);
 
     free (output);
 }
 
 #pragma mark - Tint + RGB
 
-TEST_F(TitleFormattingTests, test_CalculateRGBFromString_TintWithRGB_Valid) {
+TEST_F (TitleFormattingTests, test_CalculateRGBFromString_TintWithRGB_Valid) {
     char str[] = "\0331;-3m\0332;20;30;40mHello";
 
     tint_stop_t tintStops[100];
@@ -2665,176 +2666,174 @@ TEST_F(TitleFormattingTests, test_CalculateRGBFromString_TintWithRGB_Valid) {
     unsigned count = calculate_tint_stops_from_string (str, tintStops, 100, &output);
 
     EXPECT_EQ (count, 2);
-    EXPECT_TRUE(!strcmp(output,"Hello"));
-    EXPECT_EQ(tintStops[0].has_rgb, 0);
-    EXPECT_EQ(tintStops[0].tint, -3);
-    EXPECT_EQ(tintStops[1].has_rgb, 1);
-    EXPECT_EQ(tintStops[1].r, 20);
-    EXPECT_EQ(tintStops[1].g, 30);
-    EXPECT_EQ(tintStops[1].b, 40);
+    EXPECT_TRUE (!strcmp (output, "Hello"));
+    EXPECT_EQ (tintStops[0].has_rgb, 0);
+    EXPECT_EQ (tintStops[0].tint, -3);
+    EXPECT_EQ (tintStops[1].has_rgb, 1);
+    EXPECT_EQ (tintStops[1].r, 20);
+    EXPECT_EQ (tintStops[1].g, 30);
+    EXPECT_EQ (tintStops[1].b, 40);
 
     free (output);
 }
 
-TEST_F(TitleFormattingTests, test_year_empty_returnNothing) {
-    char *bc = tf_compile("$year()");
+TEST_F (TitleFormattingTests, test_year_empty_returnNothing) {
+    char *bc = tf_compile ("$year()");
     tf_eval (&ctx, bc, buffer, 1000);
     tf_free (bc);
-    EXPECT_TRUE(!strcmp (buffer, ""));
+    EXPECT_TRUE (!strcmp (buffer, ""));
 }
 
-TEST_F(TitleFormattingTests, test_year_text_returnNothing) {
-    char *bc = tf_compile("$year(abcd)");
+TEST_F (TitleFormattingTests, test_year_text_returnNothing) {
+    char *bc = tf_compile ("$year(abcd)");
     tf_eval (&ctx, bc, buffer, 1000);
     tf_free (bc);
-    EXPECT_TRUE(!strcmp (buffer, ""));
+    EXPECT_TRUE (!strcmp (buffer, ""));
 }
 
-TEST_F(TitleFormattingTests, test_year_shorterThan4_returnNothing) {
-    char *bc = tf_compile("$year(123)");
+TEST_F (TitleFormattingTests, test_year_shorterThan4_returnNothing) {
+    char *bc = tf_compile ("$year(123)");
     tf_eval (&ctx, bc, buffer, 1000);
     tf_free (bc);
-    EXPECT_TRUE(!strcmp (buffer, ""));
+    EXPECT_TRUE (!strcmp (buffer, ""));
 }
 
-TEST_F(TitleFormattingTests, test_year_Exactly4_returnValue) {
-    char *bc = tf_compile("$year(1234)");
+TEST_F (TitleFormattingTests, test_year_Exactly4_returnValue) {
+    char *bc = tf_compile ("$year(1234)");
     tf_eval (&ctx, bc, buffer, 1000);
     tf_free (bc);
-    EXPECT_TRUE(!strcmp (buffer, "1234"));
+    EXPECT_TRUE (!strcmp (buffer, "1234"));
 }
 
-TEST_F(TitleFormattingTests, test_year_LongerThan4WithText_returnYear) {
-    char *bc = tf_compile("$year(9999text)");
+TEST_F (TitleFormattingTests, test_year_LongerThan4WithText_returnYear) {
+    char *bc = tf_compile ("$year(9999text)");
     tf_eval (&ctx, bc, buffer, 1000);
     tf_free (bc);
-    EXPECT_TRUE(!strcmp (buffer, "9999"));
+    EXPECT_TRUE (!strcmp (buffer, "9999"));
 }
 
-TEST_F(TitleFormattingTests, test_itematindex_0_returnsFirstItem) {
-    char *bc = tf_compile("$itematindex(0,%artist%)");
+TEST_F (TitleFormattingTests, test_itematindex_0_returnsFirstItem) {
+    char *bc = tf_compile ("$itematindex(0,%artist%)");
 
     char value[] = "value1\0value2";
-    pl_add_meta_full(it, "artist", value, sizeof(value));
+    pl_add_meta_full (it, "artist", value, sizeof (value));
 
     tf_eval (&ctx, bc, buffer, 1000);
     tf_free (bc);
-    EXPECT_STREQ(buffer, "value1");
+    EXPECT_STREQ (buffer, "value1");
 }
 
-TEST_F(TitleFormattingTests, test_itematindex_1_returnsSecondItem) {
-    char *bc = tf_compile("$itematindex(1,%artist%)");
+TEST_F (TitleFormattingTests, test_itematindex_1_returnsSecondItem) {
+    char *bc = tf_compile ("$itematindex(1,%artist%)");
 
     char value[] = "value1\0value2";
-    pl_add_meta_full(it, "artist", value, sizeof(value));
+    pl_add_meta_full (it, "artist", value, sizeof (value));
 
     tf_eval (&ctx, bc, buffer, 1000);
     tf_free (bc);
-    EXPECT_STREQ(buffer, "value2");
+    EXPECT_STREQ (buffer, "value2");
 }
 
-TEST_F(TitleFormattingTests, test_itematindex_outOfBounds_returnsEmpty) {
-    char *bc = tf_compile("$itematindex(2,%artist%)");
+TEST_F (TitleFormattingTests, test_itematindex_outOfBounds_returnsEmpty) {
+    char *bc = tf_compile ("$itematindex(2,%artist%)");
 
     char value[] = "value1\0value2";
-    pl_add_meta_full(it, "artist", value, sizeof(value));
+    pl_add_meta_full (it, "artist", value, sizeof (value));
 
     tf_eval (&ctx, bc, buffer, 1000);
     tf_free (bc);
-    EXPECT_STREQ(buffer, "");
+    EXPECT_STREQ (buffer, "");
 }
 
-TEST_F(TitleFormattingTests, test_itematindex_singleValue_returnsValue) {
-    char *bc = tf_compile("$itematindex(2,%artist%)");
+TEST_F (TitleFormattingTests, test_itematindex_singleValue_returnsValue) {
+    char *bc = tf_compile ("$itematindex(2,%artist%)");
 
     char value[] = "value1";
-    pl_add_meta_full(it, "artist", value, sizeof(value));
+    pl_add_meta_full (it, "artist", value, sizeof (value));
 
     tf_eval (&ctx, bc, buffer, 1000);
     tf_free (bc);
-    EXPECT_STREQ(buffer, "value1");
+    EXPECT_STREQ (buffer, "value1");
 }
 
-TEST_F(TitleFormattingTests, test_itematindex_NoArguments_returnsEmpty) {
-    char *bc = tf_compile("$itematindex()");
+TEST_F (TitleFormattingTests, test_itematindex_NoArguments_returnsEmpty) {
+    char *bc = tf_compile ("$itematindex()");
     tf_eval (&ctx, bc, buffer, 1000);
     tf_free (bc);
-    EXPECT_STREQ(buffer, "");
+    EXPECT_STREQ (buffer, "");
 }
 
-TEST_F(TitleFormattingTests, test_itematindex_1Arguments_returnsEmpty) {
-    char *bc = tf_compile("$itematindex(0)");
+TEST_F (TitleFormattingTests, test_itematindex_1Arguments_returnsEmpty) {
+    char *bc = tf_compile ("$itematindex(0)");
     tf_eval (&ctx, bc, buffer, 1000);
     tf_free (bc);
-    EXPECT_STREQ(buffer, "");
+    EXPECT_STREQ (buffer, "");
 }
 
-TEST_F(TitleFormattingTests, test_itematindex_3Arguments_returnsEmpty) {
-    char *bc = tf_compile("$itematindex(0,1,2)");
+TEST_F (TitleFormattingTests, test_itematindex_3Arguments_returnsEmpty) {
+    char *bc = tf_compile ("$itematindex(0,1,2)");
     tf_eval (&ctx, bc, buffer, 1000);
     tf_free (bc);
-    EXPECT_STREQ(buffer, "");
+    EXPECT_STREQ (buffer, "");
 }
 
-TEST_F(TitleFormattingTests, test_meta_bufferTooShortWithMultibyteCharsInput_returnsOnlyWholeMultibyteChars) {
-    char *bc = tf_compile("$meta(comment)");
-    pl_add_meta(it, "comment", "ΘΘΘΘ");
+TEST_F (TitleFormattingTests, test_meta_bufferTooShortWithMultibyteCharsInput_returnsOnlyWholeMultibyteChars) {
+    char *bc = tf_compile ("$meta(comment)");
+    pl_add_meta (it, "comment", "ΘΘΘΘ");
     tf_eval (&ctx, bc, buffer, 8);
     tf_free (bc);
-    EXPECT_STREQ(buffer, "ΘΘΘ");
+    EXPECT_STREQ (buffer, "ΘΘΘ");
 }
 
-TEST_F(TitleFormattingTests, test_put_any_returnsValue) {
-    char *bc = tf_compile("$put(foo,bar)");
-    tf_eval (&ctx, bc, buffer, sizeof(buffer));
+TEST_F (TitleFormattingTests, test_put_any_returnsValue) {
+    char *bc = tf_compile ("$put(foo,bar)");
+    tf_eval (&ctx, bc, buffer, sizeof (buffer));
     tf_free (bc);
-    EXPECT_STREQ(buffer, "bar");
+    EXPECT_STREQ (buffer, "bar");
 }
 
-TEST_F(TitleFormattingTests, test_puts_any_returnsEmpty) {
-    char *bc = tf_compile("$puts(foo,bar)");
-    tf_eval (&ctx, bc, buffer, sizeof(buffer));
+TEST_F (TitleFormattingTests, test_puts_any_returnsEmpty) {
+    char *bc = tf_compile ("$puts(foo,bar)");
+    tf_eval (&ctx, bc, buffer, sizeof (buffer));
     tf_free (bc);
-    EXPECT_STREQ(buffer, "");
+    EXPECT_STREQ (buffer, "");
 }
 
-
-TEST_F(TitleFormattingTests, test_get_any_returnsValue) {
-    char *bc = tf_compile("$puts(foo,bar)$get(foo)");
-    tf_eval (&ctx, bc, buffer, sizeof(buffer));
+TEST_F (TitleFormattingTests, test_get_any_returnsValue) {
+    char *bc = tf_compile ("$puts(foo,bar)$get(foo)");
+    tf_eval (&ctx, bc, buffer, sizeof (buffer));
     tf_free (bc);
-    EXPECT_STREQ(buffer, "bar");
+    EXPECT_STREQ (buffer, "bar");
 }
 
-TEST_F(TitleFormattingTests, test_get_Undefined_returnsNothing) {
-    char *bc = tf_compile("$get(baz)");
-    tf_eval (&ctx, bc, buffer, sizeof(buffer));
+TEST_F (TitleFormattingTests, test_get_Undefined_returnsNothing) {
+    char *bc = tf_compile ("$get(baz)");
+    tf_eval (&ctx, bc, buffer, sizeof (buffer));
     tf_free (bc);
-    EXPECT_STREQ(buffer, "");
+    EXPECT_STREQ (buffer, "");
 }
 
-TEST_F(TitleFormattingTests, test_put_overwrite_returnsNewValue) {
-    char *bc = tf_compile("$puts(foo,bar)$puts(foo,baz)$get(foo)");
-    tf_eval (&ctx, bc, buffer, sizeof(buffer));
+TEST_F (TitleFormattingTests, test_put_overwrite_returnsNewValue) {
+    char *bc = tf_compile ("$puts(foo,bar)$puts(foo,baz)$get(foo)");
+    tf_eval (&ctx, bc, buffer, sizeof (buffer));
     tf_free (bc);
-    EXPECT_STREQ(buffer, "baz");
+    EXPECT_STREQ (buffer, "baz");
 }
 
-TEST_F(TitleFormattingTests, test_get_multiple_returnsMultiple) {
-    char *bc = tf_compile("$puts(foo,alpha)$puts(bar,beta)$get(foo) $get(bar)");
-    tf_eval (&ctx, bc, buffer, sizeof(buffer));
+TEST_F (TitleFormattingTests, test_get_multiple_returnsMultiple) {
+    char *bc = tf_compile ("$puts(foo,alpha)$puts(bar,beta)$get(foo) $get(bar)");
+    tf_eval (&ctx, bc, buffer, sizeof (buffer));
     tf_free (bc);
-    EXPECT_STREQ(buffer, "alpha beta");
+    EXPECT_STREQ (buffer, "alpha beta");
 }
 
-TEST_F(TitleFormattingTests, test_putMetaData) {
+TEST_F (TitleFormattingTests, test_putMetaData) {
     pl_add_meta (it, "album artist", "TheAlbumArtist");
     pl_add_meta (it, "year", "12345678");
     pl_add_meta (it, "album", "TheNameOfAlbum");
 
-
-    char *bc = tf_compile("$put($meta(year),%album artist%)");
-    tf_eval (&ctx, bc, buffer, sizeof(buffer));
+    char *bc = tf_compile ("$put($meta(year),%album artist%)");
+    tf_eval (&ctx, bc, buffer, sizeof (buffer));
     tf_free (bc);
-    EXPECT_STREQ(buffer, "TheAlbumArtist");
+    EXPECT_STREQ (buffer, "TheAlbumArtist");
 }

--- a/Tests/VfsCurlTests.cpp
+++ b/Tests/VfsCurlTests.cpp
@@ -12,90 +12,91 @@
 #include <gtest/gtest.h>
 
 extern "C" DB_functions_t *deadbeef;
-extern "C" DB_plugin_t *vfs_curl_load (DB_functions_t *api);
+extern "C" DB_plugin_t *
+vfs_curl_load (DB_functions_t *api);
 
-class VfsCurlTests: public ::testing::Test {
+class VfsCurlTests : public ::testing::Test {
 protected:
-    void SetUp() override {
-        messagepump_init();
+    void SetUp () override {
+        messagepump_init ();
         vfs_curl_load (deadbeef);
 
         _file = (HTTP_FILE *)calloc (1, sizeof (HTTP_FILE));
         _file->track = (DB_playItem_t *)pl_item_alloc ();
     }
-    void TearDown() override {
-        vfs_curl_free_file(_file);
+    void TearDown () override {
+        vfs_curl_free_file (_file);
         // drain
         uint32_t msg;
         uintptr_t ctx;
         uint32_t p1;
         uint32_t p2;
-        while (messagepump_pop(&msg, &ctx, &p1, &p2) != -1) {
+        while (messagepump_pop (&msg, &ctx, &p1, &p2) != -1) {
             if (msg >= DB_EV_FIRST && ctx) {
                 messagepump_event_free ((ddb_event_t *)ctx);
             }
         }
-        messagepump_free();
+        messagepump_free ();
     }
     HTTP_FILE *_file;
 };
 
 #pragma mark - In-stream headers
 
-TEST_F(VfsCurlTests, test_HandleIcyHeaders_IcyHeaderData_ConsumedUnterminated) {
+TEST_F (VfsCurlTests, test_HandleIcyHeaders_IcyHeaderData_ConsumedUnterminated) {
     const char *data = "ICY 200 OK";
-    size_t consumed = vfs_curl_handle_icy_headers (strlen(data), _file, data);
+    size_t consumed = vfs_curl_handle_icy_headers (strlen (data), _file, data);
     EXPECT_EQ (consumed, strlen (data));
     EXPECT_EQ (_file->icyheader, 1);
     EXPECT_EQ (_file->gotheader, 0);
 }
 
-TEST_F(VfsCurlTests, test_HandleIcyHeaders_IcyHeaderData_IcyHeaderFieldTrueTerminated) {
+TEST_F (VfsCurlTests, test_HandleIcyHeaders_IcyHeaderData_IcyHeaderFieldTrueTerminated) {
     const char *data = "ICY 200 OK\r\n\r\n";
-    size_t consumed = vfs_curl_handle_icy_headers (strlen(data), _file, data);
+    size_t consumed = vfs_curl_handle_icy_headers (strlen (data), _file, data);
     EXPECT_EQ (consumed, strlen (data));
     EXPECT_EQ (_file->icyheader, 1);
     EXPECT_EQ (_file->gotheader, 1);
 }
 
-TEST_F(VfsCurlTests, test_HandleIcyHeaders_NonIcyHeaderData_NotConsumed) {
+TEST_F (VfsCurlTests, test_HandleIcyHeaders_NonIcyHeaderData_NotConsumed) {
     const char *data = "Garbage";
-    size_t consumed = vfs_curl_handle_icy_headers (strlen(data), _file, data);
+    size_t consumed = vfs_curl_handle_icy_headers (strlen (data), _file, data);
     EXPECT_EQ (consumed, 0);
     EXPECT_EQ (_file->icyheader, 0);
     EXPECT_EQ (_file->gotheader, 1);
 }
 
-TEST_F(VfsCurlTests, test_HandleIcyHeaders_IcyHeaderDataFollowedByOtherData_OnlyHeaderIsConsumed) {
+TEST_F (VfsCurlTests, test_HandleIcyHeaders_IcyHeaderDataFollowedByOtherData_OnlyHeaderIsConsumed) {
     const char *data = "ICY 200 OK\r\n\r\nData";
-    size_t consumed = vfs_curl_handle_icy_headers (strlen(data), _file, data);
-    EXPECT_EQ (consumed, strlen(data)-4);
+    size_t consumed = vfs_curl_handle_icy_headers (strlen (data), _file, data);
+    EXPECT_EQ (consumed, strlen (data) - 4);
     EXPECT_EQ (_file->icyheader, 1);
     EXPECT_EQ (_file->gotheader, 1);
 }
 
-TEST_F(VfsCurlTests, test_HandleIcyHeaders_IcyHeaderTitleMeta_GotTitleMeta) {
+TEST_F (VfsCurlTests, test_HandleIcyHeaders_IcyHeaderTitleMeta_GotTitleMeta) {
     const char *data = "ICY 200 OK\r\nicy-name:Title\r\n\r\n";
-    size_t consumed = vfs_curl_handle_icy_headers (strlen(data), _file, data);
+    size_t consumed = vfs_curl_handle_icy_headers (strlen (data), _file, data);
     EXPECT_EQ (consumed, strlen (data));
     EXPECT_EQ (_file->icyheader, 1);
     EXPECT_EQ (_file->gotheader, 1);
 
-    const char *title = pl_find_meta((playItem_t *)_file->track, "title");
+    const char *title = pl_find_meta ((playItem_t *)_file->track, "title");
     EXPECT_EQ (strcmp (title, "Title"), 0);
 }
 
-TEST_F(VfsCurlTests, test_HandleIcyHeaders_IcyHeaderAndTitleMetaSeparatePackets_GotTitleMeta) {
+TEST_F (VfsCurlTests, test_HandleIcyHeaders_IcyHeaderAndTitleMetaSeparatePackets_GotTitleMeta) {
     const char *header = "ICY 200 OK\r\n";
     const char *payload = "icy-name:Title\r\n\r\n";
-    size_t consumed = vfs_curl_handle_icy_headers (strlen(header), _file, header);
+    size_t consumed = vfs_curl_handle_icy_headers (strlen (header), _file, header);
     EXPECT_EQ (consumed, strlen (header));
-    consumed = vfs_curl_handle_icy_headers (strlen(payload), _file, payload);
+    consumed = vfs_curl_handle_icy_headers (strlen (payload), _file, payload);
     EXPECT_EQ (consumed, strlen (payload));
     EXPECT_EQ (_file->icyheader, 1);
     EXPECT_EQ (_file->gotheader, 1);
 
-    const char *title = pl_find_meta((playItem_t *)_file->track, "title");
+    const char *title = pl_find_meta ((playItem_t *)_file->track, "title");
     EXPECT_NE (title, nullptr);
     EXPECT_EQ (strcmp (title, "Title"), 0);
 }

--- a/Tests/fakein.c
+++ b/Tests/fakein.c
@@ -27,7 +27,8 @@
 #include <unistd.h>
 #include <deadbeef/deadbeef.h>
 
-#define trace(...) { fprintf(stderr, __VA_ARGS__); }
+#define trace(...) \
+    { fprintf (stderr, __VA_ARGS__); }
 
 #define FAKEIN_NUMSAMPLES 44100 * 5 // 5 sec
 static int _sleep;
@@ -44,7 +45,7 @@ typedef struct {
     float *samples;
 } fakein_info_t;
 
-static const char * exts[] = { "fake", NULL };
+static const char *exts[] = { "fake", NULL };
 
 static DB_fileinfo_t *
 fakein_open (uint32_t hints) {
@@ -61,7 +62,7 @@ fakein_init (DB_fileinfo_t *_info, DB_playItem_t *it) {
     _info->fmt.bps = 32;
     _info->fmt.is_float = 1;
     _info->fmt.channels = 2;
-    _info->fmt.samplerate  = 44100;
+    _info->fmt.samplerate = 44100;
     for (int i = 0; i < _info->fmt.channels; i++) {
         _info->fmt.channelmask |= 1 << i;
     }
@@ -71,7 +72,7 @@ fakein_init (DB_fileinfo_t *_info, DB_playItem_t *it) {
     info->startsample = 0;
     info->endsample = FAKEIN_NUMSAMPLES - 1;
 
-    info->samples = calloc (FAKEIN_NUMSAMPLES,  2 * sizeof (float));
+    info->samples = calloc (FAKEIN_NUMSAMPLES, 2 * sizeof (float));
 
     const char *type = deadbeef->pl_find_meta (it, "title");
     if (!strcmp (type, "sine")) {
@@ -103,7 +104,6 @@ fakein_free (DB_fileinfo_t *_info) {
         free (info);
     }
 }
-
 
 static int
 fakein_read (DB_fileinfo_t *_info, char *bytes, int size) {
@@ -154,7 +154,7 @@ fakein_insert (ddb_playlist_t *plt, DB_playItem_t *after, const char *fname) {
 
     char title[100];
     strcpy (title, fname);
-    *(strrchr(title, '.')) = 0;
+    *(strrchr (title, '.')) = 0;
     deadbeef->pl_add_meta (it, "title", title);
 
     // now the track is ready, insert into playlist
@@ -165,8 +165,7 @@ fakein_insert (ddb_playlist_t *plt, DB_playItem_t *after, const char *fname) {
 
 // define plugin interface
 static DB_decoder_t plugin = {
-    DB_PLUGIN_SET_API_VERSION
-    .plugin.version_major = 0,
+    DB_PLUGIN_SET_API_VERSION.plugin.version_major = 0,
     .plugin.version_minor = 1,
     .plugin.type = DB_PLUGIN_DECODER,
     .plugin.name = "fakein",

--- a/Tests/fakeout.c
+++ b/Tests/fakeout.c
@@ -24,14 +24,14 @@
 #include <stdint.h>
 #include <unistd.h>
 #ifdef __linux__
-#include <sys/prctl.h>
+#    include <sys/prctl.h>
 #endif
 #include <stdio.h>
 #include <string.h>
 #include <deadbeef/deadbeef.h>
 
 //#define trace(...) { fprintf(stderr, __VA_ARGS__); }
-#define trace(fmt,...)
+#define trace(fmt, ...)
 
 static DB_output_t plugin;
 static DB_functions_t *deadbeef;
@@ -121,7 +121,7 @@ int
 fakeout_stop (void) {
     state = DDB_PLAYBACK_STATE_STOPPED;
     deadbeef->streamer_reset (1);
-    fakeout_free();
+    fakeout_free ();
     return 0;
 }
 
@@ -217,7 +217,11 @@ static DB_output_t plugin = {
     .pause = fakeout_pause,
     .unpause = fakeout_unpause,
     .state = fakeout_get_state,
-    .fmt = {.samplerate = 44100, .channels = 2, .bps = 32, .is_float = 1, .channelmask = DDB_SPEAKER_FRONT_LEFT | DDB_SPEAKER_FRONT_RIGHT}
+    .fmt = { .samplerate = 44100,
+            .channels = 2,
+            .bps = 32,
+            .is_float = 1,
+            .channelmask = DDB_SPEAKER_FRONT_LEFT | DDB_SPEAKER_FRONT_RIGHT }
 };
 
 /////////////////////

--- a/Tests/gtest-runner.cpp
+++ b/Tests/gtest-runner.cpp
@@ -10,22 +10,23 @@
 #include "plugins.h"
 #include "playmodes.h"
 
-int main(int argc, char **argv) {
+int
+main (int argc, char **argv) {
     char buf[PATH_MAX];
-    getcwd(buf, sizeof(buf));
+    getcwd (buf, sizeof (buf));
 
-    snprintf (dbplugindir, sizeof(dbplugindir), "%s/Tests", buf);
+    snprintf (dbplugindir, sizeof (dbplugindir), "%s/Tests", buf);
 
     ddb_logger_init ();
     conf_init ();
     conf_enable_saving (0);
-    streamer_playmodes_init();
+    streamer_playmodes_init ();
     pl_init ();
 
     if (plug_load_all ()) { // required to add files to playlist from commandline
         exit (1);
     }
 
-    ::testing::InitGoogleTest(&argc, argv);
-    return RUN_ALL_TESTS();
+    ::testing::InitGoogleTest (&argc, argv);
+    return RUN_ALL_TESTS ();
 }

--- a/Tests/testbootstrap.c
+++ b/Tests/testbootstrap.c
@@ -33,4 +33,3 @@ char dbpixmapdir[PATH_MAX]; // see deadbeef->get_pixmap_dir
 char dbcachedir[PATH_MAX];
 char dbresourcedir[PATH_MAX];
 char dbstatedir[PATH_MAX]; // $HOME/.local/state/deadbeef
-

--- a/plugins/cocoaui/.clang-format
+++ b/plugins/cocoaui/.clang-format
@@ -23,7 +23,6 @@ AlwaysBreakBeforeMultilineStrings: false
 AlwaysBreakTemplateDeclarations: false
 BinPackArguments: false
 BinPackParameters: false
-BinPackParameters: false
 BreakBeforeBinaryOperators: All
 BreakBeforeTernaryOperators: true
 ColumnLimit: 0

--- a/src/cocoautil.h
+++ b/src/cocoautil.h
@@ -39,4 +39,4 @@ int
 cocoautil_get_application_support_path (char *s, size_t size);
 
 void
-cocoautil_get_cache_path(char *buffer, size_t size);
+cocoautil_get_cache_path (char *buffer, size_t size);

--- a/src/conf.c
+++ b/src/conf.c
@@ -120,7 +120,7 @@ _conf_load_buffer (char *buffer) {
 }
 
 static int
-_conf_load_file(const char *fname) {
+_conf_load_file (const char *fname) {
     FILE *fp = fopen (fname, "rb");
     if (!fp) {
         // we're not logging the error when config could not be loaded -- it's the first run
@@ -150,7 +150,7 @@ _conf_load_file(const char *fname) {
 
     conf_lock ();
 
-    _conf_load_buffer(buffer);
+    _conf_load_buffer (buffer);
 
     conf_unlock ();
 
@@ -162,12 +162,12 @@ _conf_load_file(const char *fname) {
 int
 conf_load (void) {
     char config[PATH_MAX];
-    snprintf(config, sizeof(config), "%s/config", dbconfdir);
+    snprintf (config, sizeof (config), "%s/config", dbconfdir);
     char secrets[PATH_MAX];
-    snprintf(secrets, sizeof(secrets), "%s/secrets", dbstatedir);
+    snprintf (secrets, sizeof (secrets), "%s/secrets", dbstatedir);
 
-    int config_res = _conf_load_file(config);
-    int secrets_res = _conf_load_file(secrets);
+    int config_res = _conf_load_file (config);
+    int secrets_res = _conf_load_file (secrets);
 
     changed = 0;
 
@@ -179,7 +179,7 @@ conf_load (void) {
 }
 
 static int
-_conf_save_with_secrets(int secrets) {
+_conf_save_with_secrets (int secrets) {
     char tempfile[PATH_MAX];
     char str[PATH_MAX];
     FILE *fp = NULL;
@@ -271,8 +271,8 @@ conf_save (void) {
         return 0;
     }
 
-    int res = _conf_save_with_secrets(0);
-    int res_secrets = _conf_save_with_secrets(1);
+    int res = _conf_save_with_secrets (0);
+    int res_secrets = _conf_save_with_secrets (1);
 
     changed = 0;
 

--- a/src/cueutil.c
+++ b/src/cueutil.c
@@ -63,17 +63,26 @@ enum {
 #define CUE_FIELD_INDEX_X 100
 
 const char *cue_field_map[] = {
-    "CATALOG ", "CATALOG",
-    "REM DATE ", "year",
-    "REM GENRE ", "genre",
-    "REM COMMENT ", "comment",
-    "REM COMPOSER ", "composer",
-    "REM DISCNUMBER ", "disc",
-    "REM TOTALDISCS ", "numdiscs",
-    "REM DISCID ", "DISCID",
-    NULL, NULL,
+    "CATALOG ",
+    "CATALOG",
+    "REM DATE ",
+    "year",
+    "REM GENRE ",
+    "genre",
+    "REM COMMENT ",
+    "comment",
+    "REM COMPOSER ",
+    "composer",
+    "REM DISCNUMBER ",
+    "disc",
+    "REM TOTALDISCS ",
+    "numdiscs",
+    "REM DISCID ",
+    "DISCID",
+    NULL,
+    NULL,
 };
-#define MAX_EXTRA_TAGS_FROM_CUE ((sizeof(cue_field_map) / sizeof(cue_field_map[0])))
+#define MAX_EXTRA_TAGS_FROM_CUE ((sizeof (cue_field_map) / sizeof (cue_field_map[0])))
 
 #define CUE_FIELD_LEN 255
 
@@ -119,7 +128,6 @@ typedef struct {
     int64_t currsample;
     int last_round;
 } cueparser_t;
-
 
 static const uint8_t *
 skipspaces (const uint8_t *p, const uint8_t *end) {
@@ -182,13 +190,12 @@ pl_get_qvalue_from_cue (const uint8_t *p, int sz, char *out, const char *charset
         return;
     }
 
-    char recbuf[l*10];
-    int res = junk_recode (str, (int)l, recbuf, (int)(sizeof (recbuf)-1), charset);
+    char recbuf[l * 10];
+    int res = junk_recode (str, (int)l, recbuf, (int)(sizeof (recbuf) - 1), charset);
     if (res >= 0) {
         strcpy (str, recbuf);
     }
-    else
-    {
+    else {
         strcpy (str, "<UNRECOGNIZED CHARSET>");
     }
 }
@@ -199,7 +206,7 @@ pl_get_value_from_cue (const char *p, int sz, char *out) {
         sz--;
         *out++ = *p++;
     }
-    while (out > p && (*(out-1) == 0x20 || *(out-1) == 0x8)) {
+    while (out > p && (*(out - 1) == 0x20 || *(out - 1) == 0x8)) {
         out--;
     }
     *out = 0;
@@ -208,17 +215,17 @@ pl_get_value_from_cue (const char *p, int sz, char *out) {
 static float
 pl_cue_parse_time (const char *p) {
     char *endptr;
-    long mins = strtol(p, &endptr, 10);
+    long mins = strtol (p, &endptr, 10);
     if (endptr - p < 1 || *endptr != ':') {
         return -1;
     }
     p = endptr + 1;
-    long sec = strtol(p, &endptr, 10);
+    long sec = strtol (p, &endptr, 10);
     if (endptr - p != 2 || *endptr != ':') {
         return -1;
     }
     p = endptr + 1;
-    long frm = strtol(p, &endptr, 10);
+    long frm = strtol (p, &endptr, 10);
     if (endptr - p != 2 || *endptr != '\0') {
         return -1;
     }
@@ -226,7 +233,7 @@ pl_cue_parse_time (const char *p) {
 }
 
 static void
-pl_cue_get_total_tracks_and_files(const uint8_t *buffer, const uint8_t *buffer_end, int *ncuefiles, int *ncuetracks) {
+pl_cue_get_total_tracks_and_files (const uint8_t *buffer, const uint8_t *buffer_end, int *ncuefiles, int *ncuetracks) {
     const uint8_t *p = buffer;
     *ncuetracks = 0;
     *ncuefiles = 0;
@@ -243,16 +250,17 @@ pl_cue_get_total_tracks_and_files(const uint8_t *buffer, const uint8_t *buffer_e
         }
         // move pointer to the next line
         while (p < buffer_end && *p >= 0x20) {
-           p++;
+            p++;
         }
     }
 }
 
 static void
-pl_cue_set_track_field_values(playItem_t *it, cueparser_t *cue) {
+pl_cue_set_track_field_values (playItem_t *it, cueparser_t *cue) {
     if (cue->cuefields[CUE_FIELD_PERFORMER][0]) {
         pl_add_meta (it, "artist", cue->cuefields[CUE_FIELD_PERFORMER]);
-        if (cue->cuefields[CUE_FIELD_ALBUM_PERFORMER][0] && strcmp (cue->cuefields[CUE_FIELD_ALBUM_PERFORMER], cue->cuefields[CUE_FIELD_PERFORMER])) {
+        if (cue->cuefields[CUE_FIELD_ALBUM_PERFORMER][0] &&
+            strcmp (cue->cuefields[CUE_FIELD_ALBUM_PERFORMER], cue->cuefields[CUE_FIELD_PERFORMER])) {
             pl_add_meta (it, "album artist", cue->cuefields[CUE_FIELD_ALBUM_PERFORMER]);
         }
     }
@@ -278,40 +286,52 @@ pl_cue_set_track_field_values(playItem_t *it, cueparser_t *cue) {
         pl_add_meta (it, "ISRC", cue->cuefields[CUE_FIELD_ISRC]);
     }
     if (cue->cuefields[CUE_FIELD_REPLAYGAIN_ALBUM_GAIN][0]) {
-        pl_set_item_replaygain (it, DDB_REPLAYGAIN_ALBUMGAIN, (float)atof (cue->cuefields[CUE_FIELD_REPLAYGAIN_ALBUM_GAIN]));
+        pl_set_item_replaygain (
+            it,
+            DDB_REPLAYGAIN_ALBUMGAIN,
+            (float)atof (cue->cuefields[CUE_FIELD_REPLAYGAIN_ALBUM_GAIN]));
     }
     if (cue->cuefields[CUE_FIELD_REPLAYGAIN_ALBUM_PEAK][0]) {
-        pl_set_item_replaygain (it, DDB_REPLAYGAIN_ALBUMPEAK, (float)atof (cue->cuefields[CUE_FIELD_REPLAYGAIN_ALBUM_PEAK]));
+        pl_set_item_replaygain (
+            it,
+            DDB_REPLAYGAIN_ALBUMPEAK,
+            (float)atof (cue->cuefields[CUE_FIELD_REPLAYGAIN_ALBUM_PEAK]));
     }
     if (cue->cuefields[CUE_FIELD_REPLAYGAIN_TRACK_GAIN][0]) {
-        pl_set_item_replaygain (it, DDB_REPLAYGAIN_TRACKGAIN, (float)atof (cue->cuefields[CUE_FIELD_REPLAYGAIN_TRACK_GAIN]));
+        pl_set_item_replaygain (
+            it,
+            DDB_REPLAYGAIN_TRACKGAIN,
+            (float)atof (cue->cuefields[CUE_FIELD_REPLAYGAIN_TRACK_GAIN]));
     }
     if (cue->cuefields[CUE_FIELD_REPLAYGAIN_TRACK_PEAK][0]) {
-        pl_set_item_replaygain (it, DDB_REPLAYGAIN_TRACKPEAK, (float)atof (cue->cuefields[CUE_FIELD_REPLAYGAIN_TRACK_PEAK]));
+        pl_set_item_replaygain (
+            it,
+            DDB_REPLAYGAIN_TRACKPEAK,
+            (float)atof (cue->cuefields[CUE_FIELD_REPLAYGAIN_TRACK_PEAK]));
     }
 
     // add extra tags to tracks
     for (int y = 0; y < cue->extra_tag_index; y += 2) {
-        if (cue->extra_tags[y+1]) {
-            pl_add_meta (it, cue->extra_tags[y], cue->extra_tags[y+1]);
+        if (cue->extra_tags[y + 1]) {
+            pl_add_meta (it, cue->extra_tags[y], cue->extra_tags[y + 1]);
         }
     }
     for (int y = 0; y < cue->extra_track_tag_index; y += 2) {
-        if (cue->extra_track_tags[y+1]) {
-            pl_add_meta (it, cue->extra_track_tags[y], cue->extra_track_tags[y+1]);
+        if (cue->extra_track_tags[y + 1]) {
+            pl_add_meta (it, cue->extra_track_tags[y], cue->extra_track_tags[y + 1]);
         }
     }
     cue->extra_track_tag_index = 0;
     memset (cue->extra_track_tags, 0, sizeof (cue->extra_track_tags));
 
     // generated "total tracks" field
-    pl_add_meta(it, "numtracks", cue->cuefields[CUE_FIELD_TOTALTRACKS]);
+    pl_add_meta (it, "numtracks", cue->cuefields[CUE_FIELD_TOTALTRACKS]);
 
     pl_items_copy_junk (cue->origin, it, it);
 }
 
 static void
-pl_cue_reset_per_track_fields(char cuefields[CUE_MAX_FIELDS][255]) {
+pl_cue_reset_per_track_fields (char cuefields[CUE_MAX_FIELDS][255]) {
     //cuefields[CUE_FIELD_TRACK][0] = 0;
     cuefields[CUE_FIELD_TITLE][0] = 0;
     cuefields[CUE_FIELD_PREGAP][0] = 0;
@@ -329,12 +349,12 @@ pl_cue_reset_per_track_fields(char cuefields[CUE_MAX_FIELDS][255]) {
 // error:
 //    -1
 static int
-pl_cue_get_field_value(cueparser_t *cue) {
+pl_cue_get_field_value (cueparser_t *cue) {
     if (!strncasecmp (cue->p, "FILE ", 5)) {
         pl_get_qvalue_from_cue (cue->p + 5, CUE_FIELD_LEN, cue->cuefields[CUE_FIELD_FILE], cue->charset);
         const char *ext = strrchr (cue->cuefields[CUE_FIELD_FILE], '.');
-        if (ext && !strcasecmp(ext, ".cue")) {
-            trace_err("Cuesheet %s refers to another cuesheet, which is not allowed\n", cue->fname);
+        if (ext && !strcasecmp (ext, ".cue")) {
+            trace_err ("Cuesheet %s refers to another cuesheet, which is not allowed\n", cue->fname);
             return -1;
         }
         return CUE_FIELD_FILE;
@@ -346,17 +366,25 @@ pl_cue_get_field_value(cueparser_t *cue) {
     }
     else if (!strncasecmp (cue->p, "PERFORMER ", 10)) {
         if (!cue->cuefields[CUE_FIELD_TRACK][0]) {
-            pl_get_qvalue_from_cue (cue->p + 10, CUE_FIELD_LEN, cue->cuefields[CUE_FIELD_ALBUM_PERFORMER], cue->charset);
+            pl_get_qvalue_from_cue (
+                cue->p + 10,
+                CUE_FIELD_LEN,
+                cue->cuefields[CUE_FIELD_ALBUM_PERFORMER],
+                cue->charset);
             return CUE_FIELD_ALBUM_PERFORMER;
         }
         else {
-             pl_get_qvalue_from_cue (cue->p + 10, CUE_FIELD_LEN, cue->cuefields[CUE_FIELD_PERFORMER], cue->charset);
-             return CUE_FIELD_PERFORMER;
+            pl_get_qvalue_from_cue (cue->p + 10, CUE_FIELD_LEN, cue->cuefields[CUE_FIELD_PERFORMER], cue->charset);
+            return CUE_FIELD_PERFORMER;
         }
     }
     else if (!strncasecmp (cue->p, "SONGWRITER ", 11)) {
         if (!cue->cuefields[CUE_FIELD_TRACK][0]) {
-            pl_get_qvalue_from_cue (cue->p + 11, CUE_FIELD_LEN, cue->cuefields[CUE_FIELD_ALBUM_SONGWRITER], cue->charset);
+            pl_get_qvalue_from_cue (
+                cue->p + 11,
+                CUE_FIELD_LEN,
+                cue->cuefields[CUE_FIELD_ALBUM_SONGWRITER],
+                cue->charset);
             return CUE_FIELD_ALBUM_SONGWRITER;
         }
         else {
@@ -415,7 +443,7 @@ pl_cue_get_field_value(cueparser_t *cue) {
     else {
         // determine and get extra tags
         for (int m = 0; cue_field_map[m]; m += 2) {
-            if (!strncasecmp (cue->p, cue_field_map[m], strlen(cue_field_map[m]))) {
+            if (!strncasecmp (cue->p, cue_field_map[m], strlen (cue_field_map[m]))) {
                 char *key = NULL;
                 char *value = NULL;
                 if (!cue->have_track) {
@@ -423,7 +451,7 @@ pl_cue_get_field_value(cueparser_t *cue) {
                         break;
                     }
                     key = cue->extra_tags[cue->extra_tag_index];
-                    value = cue->extra_tags[cue->extra_tag_index+1];
+                    value = cue->extra_tags[cue->extra_tag_index + 1];
                     cue->extra_tag_index = cue->extra_tag_index + 2;
                 }
                 else {
@@ -431,12 +459,12 @@ pl_cue_get_field_value(cueparser_t *cue) {
                         break;
                     }
                     key = cue->extra_track_tags[cue->extra_track_tag_index];
-                    value = cue->extra_track_tags[cue->extra_track_tag_index+1];
+                    value = cue->extra_track_tags[cue->extra_track_tag_index + 1];
                     cue->extra_track_tag_index = cue->extra_track_tag_index + 2;
                 }
 
-                strcpy(key,cue_field_map[m+1]);
-                pl_get_qvalue_from_cue (cue->p + strlen(cue_field_map[m]), CUE_FIELD_LEN, value, cue->charset);
+                strcpy (key, cue_field_map[m + 1]);
+                pl_get_qvalue_from_cue (cue->p + strlen (cue_field_map[m]), CUE_FIELD_LEN, value, cue->charset);
                 return CUE_MAX_FIELDS;
             }
         }
@@ -453,10 +481,10 @@ pl_cue_get_field_value(cueparser_t *cue) {
 
 static int
 _file_exists (const char *fname) {
-    if (!plug_is_local_file(fname)) {
+    if (!plug_is_local_file (fname)) {
         return 0;
     }
-    DB_FILE *fp = vfs_fopen(fname);
+    DB_FILE *fp = vfs_fopen (fname);
     if (!fp) {
         return 0;
     }
@@ -467,15 +495,25 @@ _file_exists (const char *fname) {
 static int
 _set_last_item_region (playlist_t *plt, playItem_t *it, playItem_t *origin, int64_t totalsamples, int samplerate) {
     pl_item_set_endsample (it, pl_item_get_startsample (origin) + totalsamples - 1);
-    if ((pl_item_get_endsample (it) - pl_item_get_startsample (origin)) >= totalsamples || (pl_item_get_startsample (it)-pl_item_get_startsample (origin)) >= totalsamples) {
+    if ((pl_item_get_endsample (it) - pl_item_get_startsample (origin)) >= totalsamples ||
+        (pl_item_get_startsample (it) - pl_item_get_startsample (origin)) >= totalsamples) {
         return -1;
     }
-    plt_set_item_duration (plt, it, (float)(pl_item_get_endsample (it) - pl_item_get_startsample (it) + 1) / samplerate);
+    plt_set_item_duration (
+        plt,
+        it,
+        (float)(pl_item_get_endsample (it) - pl_item_get_startsample (it) + 1) / samplerate);
     return 0;
 }
 
 playItem_t *
-plt_load_cue_file (playlist_t *plt, playItem_t *after, const char *fname, const char *dirname, struct dirent **namelist, int n) {
+plt_load_cue_file (
+    playlist_t *plt,
+    playItem_t *after,
+    const char *fname,
+    const char *dirname,
+    struct dirent **namelist,
+    int n) {
     char resolved_fname[PATH_MAX];
 
     uint8_t *membuffer = NULL;
@@ -542,7 +580,6 @@ _file_present_in_namelist (const char *fullpath, cueparser_t *cue) {
     return 1;
 }
 
-
 static int
 cue_addfile_filter (cueparser_t *cue) {
     ddb_file_found_data_t dt;
@@ -570,7 +607,7 @@ _load_nextfile (cueparser_t *cue) {
     }
     else {
         // try relative path
-        snprintf(cue->fullpath, sizeof(cue->fullpath), "%s/%s", cue->cue_file_dir, audio_file);
+        snprintf (cue->fullpath, sizeof (cue->fullpath), "%s/%s", cue->cue_file_dir, audio_file);
 
         if (!_file_exists (cue->fullpath)) {
             cue->fullpath[0] = 0;
@@ -585,12 +622,18 @@ _load_nextfile (cueparser_t *cue) {
                             continue;
                         }
 
-                        if (!strncasecmp (cue->cue_fname, cue->namelist[i]->d_name, l-4)) {
+                        if (!strncasecmp (cue->cue_fname, cue->namelist[i]->d_name, l - 4)) {
                             // have to try loading each of these files
-                            snprintf (cue->fullpath, sizeof (cue->fullpath), "%s/%s", cue->dirname, cue->namelist[i]->d_name);
-                            int res = cue_addfile_filter(cue);
+                            snprintf (
+                                cue->fullpath,
+                                sizeof (cue->fullpath),
+                                "%s/%s",
+                                cue->dirname,
+                                cue->namelist[i]->d_name);
+                            int res = cue_addfile_filter (cue);
                             if (res >= 0) {
-                                cue->origin = plt_insert_file2 (-1, cue->temp_plt, NULL, cue->fullpath, NULL, NULL, NULL);
+                                cue->origin =
+                                    plt_insert_file2 (-1, cue->temp_plt, NULL, cue->fullpath, NULL, NULL, NULL);
                             }
                             if (cue->origin) {
                                 image_found = 1;
@@ -612,15 +655,21 @@ _load_nextfile (cueparser_t *cue) {
                             continue;
                         }
 
-                        if (!strncasecmp (audio_file, cue->namelist[i]->d_name, ext-audio_file)
-                            && cue->namelist[i]->d_name[ext-audio_file] == '.') {
+                        if (!strncasecmp (audio_file, cue->namelist[i]->d_name, ext - audio_file) &&
+                            cue->namelist[i]->d_name[ext - audio_file] == '.') {
                             // have to try loading each of these files
-                            snprintf (cue->fullpath, sizeof (cue->fullpath), "%s/%s", cue->dirname, cue->namelist[i]->d_name);
+                            snprintf (
+                                cue->fullpath,
+                                sizeof (cue->fullpath),
+                                "%s/%s",
+                                cue->dirname,
+                                cue->namelist[i]->d_name);
 
                             // adding to temp playlist will fail file add filters, so need to call this manually here
-                            int res = cue_addfile_filter(cue);
+                            int res = cue_addfile_filter (cue);
                             if (res >= 0) {
-                                cue->origin = plt_insert_file2 (-1, cue->temp_plt, NULL, cue->fullpath, NULL, NULL, NULL);
+                                cue->origin =
+                                    plt_insert_file2 (-1, cue->temp_plt, NULL, cue->fullpath, NULL, NULL, NULL);
                             }
                             if (cue->origin) {
                                 cue->namelist[i]->d_name[0] = 0;
@@ -694,7 +743,10 @@ _load_nextfile (cueparser_t *cue) {
         if (!cue->namelist) {
             // only display error if adding individual file;
             // this is to prevent bogus errors when auto-scanning for cuesheets in folders.
-            trace_err("Invalid FILE entry %s in cuesheet %s, and could not guess any suitable file name.\n", audio_file, cue->fname);
+            trace_err (
+                "Invalid FILE entry %s in cuesheet %s, and could not guess any suitable file name.\n",
+                audio_file,
+                cue->fname);
         }
         cue->dec = cue->filetype = NULL;
         return -1;
@@ -734,7 +786,10 @@ plt_process_cue_track (playlist_t *plt, cueparser_t *cue) {
             return -1;
         }
         pl_item_set_endsample (cue->prev, cue->currsample - 1);
-        plt_set_item_duration (plt, cue->prev, (float)(cue->currsample - pl_item_get_startsample (cue->prev)) / cue->samplerate);
+        plt_set_item_duration (
+            plt,
+            cue->prev,
+            (float)(cue->currsample - pl_item_get_startsample (cue->prev)) / cue->samplerate);
     }
 
     playItem_t *it = pl_item_alloc_init (cue->fullpath, cue->dec);
@@ -743,7 +798,7 @@ plt_process_cue_track (playlist_t *plt, cueparser_t *cue) {
     pl_item_set_endsample (it, -1); // will be filled by next read, or by decoder
     pl_replace_meta (it, ":FILETYPE", cue->filetype);
 
-    pl_cue_set_track_field_values(it, cue);
+    pl_cue_set_track_field_values (it, cue);
 
     if (cue->last_round) {
         int res = _set_last_item_region (plt, it, cue->origin, cue->numsamples, cue->samplerate);
@@ -777,7 +832,18 @@ _is_audio_track (const char *track) {
 }
 
 playItem_t *
-plt_load_cuesheet_from_buffer (playlist_t *plt, playItem_t *after, const char *fname, playItem_t *embedded_origin, int64_t embedded_numsamples, int embedded_samplerate, const uint8_t *buffer, int sz, const char *dirname, struct dirent **namelist, int n) {
+plt_load_cuesheet_from_buffer (
+    playlist_t *plt,
+    playItem_t *after,
+    const char *fname,
+    playItem_t *embedded_origin,
+    int64_t embedded_numsamples,
+    int embedded_samplerate,
+    const uint8_t *buffer,
+    int sz,
+    const char *dirname,
+    struct dirent **namelist,
+    int n) {
     playItem_t *result = NULL;
     cueparser_t cue;
     memset (&cue, 0, sizeof (cue));
@@ -788,7 +854,7 @@ plt_load_cuesheet_from_buffer (playlist_t *plt, playItem_t *after, const char *f
     cue.embedded_samplerate = embedded_samplerate;
 
     playItem_t *ins = after;
-    char cue_file_dir[strlen(fname)]; // can't be longer than fname
+    char cue_file_dir[strlen (fname)]; // can't be longer than fname
     cue.cue_file_dir = cue_file_dir;
 
     cue_file_dir[0] = 0;
@@ -796,9 +862,8 @@ plt_load_cuesheet_from_buffer (playlist_t *plt, playItem_t *after, const char *f
 
     if (slash && slash > fname) {
         strncat (cue_file_dir, fname, slash - fname);
-        cue.cue_fname = slash+1;
+        cue.cue_fname = slash + 1;
     }
-
 
     cue.dirname = dirname;
     cue.namelist = namelist;
@@ -817,27 +882,26 @@ plt_load_cuesheet_from_buffer (playlist_t *plt, playItem_t *after, const char *f
     cue.charset = junk_detect_charset (buffer);
     cue.p = buffer;
 
-    const uint8_t *end = buffer+sz;
+    const uint8_t *end = buffer + sz;
 
     // determine total tracks/files
-    pl_cue_get_total_tracks_and_files(cue.p, end, &cue.ncuefiles, &cue.ncuetracks);
+    pl_cue_get_total_tracks_and_files (cue.p, end, &cue.ncuefiles, &cue.ncuetracks);
     if (!cue.ncuefiles) {
-        trace_err("Cuesheet has zero FILE entries (%s)\n", fname);
+        trace_err ("Cuesheet has zero FILE entries (%s)\n", fname);
         goto error;
     }
 
     if (!cue.ncuetracks) {
-        trace_err("Cuesheet has zero TRACK entries (%s)\n", fname);
+        trace_err ("Cuesheet has zero TRACK entries (%s)\n", fname);
         goto error;
     }
 
     if (cue.ncuefiles > 1 && embedded_origin) {
-        trace_err("Can't load embedded cuesheet referencing multiple audio files (%s)\n", fname);
+        trace_err ("Can't load embedded cuesheet referencing multiple audio files (%s)\n", fname);
         goto error;
     }
 
-
-    snprintf(cue.cuefields[CUE_FIELD_TOTALTRACKS], CUE_FIELD_LEN, "%d", cue.ncuetracks);
+    snprintf (cue.cuefields[CUE_FIELD_TOTALTRACKS], CUE_FIELD_LEN, "%d", cue.ncuetracks);
 
     int filefield = 0;
 
@@ -849,7 +913,7 @@ plt_load_cuesheet_from_buffer (playlist_t *plt, playItem_t *after, const char *f
             cue.last_round = 1;
         }
         else {
-            field = pl_cue_get_field_value(&cue);
+            field = pl_cue_get_field_value (&cue);
             if (field < 0) {
                 goto error;
             }
@@ -859,8 +923,7 @@ plt_load_cuesheet_from_buffer (playlist_t *plt, playItem_t *after, const char *f
         if (filefield) {
             filefield = 0;
             // If FILE is immediately followed by TRACK, that next TRACK is from the new FILE
-            if (field == CUE_FIELD_TRACK
-                && _is_audio_track(cue.cuefields[CUE_FIELD_TRACK])) {
+            if (field == CUE_FIELD_TRACK && _is_audio_track (cue.cuefields[CUE_FIELD_TRACK])) {
                 if (plt_process_cue_track (plt, &cue) < 0) {
                     goto error;
                 }
@@ -905,7 +968,7 @@ plt_load_cuesheet_from_buffer (playlist_t *plt, playItem_t *after, const char *f
         }
         else if (field == CUE_FIELD_TRACK) {
             if (cue.origin && cue.have_track) {
-                if (_is_audio_track(cue.cuefields[CUE_FIELD_TRACK])) {
+                if (_is_audio_track (cue.cuefields[CUE_FIELD_TRACK])) {
                     if (plt_process_cue_track (plt, &cue) < 0) {
                         goto error;
                     }
@@ -920,7 +983,7 @@ plt_load_cuesheet_from_buffer (playlist_t *plt, playItem_t *after, const char *f
                 break;
             }
 
-            pl_cue_reset_per_track_fields(cue.cuefields);
+            pl_cue_reset_per_track_fields (cue.cuefields);
             pl_get_value_from_cue (cue.p + 6, CUE_FIELD_LEN, cue.cuefields[CUE_FIELD_TRACK]);
             cue.have_track = 1;
         }
@@ -951,4 +1014,3 @@ error:
     }
     return result;
 }
-

--- a/src/cueutil.h
+++ b/src/cueutil.h
@@ -38,7 +38,13 @@
 //  `namelist` and `n` is the scandir output.
 //  The `dirname`, `namelist` and `n` can be either all set to NULL, otherwise they all must be valid values.
 playItem_t *
-plt_load_cue_file (playlist_t *playlist, playItem_t *after, const char *fullname, const char *dirname, struct dirent **namelist, int n);
+plt_load_cue_file (
+    playlist_t *playlist,
+    playItem_t *after,
+    const char *fullname,
+    const char *dirname,
+    struct dirent **namelist,
+    int n);
 
 // This is a more internal function, to load cuesheet from buffer.
 // Semantics are the same as `plt_load_cue_file`.
@@ -51,5 +57,15 @@ plt_load_cue_file (playlist_t *playlist, playItem_t *after, const char *fullname
 //  `buffer`: pointer to the string containing cuesheet.
 //  `buffersize`: size of the buffer.
 playItem_t *
-plt_load_cuesheet_from_buffer (playlist_t *playlist, playItem_t *after, const char *fname, playItem_t *embedded_origin, int64_t embedded_numsamples, int embedded_samplerate, const uint8_t *buffer, int buffersize, const char *dirname, struct dirent **namelist, int n);
-
+plt_load_cuesheet_from_buffer (
+    playlist_t *playlist,
+    playItem_t *after,
+    const char *fname,
+    playItem_t *embedded_origin,
+    int64_t embedded_numsamples,
+    int embedded_samplerate,
+    const uint8_t *buffer,
+    int buffersize,
+    const char *dirname,
+    struct dirent **namelist,
+    int n);

--- a/src/decodedblock.c
+++ b/src/decodedblock.c
@@ -47,7 +47,7 @@ decoded_blocks_free (void) {
     while (_decoded_blocks) {
         decoded_block_t *next = _decoded_blocks->next;
         if (_decoded_blocks->track != NULL) {
-            pl_item_unref(_decoded_blocks->track);
+            pl_item_unref (_decoded_blocks->track);
             _decoded_blocks->track = NULL;
         }
         free (_decoded_blocks);
@@ -106,7 +106,7 @@ decoded_blocks_next (void) {
 }
 
 decoded_block_t *
-decoded_blocks_append(void) {
+decoded_blocks_append (void) {
     if (_decoded_blocks_free->queued) {
         return NULL; // all buffers full
     }

--- a/src/dsp.c
+++ b/src/dsp.c
@@ -142,7 +142,7 @@ streamer_set_dsp_chain_real (ddb_dsp_context_t *chain) {
     _eq = NULL;
 
     streamer_dsp_postinit ();
-    streamer_dsp_chain_save();
+    streamer_dsp_chain_save ();
 
     streamer_unlock ();
 
@@ -313,7 +313,6 @@ streamer_dsp_postinit (void) {
             _eq->next = _current_dsp_chain;
             _current_dsp_chain = _eq;
         }
-
     }
     ddb_dsp_context_t *ctx = _current_dsp_chain;
     while (ctx) {
@@ -328,7 +327,6 @@ streamer_dsp_postinit (void) {
     else if (!ctx) {
         _dsp_on = 0;
     }
-
 }
 
 void
@@ -361,32 +359,37 @@ streamer_dsp_init (void) {
 
         // 0.4.4 was writing buggy settings, need to multiply by 2 to compensate
         conf_get_str ("eq.preamp", "0", s, sizeof (s));
-        snprintf (s, sizeof (s), "%f", atof(s)*2);
+        snprintf (s, sizeof (s), "%f", atof (s) * 2);
         _eqplug->set_param (_eq, 0, s);
         for (int i = 0; i < 18; i++) {
             char key[100];
             snprintf (key, sizeof (key), "eq.band%d", i);
             conf_get_str (key, "0", s, sizeof (s));
-            snprintf (s, sizeof (s), "%f", atof(s)*2);
-            _eqplug->set_param (_eq, 1+i, s);
+            snprintf (s, sizeof (s), "%f", atof (s) * 2);
+            _eqplug->set_param (_eq, 1 + i, s);
         }
         // delete obsolete settings
         conf_remove_items ("eq.");
     }
 }
 
-
 int
-dsp_apply (ddb_waveformat_t *input_fmt, char *input, int inputsize,
-           ddb_waveformat_t *out_fmt, char **out_bytes, int *out_numbytes, float *out_dsp_ratio) {
+dsp_apply (
+    ddb_waveformat_t *input_fmt,
+    char *input,
+    int inputsize,
+    ddb_waveformat_t *out_fmt,
+    char **out_bytes,
+    int *out_numbytes,
+    float *out_dsp_ratio) {
 
     *out_dsp_ratio = 1;
 
     if (input_fmt->flags & DDB_WAVEFORMAT_FLAG_IS_DOP) {
-        memcpy(out_fmt, input_fmt, sizeof(ddb_waveformat_t));
+        memcpy (out_fmt, input_fmt, sizeof (ddb_waveformat_t));
         *out_bytes = ensure_dsp_temp_buffer (inputsize);
         *out_numbytes = inputsize;
-        memcpy(*out_bytes, input, inputsize);
+        memcpy (*out_bytes, input, inputsize);
         return 1;
     }
 
@@ -407,7 +410,7 @@ dsp_apply (ddb_waveformat_t *input_fmt, char *input, int inputsize,
     dspfmt.channels = dspfmt_ch;
     dspfmt.channelmask = 0;
     for (int i = 0; i < dspfmt_ch; i++) {
-        dspfmt.channelmask |= (1<<i);
+        dspfmt.channelmask |= (1 << i);
     }
 
     int can_bypass = 0;
@@ -442,11 +445,11 @@ dsp_apply (ddb_waveformat_t *input_fmt, char *input, int inputsize,
     int dspsamplesize = dspfmt_ch * sizeof (float);
 
     // make *MAX_DSP_RATIO sized buffer for float data
-    int tempbuf_size = inputsize/inputsamplesize * dspsamplesize * MAX_DSP_RATIO;
+    int tempbuf_size = inputsize / inputsamplesize * dspsamplesize * MAX_DSP_RATIO;
     char *tempbuf = ensure_dsp_temp_buffer (tempbuf_size);
 
     // convert to float
-    /*int tempsize = */pcm_convert (input_fmt, input, &dspfmt, tempbuf, inputsize);
+    /*int tempsize = */ pcm_convert (input_fmt, input, &dspfmt, tempbuf, inputsize);
     int nframes = inputsize / inputsamplesize;
     ddb_dsp_context_t *dsp = _current_dsp_chain;
     float ratio = 1.f;
@@ -496,7 +499,14 @@ dsp_get_output_format (ddb_waveformat_t *in_fmt, ddb_waveformat_t *out_fmt) {
 // Only int16 is supported, any number of channels
 // Returns number of bytes consumed from input.
 int
-dsp_apply_simple_downsampler (int input_samplerate, int channels, char *input, int inputsize, int output_samplerate, char **out_bytes, int *out_numbytes) {
+dsp_apply_simple_downsampler (
+    int input_samplerate,
+    int channels,
+    char *input,
+    int inputsize,
+    int output_samplerate,
+    char **out_bytes,
+    int *out_numbytes) {
     if (input_samplerate == output_samplerate) {
         *out_bytes = input;
         *out_numbytes = inputsize;
@@ -526,9 +536,9 @@ dsp_apply_simple_downsampler (int input_samplerate, int channels, char *input, i
         int nframes = inputsize / 2 / channels;
         int16_t *in = (int16_t *)input;
         int16_t *out = (int16_t *)bytes;
-        for (int f = 0; f < nframes/2; f++) {
+        for (int f = 0; f < nframes / 2; f++) {
             for (int c = 0; c < channels; c++) {
-                out[f*channels+c] = (in[f*2*channels+c] + in[(f*2+1)*channels+c]) >> 1;
+                out[f * channels + c] = (in[f * 2 * channels + c] + in[(f * 2 + 1) * channels + c]) >> 1;
             }
         }
         return inputsize;
@@ -553,12 +563,11 @@ dsp_apply_simple_downsampler (int input_samplerate, int channels, char *input, i
         assert (inputsize % (2 * channels) == 0);
         int16_t *in = (int16_t *)input;
         int16_t *out = (int16_t *)bytes;
-        for (int f = 0; f < nframes/4; f++) {
+        for (int f = 0; f < nframes / 4; f++) {
             for (int c = 0; c < channels; c++) {
-                out[f*channels+c] = (in[f*4*channels+c]
-                                    + in[(f*4+1)*channels+c]
-                                    + in[(f*4+2)*channels+c]
-                                    + in[(f*4+3)*channels+c]) >> 2;
+                out[f * channels + c] = (in[f * 4 * channels + c] + in[(f * 4 + 1) * channels + c] +
+                                         in[(f * 4 + 2) * channels + c] + in[(f * 4 + 3) * channels + c]) >>
+                                        2;
             }
         }
         return inputsize;
@@ -568,6 +577,6 @@ dsp_apply_simple_downsampler (int input_samplerate, int channels, char *input, i
         *out_bytes = input;
         *out_numbytes = inputsize;
     }
-    
+
     return inputsize;
 }

--- a/src/dsp.h
+++ b/src/dsp.h
@@ -64,14 +64,27 @@ ddb_dsp_context_t *
 dsp_clone (ddb_dsp_context_t *from);
 
 int
-dsp_apply (ddb_waveformat_t *input_fmt, char *input, int inputsize,
-           ddb_waveformat_t *out_fmt, char **out_bytes, int *out_numbytes, float *out_dsp_ratio);
+dsp_apply (
+    ddb_waveformat_t *input_fmt,
+    char *input,
+    int inputsize,
+    ddb_waveformat_t *out_fmt,
+    char **out_bytes,
+    int *out_numbytes,
+    float *out_dsp_ratio);
 
 void
 dsp_get_output_format (ddb_waveformat_t *in_fmt, ddb_waveformat_t *out_fmt);
 
 int
-dsp_apply_simple_downsampler (int input_samplerate, int channels, char *input, int inputsize, int output_samplerate, char **out_bytes, int *out_numbytes);
+dsp_apply_simple_downsampler (
+    int input_samplerate,
+    int channels,
+    char *input,
+    int inputsize,
+    int output_samplerate,
+    char **out_bytes,
+    int *out_numbytes);
 
 #ifdef __cplusplus
 }

--- a/src/escape.c
+++ b/src/escape.c
@@ -33,140 +33,192 @@
    its behavior is altered by the current locale.
    See http://tools.ietf.org/html/rfc3986#section-2.3
 */
-static int Curl_isunreserved(unsigned char in)
-{
-  switch (in) {
-    case '0': case '1': case '2': case '3': case '4':
-    case '5': case '6': case '7': case '8': case '9':
-    case 'a': case 'b': case 'c': case 'd': case 'e':
-    case 'f': case 'g': case 'h': case 'i': case 'j':
-    case 'k': case 'l': case 'm': case 'n': case 'o':
-    case 'p': case 'q': case 'r': case 's': case 't':
-    case 'u': case 'v': case 'w': case 'x': case 'y': case 'z':
-    case 'A': case 'B': case 'C': case 'D': case 'E':
-    case 'F': case 'G': case 'H': case 'I': case 'J':
-    case 'K': case 'L': case 'M': case 'N': case 'O':
-    case 'P': case 'Q': case 'R': case 'S': case 'T':
-    case 'U': case 'V': case 'W': case 'X': case 'Y': case 'Z':
-    case '-': case '.': case '_': case '~':
-      return 1;
+static int
+Curl_isunreserved (unsigned char in) {
+    switch (in) {
+    case '0':
+    case '1':
+    case '2':
+    case '3':
+    case '4':
+    case '5':
+    case '6':
+    case '7':
+    case '8':
+    case '9':
+    case 'a':
+    case 'b':
+    case 'c':
+    case 'd':
+    case 'e':
+    case 'f':
+    case 'g':
+    case 'h':
+    case 'i':
+    case 'j':
+    case 'k':
+    case 'l':
+    case 'm':
+    case 'n':
+    case 'o':
+    case 'p':
+    case 'q':
+    case 'r':
+    case 's':
+    case 't':
+    case 'u':
+    case 'v':
+    case 'w':
+    case 'x':
+    case 'y':
+    case 'z':
+    case 'A':
+    case 'B':
+    case 'C':
+    case 'D':
+    case 'E':
+    case 'F':
+    case 'G':
+    case 'H':
+    case 'I':
+    case 'J':
+    case 'K':
+    case 'L':
+    case 'M':
+    case 'N':
+    case 'O':
+    case 'P':
+    case 'Q':
+    case 'R':
+    case 'S':
+    case 'T':
+    case 'U':
+    case 'V':
+    case 'W':
+    case 'X':
+    case 'Y':
+    case 'Z':
+    case '-':
+    case '.':
+    case '_':
+    case '~':
+        return 1;
     default:
-      break;
-  }
-  return 0;
+        break;
+    }
+    return 0;
 }
 
-char *uri_escape(const char *string, int inlength)
-{
-  size_t alloc = (inlength?(size_t)inlength:strlen(string))+1;
-  char *ns;
-  char *testing_ptr = NULL;
-  unsigned char in; /* we need to treat the characters unsigned */
-  size_t newlen = alloc;
-  int strindex=0;
-  size_t length;
+char *
+uri_escape (const char *string, int inlength) {
+    size_t alloc = (inlength ? (size_t)inlength : strlen (string)) + 1;
+    char *ns;
+    char *testing_ptr = NULL;
+    unsigned char in; /* we need to treat the characters unsigned */
+    size_t newlen = alloc;
+    int strindex = 0;
+    size_t length;
 
-  ns = malloc(alloc);
-  if(!ns)
-    return NULL;
+    ns = malloc (alloc);
+    if (!ns)
+        return NULL;
 
-  length = alloc-1;
-  while(length--) {
-    in = *string;
+    length = alloc - 1;
+    while (length--) {
+        in = *string;
 
-    if (Curl_isunreserved(in)) {
-      /* just copy this */
-      ns[strindex++]=in;
-    }
-    else {
-      /* encode it */
-      newlen += 2; /* the size grows with two, since this'll become a %XX */
-      if(newlen > alloc) {
-        alloc *= 2;
-        testing_ptr = realloc(ns, alloc);
-        if(!testing_ptr) {
-          free( ns );
-          return NULL;
+        if (Curl_isunreserved (in)) {
+            /* just copy this */
+            ns[strindex++] = in;
         }
         else {
-          ns = testing_ptr;
+            /* encode it */
+            newlen += 2; /* the size grows with two, since this'll become a %XX */
+            if (newlen > alloc) {
+                alloc *= 2;
+                testing_ptr = realloc (ns, alloc);
+                if (!testing_ptr) {
+                    free (ns);
+                    return NULL;
+                }
+                else {
+                    ns = testing_ptr;
+                }
+            }
+
+            snprintf (&ns[strindex], 4, "%%%02X", in);
+
+            strindex += 3;
         }
-      }
-
-      snprintf(&ns[strindex], 4, "%%%02X", in);
-
-      strindex+=3;
+        string++;
     }
-    string++;
-  }
-  ns[strindex]=0; /* terminate it */
-  return ns;
+    ns[strindex] = 0; /* terminate it */
+    return ns;
 }
 
-#define ISXDIGIT(x) (isxdigit((int) ((unsigned char)x)))
-#define CURL_MASK_UCHAR  0xFF
+#define ISXDIGIT(x) (isxdigit ((int)((unsigned char)x)))
+#define CURL_MASK_UCHAR 0xFF
 
 /*
 ** unsigned long to unsigned char
 */
 
-unsigned char curlx_ultouc(unsigned long ulnum)
-{
+unsigned char
+curlx_ultouc (unsigned long ulnum) {
 #ifdef __INTEL_COMPILER
-#  pragma warning(push)
-#  pragma warning(disable:810) /* conversion may lose significant bits */
+#    pragma warning(push)
+#    pragma warning(disable : 810) /* conversion may lose significant bits */
 #endif
 
-  return (unsigned char)(ulnum & (unsigned long) CURL_MASK_UCHAR);
+    return (unsigned char)(ulnum & (unsigned long)CURL_MASK_UCHAR);
 
 #ifdef __INTEL_COMPILER
-#  pragma warning(pop)
+#    pragma warning(pop)
 #endif
 }
 
-char *uri_unescape(const char *string, int length)
-{
-  int alloc = (length?length:(int)strlen(string))+1;
-  char *ns = malloc(alloc);
-  unsigned char in;
-  int strindex=0;
-  unsigned long hex;
+char *
+uri_unescape (const char *string, int length) {
+    int alloc = (length ? length : (int)strlen (string)) + 1;
+    char *ns = malloc (alloc);
+    unsigned char in;
+    int strindex = 0;
+    unsigned long hex;
 
-  if( !ns )
-    return NULL;
+    if (!ns)
+        return NULL;
 
-  while(--alloc > 0) {
-    in = *string;
-    if(('%' == in) && ISXDIGIT(string[1]) && ISXDIGIT(string[2])) {
-      /* this is two hexadecimal digits following a '%' */
-      char hexstr[3];
-      char *ptr;
-      hexstr[0] = string[1];
-      hexstr[1] = string[2];
-      hexstr[2] = 0;
+    while (--alloc > 0) {
+        in = *string;
+        if (('%' == in) && ISXDIGIT (string[1]) && ISXDIGIT (string[2])) {
+            /* this is two hexadecimal digits following a '%' */
+            char hexstr[3];
+            char *ptr;
+            hexstr[0] = string[1];
+            hexstr[1] = string[2];
+            hexstr[2] = 0;
 
-      hex = strtoul(hexstr, &ptr, 16);
+            hex = strtoul (hexstr, &ptr, 16);
 
-      in = curlx_ultouc(hex); /* this long is never bigger than 255 anyway */
+            in = curlx_ultouc (hex); /* this long is never bigger than 255 anyway */
 
 #ifdef CURL_DOES_CONVERSIONS
-/* escape sequences are always in ASCII so convert them on non-ASCII hosts */
-      if(!handle ||
-          (Curl_convert_from_network(handle, &in, 1) != CURLE_OK)) {
-        /* Curl_convert_from_network calls failf if unsuccessful */
-        free(ns);
-        return NULL;
-      }
+            /* escape sequences are always in ASCII so convert them on non-ASCII hosts */
+            if (!handle || (Curl_convert_from_network (handle, &in, 1) != CURLE_OK)) {
+                /* Curl_convert_from_network calls failf if unsuccessful */
+                free (ns);
+                return NULL;
+            }
 #endif /* CURL_DOES_CONVERSIONS */
 
-      string+=2;
-      alloc-=2;
+            string += 2;
+            alloc -= 2;
+        }
+
+        ns[strindex++] = in;
+        string++;
     }
+    ns[strindex] = 0; /* terminate it */
 
-    ns[strindex++] = in;
-    string++;
-  }
-  ns[strindex]=0; /* terminate it */
-
-  return ns;
+    return ns;
 }

--- a/src/escape.h
+++ b/src/escape.h
@@ -23,7 +23,9 @@
 #ifndef __ESCAPE_H
 #define __ESCAPE_H
 
-char *uri_escape(const char *string, int inlength);
-char *uri_unescape(const char *string, int inlength);
+char *
+uri_escape (const char *string, int inlength);
+char *
+uri_unescape (const char *string, int inlength);
 
 #endif

--- a/src/fft.c
+++ b/src/fft.c
@@ -21,7 +21,7 @@
 // please find the original file in audacious
 
 #ifdef HAVE_CONFIG_H
-#  include <config.h>
+#    include <config.h>
 #endif
 #include <complex.h>
 #include "fft.h"
@@ -29,14 +29,17 @@
 #include <stdlib.h>
 
 static int _fft_size;
-static float *_hamming;          /* hamming window, scaled to sum to 1 */
-static int *_reversed;           /* bit-reversal table */
-static float complex *_roots;    /* N-th roots of unity */
-static int LOGN;                 /* log N (base 2) */
-static int N;                    /* _fft_size * 2 */
+static float *_hamming; /* hamming window, scaled to sum to 1 */
+static int *_reversed; /* bit-reversal table */
+static float complex *_roots; /* N-th roots of unity */
+static int LOGN; /* log N (base 2) */
+static int N; /* _fft_size * 2 */
 
 #ifndef HAVE_LOG2
-static inline float log2(float x) {return (float)log(x)/M_LN2;}
+static inline float
+log2 (float x) {
+    return (float)log (x) / M_LN2;
+}
 #endif
 
 static void
@@ -52,12 +55,10 @@ _free_buffers (void) {
 /* Reverse the order of the lowest LOGN bits in an integer. */
 
 static int
-_bit_reverse (int x)
-{
+_bit_reverse (int x) {
     int y = 0;
 
-    for (int n = LOGN; n --; )
-    {
+    for (int n = LOGN; n--;) {
         y = (y << 1) | (x & 1);
         x >>= 1;
     }
@@ -68,45 +69,40 @@ _bit_reverse (int x)
 /* Generate lookup tables. */
 
 static void
-_generate_tables (void)
-{
-    for (int n = 0; n < N; n ++)
+_generate_tables (void) {
+    for (int n = 0; n < N; n++)
         _hamming[n] = 1 - 0.85f * cosf (2 * (float)M_PI * n / N);
-    for (int n = 0; n < N; n ++)
+    for (int n = 0; n < N; n++)
         _reversed[n] = _bit_reverse (n);
-    for (int n = 0; n < N / 2; n ++)
+    for (int n = 0; n < N / 2; n++)
         _roots[n] = cexpf (2 * (float)M_PI * I * n / N);
 }
 
 static void
 _init_buffers (int fft_size) {
     if (_fft_size != fft_size) {
-        _free_buffers();
+        _free_buffers ();
         _fft_size = fft_size;
         N = fft_size * 2;
         _hamming = calloc (N, sizeof (float));
         _reversed = calloc (N, sizeof (float));
         _roots = calloc (fft_size, sizeof (float complex));
-        LOGN = (int)log2(N);
-        _generate_tables();
+        LOGN = (int)log2 (N);
+        _generate_tables ();
     }
 }
 
 static void
-_do_fft (float complex *a)
-{
-    int half = 1;       /* (2^s)/2 */
-    int inv = N / 2;    /* N/(2^s) */
+_do_fft (float complex *a) {
+    int half = 1; /* (2^s)/2 */
+    int inv = N / 2; /* N/(2^s) */
 
     /* loop through steps */
-    while (inv)
-    {
+    while (inv) {
         /* loop through groups */
-        for (int g = 0; g < N; g += half << 1)
-        {
+        for (int g = 0; g < N; g += half << 1) {
             /* loop through butterflies */
-            for (int b = 0, r = 0; b < half; b ++, r += inv)
-            {
+            for (int b = 0, r = 0; b < half; b++, r += inv) {
                 float complex even = a[g + b];
                 float complex odd = _roots[r] * a[g + half + b];
                 a[g + b] = even + odd;
@@ -121,22 +117,22 @@ _do_fft (float complex *a)
 
 void
 fft_calculate (const float *data, float *freq, int fft_size) {
-    _init_buffers(fft_size);
+    _init_buffers (fft_size);
 
     // fft code shamelessly stolen from audacious
     // thanks, John
     float complex a[N];
-    for (int n = 0; n < N; n ++) {
+    for (int n = 0; n < N; n++) {
         a[_reversed[n]] = data[n] * _hamming[n];
     }
-    _do_fft(a);
+    _do_fft (a);
 
-    for (int n = 0; n < N / 2 - 1; n ++)
+    for (int n = 0; n < N / 2 - 1; n++)
         freq[n] = 2 * cabsf (a[1 + n]) / N;
-    freq[N / 2 - 1] = cabsf(a[N / 2]) / N;
+    freq[N / 2 - 1] = cabsf (a[N / 2]) / N;
 }
 
 void
 fft_free (void) {
-    _free_buffers();
+    _free_buffers ();
 }

--- a/src/fft.h
+++ b/src/fft.h
@@ -25,8 +25,7 @@
 #define FFT_H
 
 #ifdef __cplusplus
-extern "C" {
-}
+extern "C" {}
 #endif
 
 void

--- a/src/handler.c
+++ b/src/handler.c
@@ -64,7 +64,7 @@ handler_reset (handler_t *h) {
 
 handler_t *
 handler_alloc (int queue_size) {
-    int sz = sizeof (handler_t) + (queue_size-1) * sizeof (message_t);
+    int sz = sizeof (handler_t) + (queue_size - 1) * sizeof (message_t);
     handler_t *h = malloc (sz);
     memset (h, 0, sz);
     h->queue_size = queue_size;
@@ -149,4 +149,3 @@ handler_hasmessages (handler_t *h) {
     mutex_unlock (h->mutex);
     return res;
 }
-

--- a/src/junklib.h
+++ b/src/junklib.h
@@ -150,7 +150,7 @@ uint8_t
 junk_popm_rating_from_stars (unsigned stars);
 
 void
-junk_make_tdrc_string(char *tdrc, size_t tdrc_size, int year, int month, int day, int hour, int minute);
+junk_make_tdrc_string (char *tdrc, size_t tdrc_size, int year, int month, int day, int hour, int minute);
 
 #ifdef __cplusplus
 }

--- a/src/logger.c
+++ b/src/logger.c
@@ -49,17 +49,16 @@ static char *init_buffer_ptr;
 static char *init_buffer_info;
 static char *init_buffer_info_ptr;
 
-
 #ifdef ANDROID
-#include <android/log.h>
+#    include <android/log.h>
 static void
 console_write (const char *text) {
-    __android_log_write(ANDROID_LOG_INFO,ANDROID_LOGGER_TAG,text);
+    __android_log_write (ANDROID_LOG_INFO, ANDROID_LOGGER_TAG, text);
 }
 #else
 static void
 console_write (const char *text) {
-    fwrite (text, strlen(text), 1, stderr);
+    fwrite (text, strlen (text), 1, stderr);
     fflush (stderr);
 }
 #endif
@@ -86,12 +85,12 @@ _log_internal (DB_plugin_t *plugin, uint32_t layers, const char *text) {
             *init_buffer_info_ptr = 0;
         }
     }
-    mutex_unlock(_mutex);
+    mutex_unlock (_mutex);
 }
 
 static int
 _is_log_visible (DB_plugin_t *plugin, uint32_t layers) {
-    if (plugin && !(plugin->flags&DDB_PLUGIN_FLAG_LOGGING)) {
+    if (plugin && !(plugin->flags & DDB_PLUGIN_FLAG_LOGGING)) {
         return 0;
     }
     if (layers && !(layers & _log_layers)) {
@@ -107,9 +106,9 @@ ddb_logger_init (void) {
     if (!_mutex) {
         return -1;
     }
-    init_buffer = calloc(1, INIT_BUFFER_SIZE);
+    init_buffer = calloc (1, INIT_BUFFER_SIZE);
     init_buffer_ptr = init_buffer;
-    init_buffer_info = calloc(1, INIT_BUFFER_SIZE);
+    init_buffer_info = calloc (1, INIT_BUFFER_SIZE);
     init_buffer_info_ptr = init_buffer_info;
     return 0;
 }
@@ -136,7 +135,7 @@ ddb_logger_free (void) {
         ddb_logger_stop_buffering ();
 
         while (_loggers) {
-            ddb_log_viewer_unregister(_loggers->log, _loggers->ctx);
+            ddb_log_viewer_unregister (_loggers->log, _loggers->ctx);
         }
 
         mutex_free (_mutex);
@@ -146,27 +145,27 @@ ddb_logger_free (void) {
 
 void
 ddb_log_detailed (DB_plugin_t *plugin, uint32_t layers, const char *fmt, ...) {
-    if (!_is_log_visible(plugin, layers)) {
+    if (!_is_log_visible (plugin, layers)) {
         return;
     }
 
     char text[2048];
     va_list ap;
-    va_start(ap, fmt);
-    (void) vsnprintf(text, sizeof (text), fmt, ap);
-    va_end(ap);
+    va_start (ap, fmt);
+    (void)vsnprintf (text, sizeof (text), fmt, ap);
+    va_end (ap);
 
     _log_internal (plugin, layers, text);
 }
 
 void
 ddb_vlog_detailed (DB_plugin_t *plugin, uint32_t layers, const char *fmt, va_list ap) {
-    if (!_is_log_visible(plugin, layers)) {
+    if (!_is_log_visible (plugin, layers)) {
         return;
     }
 
     char text[2048];
-    (void) vsnprintf(text, sizeof (text), fmt, ap);
+    (void)vsnprintf (text, sizeof (text), fmt, ap);
 
     _log_internal (plugin, layers, text);
 }
@@ -175,9 +174,9 @@ void
 ddb_log (const char *fmt, ...) {
     char text[2048];
     va_list ap;
-    va_start(ap, fmt);
-    (void) vsnprintf(text, sizeof (text), fmt, ap);
-    va_end(ap);
+    va_start (ap, fmt);
+    (void)vsnprintf (text, sizeof (text), fmt, ap);
+    va_end (ap);
 
     _log_internal (NULL, 0, text);
 }
@@ -185,18 +184,20 @@ ddb_log (const char *fmt, ...) {
 void
 ddb_vlog (const char *fmt, va_list ap) {
     char text[2048];
-    (void) vsnprintf(text, sizeof (text), fmt, ap);
+    (void)vsnprintf (text, sizeof (text), fmt, ap);
 
     _log_internal (NULL, 0, text);
 }
 
 void
-ddb_log_viewer_register (void (*callback)(DB_plugin_t *plugin, uint32_t layers, const char *text, void *ctx), void *ctx) {
-    mutex_lock(_mutex);
+ddb_log_viewer_register (
+    void (*callback) (DB_plugin_t *plugin, uint32_t layers, const char *text, void *ctx),
+    void *ctx) {
+    mutex_lock (_mutex);
 
     for (logger_t *l = _loggers; l; l = l->next) {
         if (l->log == callback && l->ctx == ctx) {
-            mutex_unlock(_mutex);
+            mutex_unlock (_mutex);
             return;
         }
     }
@@ -222,12 +223,14 @@ ddb_log_viewer_register (void (*callback)(DB_plugin_t *plugin, uint32_t layers, 
 
     ddb_logger_stop_buffering ();
 
-    mutex_unlock(_mutex);
+    mutex_unlock (_mutex);
 }
 
 void
-ddb_log_viewer_unregister (void (*callback)(DB_plugin_t *plugin, uint32_t layers, const char *text, void *ctx), void *ctx) {
-    mutex_lock(_mutex);
+ddb_log_viewer_unregister (
+    void (*callback) (DB_plugin_t *plugin, uint32_t layers, const char *text, void *ctx),
+    void *ctx) {
+    mutex_lock (_mutex);
     logger_t *prev = NULL;
     for (logger_t *l = _loggers; l; l = l->next) {
         if (l->log == callback && l->ctx == ctx) {
@@ -242,5 +245,5 @@ ddb_log_viewer_unregister (void (*callback)(DB_plugin_t *plugin, uint32_t layers
         }
         prev = l;
     }
-    mutex_unlock(_mutex);
+    mutex_unlock (_mutex);
 }

--- a/src/logger.h
+++ b/src/logger.h
@@ -52,10 +52,14 @@ void
 ddb_vlog (const char *fmt, va_list ap);
 
 void
-ddb_log_viewer_register (void (*callback)(DB_plugin_t *plugin, uint32_t layers, const char *text, void *ctx), void *ctx);
+ddb_log_viewer_register (
+    void (*callback) (DB_plugin_t *plugin, uint32_t layers, const char *text, void *ctx),
+    void *ctx);
 
 void
-ddb_log_viewer_unregister (void (*callback)(DB_plugin_t *plugin, uint32_t layers, const char *text, void *ctx), void *ctx);
+ddb_log_viewer_unregister (
+    void (*callback) (DB_plugin_t *plugin, uint32_t layers, const char *text, void *ctx),
+    void *ctx);
 
 #ifdef __cplusplus
 }

--- a/src/main.c
+++ b/src/main.c
@@ -1108,7 +1108,7 @@ main_cleanup_and_quit (void) {
 #endif
 
         pl_free (); // may access conf_*
-        ddb_undomanager_free(ddb_undomanager_shared());
+        ddb_undomanager_free (ddb_undomanager_shared ());
 
         conf_free ();
 
@@ -1127,7 +1127,6 @@ main_cleanup_and_quit (void) {
 
         exit (0);
     });
-
 }
 
 static void
@@ -1416,10 +1415,10 @@ main (int argc, char *argv[]) {
 #if __APPLE__
     char statedir[PATH_MAX];
     cocoautil_get_application_support_path (statedir, sizeof (statedir));
-    mkdir(statedir, 0755);
+    mkdir (statedir, 0755);
     char temp[PATH_MAX];
-    snprintf(temp, sizeof(temp), "%s/Deadbeef", statedir);
-    mkdir(temp, 0755);
+    snprintf (temp, sizeof (temp), "%s/Deadbeef", statedir);
+    mkdir (temp, 0755);
     if (snprintf (dbstatedir, sizeof (dbstatedir), "%s/Deadbeef/State", statedir) > (int)sizeof (dbstatedir)) {
         trace_err ("fatal: state path is too long: %s\n", dbstatedir);
         return -1;
@@ -1435,16 +1434,16 @@ main (int argc, char *argv[]) {
     }
     else {
         char temp[PATH_MAX];
-        snprintf(temp, sizeof(temp), "%s/.local/state", homedir);
+        snprintf (temp, sizeof (temp), "%s/.local/state", homedir);
         mkdir (temp, 0755);
-        if (snprintf (dbstatedir, sizeof (dbstatedir), "%s/.local/state/deadbeef", homedir) > (int)sizeof (dbstatedir)) {
+        if (snprintf (dbstatedir, sizeof (dbstatedir), "%s/.local/state/deadbeef", homedir) >
+            (int)sizeof (dbstatedir)) {
             trace_err ("fatal: state path is too long: %s\n", dbstatedir);
             return -1;
         }
     }
 #endif
     mkdir (dbstatedir, 0755);
-
 
     const char *plugname = "main";
     for (int i = 1; i < argc; i++) {

--- a/src/messagepump.c
+++ b/src/messagepump.c
@@ -191,36 +191,30 @@ messagepump_event_alloc (uint32_t id) {
 void
 messagepump_event_free (ddb_event_t *ev) {
     switch (ev->event) {
-    case DB_EV_SONGCHANGED:
-        {
-            ddb_event_trackchange_t *tc = (ddb_event_trackchange_t*)ev;
-            if (tc->from) {
-                pl_item_unref ((playItem_t *)tc->from);
-            }
-            if (tc->to) {
-                pl_item_unref ((playItem_t *)tc->to);
-            }
+    case DB_EV_SONGCHANGED: {
+        ddb_event_trackchange_t *tc = (ddb_event_trackchange_t *)ev;
+        if (tc->from) {
+            pl_item_unref ((playItem_t *)tc->from);
         }
-        break;
+        if (tc->to) {
+            pl_item_unref ((playItem_t *)tc->to);
+        }
+    } break;
     case DB_EV_SONGSTARTED:
     case DB_EV_SONGFINISHED:
     case DB_EV_TRACKINFOCHANGED:
-    case DB_EV_CURSOR_MOVED:
-        {
-            ddb_event_track_t *tc = (ddb_event_track_t*)ev;
-            if (tc->track) {
-                pl_item_unref ((playItem_t *)tc->track);
-            }
+    case DB_EV_CURSOR_MOVED: {
+        ddb_event_track_t *tc = (ddb_event_track_t *)ev;
+        if (tc->track) {
+            pl_item_unref ((playItem_t *)tc->track);
         }
-        break;
-    case DB_EV_SEEKED:
-        {
-            ddb_event_playpos_t *tc = (ddb_event_playpos_t*)ev;
-            if (tc->track) {
-                pl_item_unref ((playItem_t *)tc->track);
-            }
+    } break;
+    case DB_EV_SEEKED: {
+        ddb_event_playpos_t *tc = (ddb_event_playpos_t *)ev;
+        if (tc->track) {
+            pl_item_unref ((playItem_t *)tc->track);
         }
-        break;
+    } break;
     }
     free (ev);
 }
@@ -229,4 +223,3 @@ int
 messagepump_push_event (ddb_event_t *ev, uint32_t p1, uint32_t p2) {
     return messagepump_push (ev->event, (uintptr_t)ev, p1, p2);
 }
-

--- a/src/messagepump.h
+++ b/src/messagepump.h
@@ -34,15 +34,23 @@
 extern "C" {
 #endif
 
-int messagepump_init (void);
-void messagepump_free (void);
-int messagepump_push (uint32_t id, uintptr_t ctx, uint32_t p1, uint32_t p2);
-int messagepump_pop (uint32_t *id, uintptr_t *ctx, uint32_t *p1, uint32_t *p2);
-void messagepump_wait (void);
+int
+messagepump_init (void);
+void
+messagepump_free (void);
+int
+messagepump_push (uint32_t id, uintptr_t ctx, uint32_t p1, uint32_t p2);
+int
+messagepump_pop (uint32_t *id, uintptr_t *ctx, uint32_t *p1, uint32_t *p2);
+void
+messagepump_wait (void);
 
-ddb_event_t *messagepump_event_alloc (uint32_t id);
-void messagepump_event_free (ddb_event_t *ev);
-int messagepump_push_event (ddb_event_t *ev, uint32_t p1, uint32_t p2);
+ddb_event_t *
+messagepump_event_alloc (uint32_t id);
+void
+messagepump_event_free (ddb_event_t *ev);
+int
+messagepump_push_event (ddb_event_t *ev, uint32_t p1, uint32_t p2);
 
 #ifdef __cplusplus
 }

--- a/src/metacache.c
+++ b/src/metacache.c
@@ -39,7 +39,7 @@ typedef struct metacache_str_s {
 } metacache_str_t;
 
 typedef struct {
-//    uint32_t hash;
+    //    uint32_t hash;
     metacache_str_t *chain;
 } metacache_hash_t;
 
@@ -52,7 +52,7 @@ metacache_get_hash_sdbm (const char *str, size_t len) {
     uint32_t h = 0;
     int c;
 
-    const char *end = str+len;
+    const char *end = str + len;
 
     while (str < end) {
         c = *str++;
@@ -83,13 +83,13 @@ const char *
 metacache_add_value (const char *value, size_t len) {
     //    printf ("n_strings=%d, n_inserts=%d, n_buckets=%d\n", n_strings, n_inserts, n_buckets);
     uint32_t h = metacache_get_hash_sdbm (value, len);
-    metacache_str_t *data = metacache_find_in_bucket (h & (HASH_SIZE-1), value, len);
+    metacache_str_t *data = metacache_find_in_bucket (h & (HASH_SIZE - 1), value, len);
     n_inserts++;
     if (data) {
         data->refcount++;
         return data->str;
     }
-    metacache_hash_t *bucket = &hash[h & (HASH_SIZE-1)];
+    metacache_hash_t *bucket = &hash[h & (HASH_SIZE - 1)];
     if (!bucket->chain) {
         n_buckets++;
     }
@@ -112,7 +112,7 @@ metacache_add_string (const char *str) {
 void
 metacache_remove_value (const char *value, size_t valuesize) {
     uint32_t h = metacache_get_hash_sdbm (value, valuesize);
-    metacache_hash_t *bucket = &hash[h & (HASH_SIZE-1)];
+    metacache_hash_t *bucket = &hash[h & (HASH_SIZE - 1)];
     metacache_str_t *chain = bucket->chain;
     metacache_str_t *prev = NULL;
     while (chain) {
@@ -142,26 +142,26 @@ metacache_remove_string (const char *str) {
 // DEPRECATED_113
 void
 metacache_ref (const char *str) {
-    uint32_t *refc = (uint32_t *)(str-5);
+    uint32_t *refc = (uint32_t *)(str - 5);
     (*refc)++;
 }
 
 // DEPRECATED_113
 void
 metacache_unref (const char *str) {
-    uint32_t *refc = (uint32_t *)(str-5);
+    uint32_t *refc = (uint32_t *)(str - 5);
     (*refc)--;
 }
 
 const char *
 metacache_get_string (const char *str) {
-    return metacache_get_value (str, strlen (str)+1);
+    return metacache_get_value (str, strlen (str) + 1);
 }
 
 const char *
 metacache_get_value (const char *value, size_t len) {
     uint32_t h = metacache_get_hash_sdbm (value, len);
-    metacache_str_t *data = metacache_find_in_bucket (h & (HASH_SIZE-1), value, len);
+    metacache_str_t *data = metacache_find_in_bucket (h & (HASH_SIZE - 1), value, len);
     n_inserts++;
     if (data) {
         data->refcount++;

--- a/src/moduleconf.h
+++ b/src/moduleconf.h
@@ -1,14 +1,14 @@
-PLUG(stdio)
+PLUG (stdio)
 #ifdef HAVE_COCOAUI
-PLUG(cocoaui)
+PLUG (cocoaui)
 #endif
 #ifdef HAVE_COREAUDIO
-PLUG(coreaudio)
-PLUG(nullout)
+PLUG (coreaudio)
+PLUG (nullout)
 #endif
 #ifdef HAVE_XGUI
-PLUG(xgui)
+PLUG (xgui)
 #endif
 #ifdef GOOGLETEST_STATIC
-PLUG(mp3)
+PLUG (mp3)
 #endif

--- a/src/playlist.c
+++ b/src/playlist.c
@@ -909,7 +909,7 @@ plt_clear (playlist_t *plt) {
         playItem_t *next = it->next[PL_MAIN];
         playItem_t *next_search = it->next[PL_SEARCH];
 
-        undo_remove_items(undobuffer, plt, &it, 1);
+        undo_remove_items (undobuffer, plt, &it, 1);
 
         if (next != NULL) {
             next->prev[PL_MAIN] = NULL;
@@ -1659,7 +1659,7 @@ plt_remove_item (playlist_t *playlist, playItem_t *it) {
 
     // remove from both lists
     LOCK;
-    undo_remove_items(ddb_undomanager_get_buffer(ddb_undomanager_shared()), playlist, &it, 1);
+    undo_remove_items (ddb_undomanager_get_buffer (ddb_undomanager_shared ()), playlist, &it, 1);
 
     for (int iter = PL_MAIN; iter <= PL_SEARCH; iter++) {
         if (it->prev[iter] || it->next[iter] || playlist->head[iter] == it || playlist->tail[iter] == it) {
@@ -1812,7 +1812,7 @@ pl_get_idx_of_iter (playItem_t *it, int iter) {
 playItem_t *
 plt_insert_item (playlist_t *playlist, playItem_t *after, playItem_t *it) {
     LOCK;
-    undo_insert_items(ddb_undomanager_get_buffer(ddb_undomanager_shared()), playlist, &it, 1);
+    undo_insert_items (ddb_undomanager_get_buffer (ddb_undomanager_shared ()), playlist, &it, 1);
     pl_item_ref (it);
     if (!after) {
         it->next[PL_MAIN] = playlist->head[PL_MAIN];
@@ -2040,8 +2040,7 @@ _plt_save_to_buffered_writer (
     playlist_t *plt,
     buffered_file_writer_t *writer,
     int (*cb) (playItem_t *it, void *data),
-    void *user_data
-) {
+    void *user_data) {
     LOCK;
 
     const char magic[] = "DBPL";
@@ -2223,10 +2222,7 @@ save_fail:
 }
 
 ssize_t
-plt_save_to_buffer(
-                   playlist_t *plt,
-                   uint8_t **out_buffer
-                   ) {
+plt_save_to_buffer (playlist_t *plt, uint8_t **out_buffer) {
     buffered_file_writer_t *writer = buffered_file_writer_new (NULL, 64 * 1024);
 
     LOCK;
@@ -2242,8 +2238,8 @@ plt_save_to_buffer(
     }
 
     size_t size = buffered_file_writer_get_size (writer);
-    uint8_t *buffer = malloc(size);
-    memcpy(buffer, buffered_file_writer_get_buffer (writer), size);
+    uint8_t *buffer = malloc (size);
+    memcpy (buffer, buffered_file_writer_get_buffer (writer), size);
     buffered_file_writer_free (writer);
 
     *out_buffer = buffer;
@@ -2251,15 +2247,14 @@ plt_save_to_buffer(
 }
 
 int
-plt_save(
+plt_save (
     playlist_t *plt,
     playItem_t *first,
     playItem_t *last,
     const char *fname,
     int *pabort,
     int (*cb) (playItem_t *it, void *data),
-    void *user_data
-) {
+    void *user_data) {
     LOCK;
     plt->last_save_modification_idx = plt->modification_idx;
     const char *ext = strrchr (fname, '.');
@@ -2272,10 +2267,10 @@ plt_save(
                     for (int e = 0; exts[e]; e++) {
                         if (!strcasecmp (exts[e], ext + 1)) {
                             int res = plug[i]->save (
-                                                     (ddb_playlist_t *)plt,
-                                                     fname,
-                                                     (DB_playItem_t *)_current_playlist->head[PL_MAIN],
-                                                     NULL);
+                                (ddb_playlist_t *)plt,
+                                fname,
+                                (DB_playItem_t *)_current_playlist->head[PL_MAIN],
+                                NULL);
                             UNLOCK;
                             return res;
                         }
@@ -2292,7 +2287,6 @@ plt_save(
         UNLOCK;
         return -1;
     }
-
 
     buffered_file_writer_t *writer = buffered_file_writer_new (fp, 64 * 1024);
 
@@ -2430,7 +2424,7 @@ _plt_load_from_file (playlist_t *plt, ddb_file_handle_t *fp, playItem_t **last_a
     if (ddb_file_read (&cnt, 1, 4, fp) != 4) {
         goto load_fail;
     }
-    
+
     for (uint32_t i = 0; i < cnt; i++) {
         it = pl_item_alloc ();
         if (!it) {
@@ -2501,16 +2495,16 @@ _plt_load_from_file (playlist_t *plt, ddb_file_handle_t *fp, playItem_t **last_a
                 ftype[ft] = 0;
                 pl_replace_meta (it, ":FILETYPE", ftype);
             }
-            
+
             float f;
-            
+
             if (ddb_file_read (&f, 1, 4, fp) != 4) {
                 goto load_fail;
             }
             if (f != 0) {
                 pl_set_item_replaygain (it, DDB_REPLAYGAIN_ALBUMGAIN, f);
             }
-            
+
             if (ddb_file_read (&f, 1, 4, fp) != 4) {
                 goto load_fail;
             }
@@ -2520,14 +2514,14 @@ _plt_load_from_file (playlist_t *plt, ddb_file_handle_t *fp, playItem_t **last_a
             if (f != 1) {
                 pl_set_item_replaygain (it, DDB_REPLAYGAIN_ALBUMPEAK, f);
             }
-            
+
             if (ddb_file_read (&f, 1, 4, fp) != 4) {
                 goto load_fail;
             }
             if (f != 0) {
                 pl_set_item_replaygain (it, DDB_REPLAYGAIN_TRACKGAIN, f);
             }
-            
+
             if (ddb_file_read (&f, 1, 4, fp) != 4) {
                 goto load_fail;
             }
@@ -2538,7 +2532,7 @@ _plt_load_from_file (playlist_t *plt, ddb_file_handle_t *fp, playItem_t **last_a
                 pl_set_item_replaygain (it, DDB_REPLAYGAIN_TRACKPEAK, f);
             }
         }
-        
+
         uint32_t flg = 0;
         if (minorver >= 2) {
             if (ddb_file_read (&flg, 1, 4, fp) != 4) {
@@ -2551,7 +2545,7 @@ _plt_load_from_file (playlist_t *plt, ddb_file_handle_t *fp, playItem_t **last_a
             }
         }
         pl_set_item_flags (it, flg);
-        
+
         int16_t nm = 0;
         if (ddb_file_read (&nm, 1, 2, fp) != 2) {
             goto load_fail;
@@ -2609,7 +2603,7 @@ _plt_load_from_file (playlist_t *plt, ddb_file_handle_t *fp, playItem_t **last_a
         *last_added = it;
         it = NULL;
     }
-    
+
     // load playlist metadata
     int16_t nm = 0;
     // for backwards format compatibility, don't fail if metadata is not found
@@ -2737,9 +2731,9 @@ plt_load_int (
     }
 
     ddb_file_handle_t fh;
-    ddb_file_init_stdio(&fh, fp);
+    ddb_file_init_stdio (&fh, fp);
 
-    if (0 != _plt_load_from_file(plt, &fh, &last_added)) {
+    if (0 != _plt_load_from_file (plt, &fh, &last_added)) {
         goto load_fail;
     }
 
@@ -2766,10 +2760,10 @@ load_fail:
 int
 plt_load_from_buffer (playlist_t *plt, const uint8_t *buffer, size_t size) {
     ddb_file_handle_t fh;
-    ddb_file_init_buffer(&fh, buffer, size);
+    ddb_file_init_buffer (&fh, buffer, size);
 
     playItem_t *last_added = NULL;
-    int res = _plt_load_from_file(plt, &fh, &last_added);
+    int res = _plt_load_from_file (plt, &fh, &last_added);
     if (last_added) {
         pl_item_unref (last_added);
     }
@@ -3795,7 +3789,7 @@ plt_move_all_items (playlist_t *to, playlist_t *from, playItem_t *insert_after) 
         UNLOCK;
         return;
     }
-    pl_item_ref(it);
+    pl_item_ref (it);
     ddb_undobuffer_group_begin (ddb_undomanager_get_buffer (ddb_undomanager_shared ()));
     while (it != NULL) {
         playItem_t *next = it->next[PL_MAIN];
@@ -4564,7 +4558,7 @@ pl_items_from_same_album (playItem_t *a, playItem_t *b) {
 static size_t
 _plt_get_items (playlist_t *plt, playItem_t ***out_items, int selected) {
     LOCK;
-    int count = selected ? plt_getselcount (plt) : plt_get_item_count(plt, PL_MAIN);
+    int count = selected ? plt_getselcount (plt) : plt_get_item_count (plt, PL_MAIN);
     if (count == 0) {
         UNLOCK;
         return 0;
@@ -4592,6 +4586,6 @@ plt_get_items (playlist_t *plt, playItem_t ***out_items) {
 }
 
 size_t
-plt_get_selected_items(playlist_t *plt, playItem_t ***out_items) {
+plt_get_selected_items (playlist_t *plt, playItem_t ***out_items) {
     return _plt_get_items (plt, out_items, 1);
 }

--- a/src/playlist.h
+++ b/src/playlist.h
@@ -85,14 +85,14 @@ typedef struct playlist_s {
     int cue_samplerate;
 
     int search_cmpidx;
-    
+
     unsigned fast_mode : 1;
     unsigned files_adding : 1;
     unsigned recalc_seltime : 1;
     unsigned loading_cue : 1;
     unsigned ignore_archives : 1;
     unsigned follow_symlinks : 1;
-    unsigned undo_enabled: 1;
+    unsigned undo_enabled : 1;
 } playlist_t;
 
 // global playlist control functions
@@ -201,10 +201,10 @@ void
 plt_clear (playlist_t *plt);
 
 int
-plt_add_dir (playlist_t *plt, const char *dirname, int (*cb)(playItem_t *it, void *data), void *user_data);
+plt_add_dir (playlist_t *plt, const char *dirname, int (*cb) (playItem_t *it, void *data), void *user_data);
 
 int
-plt_add_file (playlist_t *plt, const char *fname, int (*cb)(playItem_t *it, void *data), void *user_data);
+plt_add_file (playlist_t *plt, const char *fname, int (*cb) (playItem_t *it, void *data), void *user_data);
 
 int
 pl_add_files_begin (playlist_t *plt);
@@ -213,10 +213,22 @@ void
 pl_add_files_end (void);
 
 playItem_t *
-plt_insert_dir (playlist_t *plt, playItem_t *after, const char *dirname, int *pabort, int (*cb)(playItem_t *it, void *data), void *user_data);
+plt_insert_dir (
+    playlist_t *plt,
+    playItem_t *after,
+    const char *dirname,
+    int *pabort,
+    int (*cb) (playItem_t *it, void *data),
+    void *user_data);
 
 playItem_t *
-plt_insert_file (playlist_t *playlist, playItem_t *after, const char *fname, int *pabort, int (*cb)(playItem_t *it, void *data), void *user_data);
+plt_insert_file (
+    playlist_t *playlist,
+    playItem_t *after,
+    const char *fname,
+    int *pabort,
+    int (*cb) (playItem_t *it, void *data),
+    void *user_data);
 
 playItem_t *
 pl_insert_item (playItem_t *after, playItem_t *it);
@@ -273,7 +285,14 @@ int
 pl_get_idx_of_iter (playItem_t *it, int iter);
 
 playItem_t *
-plt_insert_cue_from_buffer (playlist_t *plt, playItem_t *after, playItem_t *origin, const uint8_t *buffer, int buffersize, int numsamples, int samplerate);
+plt_insert_cue_from_buffer (
+    playlist_t *plt,
+    playItem_t *after,
+    playItem_t *origin,
+    const uint8_t *buffer,
+    int buffersize,
+    int numsamples,
+    int samplerate);
 
 playItem_t *
 plt_insert_cue (playlist_t *plt, playItem_t *after, playItem_t *origin, int numsamples, int samplerate);
@@ -298,7 +317,14 @@ void
 pl_crop_selected (void);
 
 int
-plt_save (playlist_t *plt, playItem_t *first, playItem_t *last, const char *fname, int *pabort, int (*cb)(playItem_t *it, void *data), void *user_data);
+plt_save (
+    playlist_t *plt,
+    playItem_t *first,
+    playItem_t *last,
+    const char *fname,
+    int *pabort,
+    int (*cb) (playItem_t *it, void *data),
+    void *user_data);
 
 int
 plt_save_n (int n);
@@ -310,7 +336,13 @@ int
 pl_save_all (void);
 
 playItem_t *
-plt_load (playlist_t *plt, playItem_t *after, const char *fname, int *pabort, int (*cb)(playItem_t *it, void *data), void *user_data);
+plt_load (
+    playlist_t *plt,
+    playItem_t *after,
+    const char *fname,
+    int *pabort,
+    int (*cb) (playItem_t *it, void *data),
+    void *user_data);
 
 int
 pl_load_all (void);
@@ -460,34 +492,76 @@ int
 plt_save_config (playlist_t *plt);
 
 int
-listen_file_added (int (*callback)(ddb_fileadd_data_t *data, void *user_data), void *user_data);
+listen_file_added (int (*callback) (ddb_fileadd_data_t *data, void *user_data), void *user_data);
 
 void
 unlisten_file_added (int id);
 
 int
-listen_file_add_beginend (void (*callback_begin) (ddb_fileadd_data_t *data, void *user_data), void (*callback_end)(ddb_fileadd_data_t *data, void *user_data), void *user_data);
+listen_file_add_beginend (
+    void (*callback_begin) (ddb_fileadd_data_t *data, void *user_data),
+    void (*callback_end) (ddb_fileadd_data_t *data, void *user_data),
+    void *user_data);
 
 void
 unlisten_file_add_beginend (int id);
 
 playItem_t *
-plt_load2 (int visibility, playlist_t *plt, playItem_t *after, const char *fname, int *pabort, int (*callback)(playItem_t *it, void *user_data), void *user_data);
+plt_load2 (
+    int visibility,
+    playlist_t *plt,
+    playItem_t *after,
+    const char *fname,
+    int *pabort,
+    int (*callback) (playItem_t *it, void *user_data),
+    void *user_data);
 
 int
-plt_add_file2 (int visibility, playlist_t *plt, const char *fname, int (*callback)(playItem_t *it, void *user_data), void *user_data);
+plt_add_file2 (
+    int visibility,
+    playlist_t *plt,
+    const char *fname,
+    int (*callback) (playItem_t *it, void *user_data),
+    void *user_data);
 
 int
-plt_add_dir2 (int visibility, playlist_t *plt, const char *dirname, int (*callback)(playItem_t *it, void *user_data), void *user_data);
+plt_add_dir2 (
+    int visibility,
+    playlist_t *plt,
+    const char *dirname,
+    int (*callback) (playItem_t *it, void *user_data),
+    void *user_data);
 
 playItem_t *
-plt_insert_file2 (int visibility, playlist_t *playlist, playItem_t *after, const char *fname, int *pabort, int (*callback)(playItem_t *it, void *user_data), void *user_data);
+plt_insert_file2 (
+    int visibility,
+    playlist_t *playlist,
+    playItem_t *after,
+    const char *fname,
+    int *pabort,
+    int (*callback) (playItem_t *it, void *user_data),
+    void *user_data);
 
 playItem_t *
-plt_insert_dir2 (int visibility, playlist_t *plt, playItem_t *after, const char *dirname, int *pabort, int (*callback)(playItem_t *it, void *user_data), void *user_data);
+plt_insert_dir2 (
+    int visibility,
+    playlist_t *plt,
+    playItem_t *after,
+    const char *dirname,
+    int *pabort,
+    int (*callback) (playItem_t *it, void *user_data),
+    void *user_data);
 
 playItem_t *
-plt_insert_dir3 (int visibility, uint32_t flags, playlist_t *plt, playItem_t *after, const char *dirname, int *pabort, int (*callback)(ddb_insert_file_result_t result, const char *fname, void *user_data), void *user_data);
+plt_insert_dir3 (
+    int visibility,
+    uint32_t flags,
+    playlist_t *plt,
+    playItem_t *after,
+    const char *dirname,
+    int *pabort,
+    int (*callback) (ddb_insert_file_result_t result, const char *fname, void *user_data),
+    void *user_data);
 
 int
 plt_add_files_begin (playlist_t *plt, int visibility);
@@ -520,7 +594,7 @@ void
 pl_configchanged (void);
 
 int
-register_fileadd_filter (int (*callback)(ddb_file_found_data_t *data, void *user_data), void *user_data);
+register_fileadd_filter (int (*callback) (ddb_file_found_data_t *data, void *user_data), void *user_data);
 
 void
 unregister_fileadd_filter (int id);
@@ -550,10 +624,10 @@ void
 pl_set_selected_in_playlist (playlist_t *playlist, playItem_t *it, int sel);
 
 playItem_t *
-plt_get_head_item(playlist_t *p, int iter);
+plt_get_head_item (playlist_t *p, int iter);
 
 playItem_t *
-plt_get_tail_item(playlist_t *p, int iter);
+plt_get_tail_item (playlist_t *p, int iter);
 
 int
 pl_get_played (playItem_t *it);
@@ -568,19 +642,19 @@ void
 pl_set_shufflerating (playItem_t *it, int rating);
 
 int
-pl_items_from_same_album(playItem_t* a, playItem_t* b);
+pl_items_from_same_album (playItem_t *a, playItem_t *b);
 
 size_t
 plt_get_items (playlist_t *plt, playItem_t ***out_items);
 
 size_t
-plt_get_selected_items(playlist_t *plt, playItem_t ***out_items);
+plt_get_selected_items (playlist_t *plt, playItem_t ***out_items);
 
 int
 plt_load_from_buffer (playlist_t *plt, const uint8_t *buffer, size_t size);
 
 ssize_t
-plt_save_to_buffer(playlist_t *plt, uint8_t **out_buffer);
+plt_save_to_buffer (playlist_t *plt, uint8_t **out_buffer);
 
 #ifdef __cplusplus
 }

--- a/src/playqueue.c
+++ b/src/playqueue.c
@@ -34,7 +34,8 @@
 static playItem_t *playqueue[100];
 static int playqueue_count = 0;
 
-#define trace(...) { fprintf(stderr, __VA_ARGS__); }
+#define trace(...) \
+    { fprintf (stderr, __VA_ARGS__); }
 //#define trace(fmt,...)
 
 static void
@@ -44,7 +45,7 @@ playqueue_send_trackinfochanged (playItem_t *track) {
     if (track) {
         pl_item_ref (track);
     }
-    messagepump_push_event ((ddb_event_t*)ev, DDB_PLAYLIST_CHANGE_PLAYQUEUE, 0);
+    messagepump_push_event ((ddb_event_t *)ev, DDB_PLAYLIST_CHANGE_PLAYQUEUE, 0);
 }
 
 int
@@ -87,7 +88,7 @@ playqueue_pop (void) {
         return;
     }
     playItem_t *it = playqueue[0];
-    memmove (&playqueue[0], &playqueue[1], (playqueue_count-1) * sizeof (playItem_t*));
+    memmove (&playqueue[0], &playqueue[1], (playqueue_count - 1) * sizeof (playItem_t *));
     playqueue_count--;
     pl_item_unref (it);
     pl_unlock ();
@@ -101,8 +102,8 @@ playqueue_remove (playItem_t *it) {
         int i;
         for (i = 0; i < playqueue_count; i++) {
             if (playqueue[i] == it) {
-                if (i < playqueue_count-1) {
-                    memmove (&playqueue[i], &playqueue[i+1], (playqueue_count-i) * sizeof (playItem_t*));
+                if (i < playqueue_count - 1) {
+                    memmove (&playqueue[i], &playqueue[i + 1], (playqueue_count - i) * sizeof (playItem_t *));
                     messagepump_push (DB_EV_PLAYLISTCHANGED, 0, DDB_PLAYLIST_CHANGE_PLAYQUEUE, 0);
                 }
                 else {
@@ -164,8 +165,8 @@ void
 playqueue_remove_nth (int n) {
     pl_lock ();
     playItem_t *it = playqueue[n];
-    if (n < playqueue_count-1) {
-        memmove (playqueue + n, playqueue + n + 1, (playqueue_count-n) * sizeof (playItem_t*));
+    if (n < playqueue_count - 1) {
+        memmove (playqueue + n, playqueue + n + 1, (playqueue_count - n) * sizeof (playItem_t *));
     }
     playqueue_count--;
 
@@ -182,11 +183,11 @@ playqueue_insert_at (int n, playItem_t *it) {
     }
     pl_lock ();
     if (n == playqueue_count) {
-        playqueue_push(it);
+        playqueue_push (it);
         pl_unlock ();
         return;
     }
-    memmove (playqueue+n+1, playqueue+n, (playqueue_count - n) * sizeof (playItem_t *));
+    memmove (playqueue + n + 1, playqueue + n, (playqueue_count - n) * sizeof (playItem_t *));
     playqueue[n] = it;
     pl_item_ref (it);
     playqueue_count++;

--- a/src/plmeta.c
+++ b/src/plmeta.c
@@ -31,8 +31,10 @@
 #include <deadbeef/deadbeef.h>
 #include "metacache.h"
 
-#define LOCK {pl_lock();}
-#define UNLOCK {pl_unlock();}
+#define LOCK \
+    { pl_lock (); }
+#define UNLOCK \
+    { pl_unlock (); }
 
 DB_metaInfo_t *
 pl_meta_for_key_with_override (playItem_t *it, const char *key) {
@@ -41,7 +43,7 @@ pl_meta_for_key_with_override (playItem_t *it, const char *key) {
 
     // try to find an override
     while (m) {
-        if (m->key[0] == '!' && !strcasecmp (key, m->key+1)) {
+        if (m->key[0] == '!' && !strcasecmp (key, m->key + 1)) {
             return m;
         }
         m = m->next;
@@ -54,8 +56,8 @@ pl_meta_for_key_with_override (playItem_t *it, const char *key) {
         }
         m = m->next;
     }
-    return NULL;}
-
+    return NULL;
+}
 
 DB_metaInfo_t *
 pl_meta_for_key (playItem_t *it, const char *key) {
@@ -234,7 +236,6 @@ _combine_into_unique_multivalue (const char *value1, int size1, const char *valu
     return buf;
 }
 
-
 // append zero-divided multivalue data to existing data
 // skip duplicates
 void
@@ -245,7 +246,7 @@ pl_append_meta_full (playItem_t *it, const char *key, const char *value, int siz
     pl_lock ();
     DB_metaInfo_t *m = pl_meta_for_key (it, key);
     if (!m) {
-        m = pl_add_empty_meta_for_key(it, key);
+        m = pl_add_empty_meta_for_key (it, key);
     }
 
     if (!m->value) {
@@ -255,7 +256,7 @@ pl_append_meta_full (playItem_t *it, const char *key, const char *value, int siz
     }
 
     int buflen;
-    char *buf = _combine_into_unique_multivalue(m->value, m->valuesize, value, size, &buflen);
+    char *buf = _combine_into_unique_multivalue (m->value, m->valuesize, value, size, &buflen);
 
     if (!buf) {
         pl_unlock ();
@@ -271,7 +272,7 @@ pl_append_meta_full (playItem_t *it, const char *key, const char *value, int siz
 
 void
 pl_append_meta (playItem_t *it, const char *key, const char *value) {
-    pl_append_meta_full(it, key, value, (int)strlen (value)+1);
+    pl_append_meta_full (it, key, value, (int)strlen (value) + 1);
 }
 
 void
@@ -283,7 +284,7 @@ pl_replace_meta (playItem_t *it, const char *key, const char *value) {
     if (m) {
         pl_meta_free_values (m);
         int l = (int)strlen (value) + 1;
-        m->value = metacache_add_value(value, l);
+        m->value = metacache_add_value (value, l);
         m->valuesize = l;
         UNLOCK;
         return;
@@ -329,7 +330,7 @@ pl_delete_meta (playItem_t *it, const char *key) {
                 it->meta = m->next;
             }
             metacache_remove_string (m->key);
-            pl_meta_free_values(m);
+            pl_meta_free_values (m);
             free (m);
             break;
         }
@@ -347,7 +348,7 @@ pl_find_meta (playItem_t *it, const char *key) {
     if (key && key[0] == ':') {
         // try to find an override
         while (m) {
-            if (m->key[0] == '!' && !strcasecmp (key+1, m->key+1)) {
+            if (m->key[0] == '!' && !strcasecmp (key + 1, m->key + 1)) {
                 return m->value;
             }
             m = m->next;
@@ -367,7 +368,7 @@ pl_find_meta (playItem_t *it, const char *key) {
 const char *
 pl_find_meta_with_override (playItem_t *it, const char *key) {
     pl_ensure_lock ();
-    DB_metaInfo_t *m = pl_meta_for_key_with_override(it, key);
+    DB_metaInfo_t *m = pl_meta_for_key_with_override (it, key);
     if (m) {
         return m->value;
     }
@@ -426,7 +427,7 @@ pl_delete_metadata (playItem_t *it, DB_metaInfo_t *meta) {
                 it->meta = m->next;
             }
             metacache_remove_string (m->key);
-            pl_meta_free_values(m);
+            pl_meta_free_values (m);
             free (m);
             break;
         }
@@ -443,7 +444,7 @@ pl_delete_all_meta (playItem_t *it) {
     DB_metaInfo_t *prev = NULL;
     while (m) {
         DB_metaInfo_t *next = m->next;
-        if (m->key[0] == ':'  || m->key[0] == '_' || m->key[0] == '!') {
+        if (m->key[0] == ':' || m->key[0] == '_' || m->key[0] == '!') {
             prev = m;
         }
         else {
@@ -462,10 +463,10 @@ pl_delete_all_meta (playItem_t *it) {
 
     // delete replaygain fields
     extern const char *ddb_internal_rg_keys[];
-    pl_delete_meta(it, ddb_internal_rg_keys[DDB_REPLAYGAIN_ALBUMGAIN]);
-    pl_delete_meta(it, ddb_internal_rg_keys[DDB_REPLAYGAIN_ALBUMPEAK]);
-    pl_delete_meta(it, ddb_internal_rg_keys[DDB_REPLAYGAIN_TRACKGAIN]);
-    pl_delete_meta(it, ddb_internal_rg_keys[DDB_REPLAYGAIN_TRACKPEAK]);
+    pl_delete_meta (it, ddb_internal_rg_keys[DDB_REPLAYGAIN_ALBUMGAIN]);
+    pl_delete_meta (it, ddb_internal_rg_keys[DDB_REPLAYGAIN_ALBUMPEAK]);
+    pl_delete_meta (it, ddb_internal_rg_keys[DDB_REPLAYGAIN_TRACKGAIN]);
+    pl_delete_meta (it, ddb_internal_rg_keys[DDB_REPLAYGAIN_TRACKPEAK]);
 
     uint32_t f = pl_get_item_flags (it);
     f &= ~DDB_TAG_MASK;
@@ -533,7 +534,7 @@ pl_meta_exists_with_override (playItem_t *it, const char *key) {
 
 void
 pl_add_meta_copy (playItem_t *it, DB_metaInfo_t *meta) {
-    DB_metaInfo_t *m = pl_add_empty_meta_for_key(it, meta->key);
+    DB_metaInfo_t *m = pl_add_empty_meta_for_key (it, meta->key);
     if (!m) {
         return; // dupe
     }

--- a/src/pltmeta.c
+++ b/src/pltmeta.c
@@ -32,8 +32,10 @@
 #include "metacache.h"
 #include "pltmeta.h"
 
-#define LOCK {pl_lock();}
-#define UNLOCK {pl_unlock();}
+#define LOCK \
+    { pl_lock (); }
+#define UNLOCK \
+    { pl_unlock (); }
 
 void
 plt_add_meta (playlist_t *it, const char *key, const char *value) {
@@ -222,7 +224,6 @@ plt_delete_metadata (playlist_t *it, DB_metaInfo_t *meta) {
         m = m->next;
     }
 }
-
 
 void
 plt_delete_all_meta (playlist_t *it) {

--- a/src/plugins.h
+++ b/src/plugins.h
@@ -40,7 +40,7 @@ int
 plug_load_all (void);
 
 void
-plug_unload_all (void(^completion_block)(void));
+plug_unload_all (void (^completion_block) (void));
 
 void
 plug_connect_all (void);
@@ -171,7 +171,7 @@ DB_functions_t *
 plug_get_api (void);
 
 int
-plug_init_plugin (DB_plugin_t* (*loadfunc)(DB_functions_t *), void *handle);
+plug_init_plugin (DB_plugin_t *(*loadfunc) (DB_functions_t *), void *handle);
 
 const char *
 plug_get_path_for_plugin_ptr (DB_plugin_t *plugin_ptr);

--- a/src/premix.c
+++ b/src/premix.c
@@ -32,12 +32,19 @@
 #include <deadbeef/fastftoi.h>
 #include "premix.h"
 
-#define trace(...) { fprintf(stderr, __VA_ARGS__); }
+#define trace(...) \
+    { fprintf (stderr, __VA_ARGS__); }
 //#define trace(fmt,...)
 
-
 static inline void
-pcm_write_samples_8_to_8 (const ddb_waveformat_t * restrict inputfmt, const char * restrict input, const ddb_waveformat_t * restrict outputfmt, char * restrict output, int nsamples, int * restrict channelmap, int outputsamplesize) {
+pcm_write_samples_8_to_8 (
+    const ddb_waveformat_t *restrict inputfmt,
+    const char *restrict input,
+    const ddb_waveformat_t *restrict outputfmt,
+    char *restrict output,
+    int nsamples,
+    int *restrict channelmap,
+    int outputsamplesize) {
     for (int s = 0; s < nsamples; s++) {
         for (int c = 0; c < outputfmt->channels; c++) {
             if (channelmap[c] < 0) {
@@ -51,13 +58,20 @@ pcm_write_samples_8_to_8 (const ddb_waveformat_t * restrict inputfmt, const char
 }
 
 static inline void
-pcm_write_samples_8_to_16 (const ddb_waveformat_t * restrict inputfmt, const char * restrict input, const ddb_waveformat_t * restrict outputfmt, char * restrict output, int nsamples, int * restrict channelmap, int outputsamplesize) {
+pcm_write_samples_8_to_16 (
+    const ddb_waveformat_t *restrict inputfmt,
+    const char *restrict input,
+    const ddb_waveformat_t *restrict outputfmt,
+    char *restrict output,
+    int nsamples,
+    int *restrict channelmap,
+    int outputsamplesize) {
     for (int s = 0; s < nsamples; s++) {
         for (int c = 0; c < outputfmt->channels; c++) {
             if (channelmap[c] < 0) {
                 continue;
             }
-            *((int16_t*)(output + 2 * c)) = (int16_t)(*(input + channelmap[c]) << 8);
+            *((int16_t *)(output + 2 * c)) = (int16_t)(*(input + channelmap[c]) << 8);
         }
         input += inputfmt->channels;
         output += outputsamplesize;
@@ -65,7 +79,14 @@ pcm_write_samples_8_to_16 (const ddb_waveformat_t * restrict inputfmt, const cha
 }
 
 static inline void
-pcm_write_samples_8_to_24 (const ddb_waveformat_t * restrict inputfmt, const char * restrict input, const ddb_waveformat_t * restrict outputfmt, char * restrict output, int nsamples, int * restrict channelmap, int outputsamplesize) {
+pcm_write_samples_8_to_24 (
+    const ddb_waveformat_t *restrict inputfmt,
+    const char *restrict input,
+    const ddb_waveformat_t *restrict outputfmt,
+    char *restrict output,
+    int nsamples,
+    int *restrict channelmap,
+    int outputsamplesize) {
     for (int s = 0; s < nsamples; s++) {
         for (int c = 0; c < outputfmt->channels; c++) {
             if (channelmap[c] < 0) {
@@ -82,7 +103,14 @@ pcm_write_samples_8_to_24 (const ddb_waveformat_t * restrict inputfmt, const cha
 }
 
 static inline void
-pcm_write_samples_8_to_32 (const ddb_waveformat_t * restrict inputfmt, const char * restrict input, const ddb_waveformat_t * restrict outputfmt, char * restrict output, int nsamples, int * restrict channelmap, int outputsamplesize) {
+pcm_write_samples_8_to_32 (
+    const ddb_waveformat_t *restrict inputfmt,
+    const char *restrict input,
+    const ddb_waveformat_t *restrict outputfmt,
+    char *restrict output,
+    int nsamples,
+    int *restrict channelmap,
+    int outputsamplesize) {
     for (int s = 0; s < nsamples; s++) {
         for (int c = 0; c < outputfmt->channels; c++) {
             if (channelmap[c] < 0) {
@@ -100,13 +128,20 @@ pcm_write_samples_8_to_32 (const ddb_waveformat_t * restrict inputfmt, const cha
 }
 
 static inline void
-pcm_write_samples_8_to_float (const ddb_waveformat_t * restrict inputfmt, const char * restrict input, const ddb_waveformat_t * restrict outputfmt, char * restrict output, int nsamples, int * restrict channelmap, int outputsamplesize) {
+pcm_write_samples_8_to_float (
+    const ddb_waveformat_t *restrict inputfmt,
+    const char *restrict input,
+    const ddb_waveformat_t *restrict outputfmt,
+    char *restrict output,
+    int nsamples,
+    int *restrict channelmap,
+    int outputsamplesize) {
     for (int s = 0; s < nsamples; s++) {
         for (int c = 0; c < outputfmt->channels; c++) {
             if (channelmap[c] < 0) {
                 continue;
             }
-            float sample = (*(input+channelmap[c])) / (float)0x80;
+            float sample = (*(input + channelmap[c])) / (float)0x80;
             *((float *)(output + 4 * c)) = sample;
         }
         input += inputfmt->channels;
@@ -115,13 +150,20 @@ pcm_write_samples_8_to_float (const ddb_waveformat_t * restrict inputfmt, const 
 }
 
 static inline void
-pcm_write_samples_16_to_16 (const ddb_waveformat_t * restrict inputfmt, const char * restrict input, const ddb_waveformat_t * restrict outputfmt, char * restrict output, int nsamples, int * restrict channelmap, int outputsamplesize) {
+pcm_write_samples_16_to_16 (
+    const ddb_waveformat_t *restrict inputfmt,
+    const char *restrict input,
+    const ddb_waveformat_t *restrict outputfmt,
+    char *restrict output,
+    int nsamples,
+    int *restrict channelmap,
+    int outputsamplesize) {
     for (int s = 0; s < nsamples; s++) {
         for (int c = 0; c < outputfmt->channels; c++) {
             if (channelmap[c] < 0) {
                 continue;
             }
-            *((int16_t*)(output + 2 * c)) = *((int16_t*)(input + channelmap[c]*2));
+            *((int16_t *)(output + 2 * c)) = *((int16_t *)(input + channelmap[c] * 2));
         }
         input += 2 * inputfmt->channels;
         output += outputsamplesize;
@@ -129,13 +171,20 @@ pcm_write_samples_16_to_16 (const ddb_waveformat_t * restrict inputfmt, const ch
 }
 
 static inline void
-pcm_write_samples_16_to_8 (const ddb_waveformat_t * restrict inputfmt, const char * restrict input, const ddb_waveformat_t * restrict outputfmt, char * restrict output, int nsamples, int * restrict channelmap, int outputsamplesize) {
+pcm_write_samples_16_to_8 (
+    const ddb_waveformat_t *restrict inputfmt,
+    const char *restrict input,
+    const ddb_waveformat_t *restrict outputfmt,
+    char *restrict output,
+    int nsamples,
+    int *restrict channelmap,
+    int outputsamplesize) {
     for (int s = 0; s < nsamples; s++) {
         for (int c = 0; c < outputfmt->channels; c++) {
             if (channelmap[c] < 0) {
                 continue;
             }
-            *((int8_t*)(output + c)) = *((int16_t*)(input + channelmap[c]*2)) >> 8;
+            *((int8_t *)(output + c)) = *((int16_t *)(input + channelmap[c] * 2)) >> 8;
         }
         input += 2 * inputfmt->channels;
         output += outputsamplesize;
@@ -143,14 +192,21 @@ pcm_write_samples_16_to_8 (const ddb_waveformat_t * restrict inputfmt, const cha
 }
 
 static inline void
-pcm_write_samples_16_to_24 (const ddb_waveformat_t * restrict inputfmt, const char * restrict input, const ddb_waveformat_t * restrict outputfmt, char * restrict output, int nsamples, int * restrict channelmap, int outputsamplesize) {
+pcm_write_samples_16_to_24 (
+    const ddb_waveformat_t *restrict inputfmt,
+    const char *restrict input,
+    const ddb_waveformat_t *restrict outputfmt,
+    char *restrict output,
+    int nsamples,
+    int *restrict channelmap,
+    int outputsamplesize) {
     for (int s = 0; s < nsamples; s++) {
         for (int c = 0; c < outputfmt->channels; c++) {
             if (channelmap[c] < 0) {
                 continue;
             }
             char *out = output + 3 * c;
-            const char *in = input + channelmap[c]*2;
+            const char *in = input + channelmap[c] * 2;
             out[0] = 0;
             out[1] = in[0];
             out[2] = in[1];
@@ -161,14 +217,21 @@ pcm_write_samples_16_to_24 (const ddb_waveformat_t * restrict inputfmt, const ch
 }
 
 static inline void
-pcm_write_samples_16_to_32 (const ddb_waveformat_t * restrict inputfmt, const char * restrict input, const ddb_waveformat_t * restrict outputfmt, char * restrict output, int nsamples, int * restrict channelmap, int outputsamplesize) {
+pcm_write_samples_16_to_32 (
+    const ddb_waveformat_t *restrict inputfmt,
+    const char *restrict input,
+    const ddb_waveformat_t *restrict outputfmt,
+    char *restrict output,
+    int nsamples,
+    int *restrict channelmap,
+    int outputsamplesize) {
     for (int s = 0; s < nsamples; s++) {
         for (int c = 0; c < outputfmt->channels; c++) {
             if (channelmap[c] < 0) {
                 continue;
             }
             char *out = output + 4 * c;
-            const char *in = input + channelmap[c]*2;
+            const char *in = input + channelmap[c] * 2;
             out[0] = 0;
             out[1] = 0;
             out[2] = in[0];
@@ -180,13 +243,20 @@ pcm_write_samples_16_to_32 (const ddb_waveformat_t * restrict inputfmt, const ch
 }
 
 static inline void
-pcm_write_samples_16_to_float (const ddb_waveformat_t * restrict inputfmt, const char * restrict input, const ddb_waveformat_t * restrict outputfmt, char * restrict output, int nsamples, int * restrict channelmap, int outputsamplesize) {
+pcm_write_samples_16_to_float (
+    const ddb_waveformat_t *restrict inputfmt,
+    const char *restrict input,
+    const ddb_waveformat_t *restrict outputfmt,
+    char *restrict output,
+    int nsamples,
+    int *restrict channelmap,
+    int outputsamplesize) {
     for (int s = 0; s < nsamples; s++) {
         for (int c = 0; c < outputfmt->channels; c++) {
             if (channelmap[c] < 0) {
                 continue;
             }
-            float sample = (*((int16_t*)(input + channelmap[c]*2))) / (float)0x8000;
+            float sample = (*((int16_t *)(input + channelmap[c] * 2))) / (float)0x8000;
             *((float *)(output + 4 * c)) = sample;
         }
         input += 2 * inputfmt->channels;
@@ -195,7 +265,14 @@ pcm_write_samples_16_to_float (const ddb_waveformat_t * restrict inputfmt, const
 }
 
 static inline void
-pcm_write_samples_24_to_8 (const ddb_waveformat_t * restrict inputfmt, const char * restrict input, const ddb_waveformat_t * restrict outputfmt, char * restrict output, int nsamples, int * restrict channelmap, int outputsamplesize) {
+pcm_write_samples_24_to_8 (
+    const ddb_waveformat_t *restrict inputfmt,
+    const char *restrict input,
+    const ddb_waveformat_t *restrict outputfmt,
+    char *restrict output,
+    int nsamples,
+    int *restrict channelmap,
+    int outputsamplesize) {
     for (int s = 0; s < nsamples; s++) {
         for (int c = 0; c < outputfmt->channels; c++) {
             if (channelmap[c] < 0) {
@@ -210,7 +287,14 @@ pcm_write_samples_24_to_8 (const ddb_waveformat_t * restrict inputfmt, const cha
 }
 
 static inline void
-pcm_write_samples_24_to_24 (const ddb_waveformat_t * restrict inputfmt, const char * restrict input, const ddb_waveformat_t * restrict outputfmt, char * restrict output, int nsamples, int * restrict channelmap, int outputsamplesize) {
+pcm_write_samples_24_to_24 (
+    const ddb_waveformat_t *restrict inputfmt,
+    const char *restrict input,
+    const ddb_waveformat_t *restrict outputfmt,
+    char *restrict output,
+    int nsamples,
+    int *restrict channelmap,
+    int outputsamplesize) {
     for (int s = 0; s < nsamples; s++) {
         for (int c = 0; c < outputfmt->channels; c++) {
             if (channelmap[c] < 0) {
@@ -228,7 +312,14 @@ pcm_write_samples_24_to_24 (const ddb_waveformat_t * restrict inputfmt, const ch
 }
 
 static inline void
-pcm_write_samples_24_to_32 (const ddb_waveformat_t * restrict inputfmt, const char * restrict input, const ddb_waveformat_t * restrict outputfmt, char * restrict output, int nsamples, int * restrict channelmap, int outputsamplesize) {
+pcm_write_samples_24_to_32 (
+    const ddb_waveformat_t *restrict inputfmt,
+    const char *restrict input,
+    const ddb_waveformat_t *restrict outputfmt,
+    char *restrict output,
+    int nsamples,
+    int *restrict channelmap,
+    int outputsamplesize) {
     for (int s = 0; s < nsamples; s++) {
         for (int c = 0; c < outputfmt->channels; c++) {
             if (channelmap[c] < 0) {
@@ -247,7 +338,14 @@ pcm_write_samples_24_to_32 (const ddb_waveformat_t * restrict inputfmt, const ch
 }
 
 static inline void
-pcm_write_samples_24_to_16 (const ddb_waveformat_t * restrict inputfmt, const char * restrict input, const ddb_waveformat_t * restrict outputfmt, char * restrict output, int nsamples, int * restrict channelmap, int outputsamplesize) {
+pcm_write_samples_24_to_16 (
+    const ddb_waveformat_t *restrict inputfmt,
+    const char *restrict input,
+    const ddb_waveformat_t *restrict outputfmt,
+    char *restrict output,
+    int nsamples,
+    int *restrict channelmap,
+    int outputsamplesize) {
     for (int s = 0; s < nsamples; s++) {
         for (int c = 0; c < outputfmt->channels; c++) {
             if (channelmap[c] < 0) {
@@ -264,7 +362,14 @@ pcm_write_samples_24_to_16 (const ddb_waveformat_t * restrict inputfmt, const ch
 }
 
 static inline void
-pcm_write_samples_24_to_float (const ddb_waveformat_t * restrict inputfmt, const char * restrict input, const ddb_waveformat_t * restrict outputfmt, char * restrict output, int nsamples, int * restrict channelmap, int outputsamplesize) {
+pcm_write_samples_24_to_float (
+    const ddb_waveformat_t *restrict inputfmt,
+    const char *restrict input,
+    const ddb_waveformat_t *restrict outputfmt,
+    char *restrict output,
+    int nsamples,
+    int *restrict channelmap,
+    int outputsamplesize) {
     for (int s = 0; s < nsamples; s++) {
         for (int c = 0; c < outputfmt->channels; c++) {
             if (channelmap[c] < 0) {
@@ -272,7 +377,7 @@ pcm_write_samples_24_to_float (const ddb_waveformat_t * restrict inputfmt, const
             }
             float *out = (float *)(output + 4 * c);
             const char *in = input + 3 * channelmap[c];
-            int32_t sample = ((unsigned char)in[0]) | ((unsigned char)in[1]<<8) | ((signed char)in[2]<<16);
+            int32_t sample = ((unsigned char)in[0]) | ((unsigned char)in[1] << 8) | ((signed char)in[2] << 16);
             *out = sample / (float)0x800000;
         }
         input += inputfmt->channels * 3;
@@ -281,15 +386,22 @@ pcm_write_samples_24_to_float (const ddb_waveformat_t * restrict inputfmt, const
 }
 
 static inline void
-pcm_write_samples_32_to_8 (const ddb_waveformat_t * restrict inputfmt, const char * restrict input, const ddb_waveformat_t * restrict outputfmt, char * restrict output, int nsamples, int * restrict channelmap, int outputsamplesize) {
+pcm_write_samples_32_to_8 (
+    const ddb_waveformat_t *restrict inputfmt,
+    const char *restrict input,
+    const ddb_waveformat_t *restrict outputfmt,
+    char *restrict output,
+    int nsamples,
+    int *restrict channelmap,
+    int outputsamplesize) {
     for (int s = 0; s < nsamples; s++) {
         for (int c = 0; c < outputfmt->channels; c++) {
             if (channelmap[c] < 0) {
                 continue;
             }
-            int8_t *out = (int8_t*)(output + c);
-            int32_t sample = *((int32_t*)(input + 4 * channelmap[c]));
-            *out = (int8_t)(sample>>24);
+            int8_t *out = (int8_t *)(output + c);
+            int32_t sample = *((int32_t *)(input + 4 * channelmap[c]));
+            *out = (int8_t)(sample >> 24);
         }
         input += 4 * inputfmt->channels;
         output += outputsamplesize;
@@ -297,15 +409,22 @@ pcm_write_samples_32_to_8 (const ddb_waveformat_t * restrict inputfmt, const cha
 }
 
 static inline void
-pcm_write_samples_32_to_16 (const ddb_waveformat_t * restrict inputfmt, const char * restrict input, const ddb_waveformat_t * restrict outputfmt, char * restrict output, int nsamples, int * restrict channelmap, int outputsamplesize) {
+pcm_write_samples_32_to_16 (
+    const ddb_waveformat_t *restrict inputfmt,
+    const char *restrict input,
+    const ddb_waveformat_t *restrict outputfmt,
+    char *restrict output,
+    int nsamples,
+    int *restrict channelmap,
+    int outputsamplesize) {
     for (int s = 0; s < nsamples; s++) {
         for (int c = 0; c < outputfmt->channels; c++) {
             if (channelmap[c] < 0) {
                 continue;
             }
-            int16_t *out = (int16_t*)(output + 2 * c);
-            int32_t sample = *((int32_t*)(input + 4 * channelmap[c]));
-            *out = (int16_t)(sample>>16);
+            int16_t *out = (int16_t *)(output + 2 * c);
+            int32_t sample = *((int32_t *)(input + 4 * channelmap[c]));
+            *out = (int16_t)(sample >> 16);
         }
         input += 4 * inputfmt->channels;
         output += outputsamplesize;
@@ -313,7 +432,14 @@ pcm_write_samples_32_to_16 (const ddb_waveformat_t * restrict inputfmt, const ch
 }
 
 static inline void
-pcm_write_samples_32_to_24 (const ddb_waveformat_t * restrict inputfmt, const char * restrict input, const ddb_waveformat_t * restrict outputfmt, char * restrict output, int nsamples, int * restrict channelmap, int outputsamplesize) {
+pcm_write_samples_32_to_24 (
+    const ddb_waveformat_t *restrict inputfmt,
+    const char *restrict input,
+    const ddb_waveformat_t *restrict outputfmt,
+    char *restrict output,
+    int nsamples,
+    int *restrict channelmap,
+    int outputsamplesize) {
     for (int s = 0; s < nsamples; s++) {
         for (int c = 0; c < outputfmt->channels; c++) {
             if (channelmap[c] < 0) {
@@ -331,29 +457,42 @@ pcm_write_samples_32_to_24 (const ddb_waveformat_t * restrict inputfmt, const ch
 }
 
 static inline void
-pcm_write_samples_32_to_32 (const ddb_waveformat_t * restrict inputfmt, const char * restrict input, const ddb_waveformat_t * restrict outputfmt, char * restrict output, int nsamples, int * restrict channelmap, int outputsamplesize) {
+pcm_write_samples_32_to_32 (
+    const ddb_waveformat_t *restrict inputfmt,
+    const char *restrict input,
+    const ddb_waveformat_t *restrict outputfmt,
+    char *restrict output,
+    int nsamples,
+    int *restrict channelmap,
+    int outputsamplesize) {
     for (int s = 0; s < nsamples; s++) {
         for (int c = 0; c < outputfmt->channels; c++) {
             if (channelmap[c] < 0) {
                 continue;
             }
-            *((int32_t*)(output + 4 * c)) = *((int32_t*)(input + channelmap[c] * 4));
+            *((int32_t *)(output + 4 * c)) = *((int32_t *)(input + channelmap[c] * 4));
         }
         input += 4 * inputfmt->channels;
         output += outputsamplesize;
     }
 }
 
-
 static inline void
-pcm_write_samples_32_to_float (const ddb_waveformat_t * restrict inputfmt, const char * restrict input, const ddb_waveformat_t * restrict outputfmt, char * restrict output, int nsamples, int * restrict channelmap, int outputsamplesize) {
+pcm_write_samples_32_to_float (
+    const ddb_waveformat_t *restrict inputfmt,
+    const char *restrict input,
+    const ddb_waveformat_t *restrict outputfmt,
+    char *restrict output,
+    int nsamples,
+    int *restrict channelmap,
+    int outputsamplesize) {
     for (int s = 0; s < nsamples; s++) {
         for (int c = 0; c < outputfmt->channels; c++) {
             if (channelmap[c] < 0) {
                 continue;
             }
             float *out = (float *)(output + 4 * c);
-            int32_t sample = *((int32_t*)(input + channelmap[c] * 4));
+            int32_t sample = *((int32_t *)(input + channelmap[c] * 4));
             *out = sample / (float)0x80000000;
         }
         input += 4 * inputfmt->channels;
@@ -361,7 +500,14 @@ pcm_write_samples_32_to_float (const ddb_waveformat_t * restrict inputfmt, const
     }
 }
 static inline void
-pcm_write_samples_float_to_8 (const ddb_waveformat_t * restrict inputfmt, const char * restrict input, const ddb_waveformat_t * restrict outputfmt, char * restrict output, int nsamples, int * restrict channelmap, int outputsamplesize) {
+pcm_write_samples_float_to_8 (
+    const ddb_waveformat_t *restrict inputfmt,
+    const char *restrict input,
+    const ddb_waveformat_t *restrict outputfmt,
+    char *restrict output,
+    int nsamples,
+    int *restrict channelmap,
+    int outputsamplesize) {
     fpu_control ctl = 0;
     (void)ctl;
     fpu_setround (&ctl);
@@ -370,9 +516,9 @@ pcm_write_samples_float_to_8 (const ddb_waveformat_t * restrict inputfmt, const 
             if (channelmap[c] < 0) {
                 continue;
             }
-            int8_t *out = (int8_t*)(output + c);
-            float sample = *((float*)(input + channelmap[c] * 4));
-            int isample = ftoi(sample * 0x80);
+            int8_t *out = (int8_t *)(output + c);
+            float sample = *((float *)(input + channelmap[c] * 4));
+            int isample = ftoi (sample * 0x80);
             if (isample > 0x7f) {
                 isample = 0x7f;
             }
@@ -388,7 +534,14 @@ pcm_write_samples_float_to_8 (const ddb_waveformat_t * restrict inputfmt, const 
 }
 
 static inline void
-pcm_write_samples_float_to_16 (const ddb_waveformat_t * restrict inputfmt, const char * restrict input, const ddb_waveformat_t * restrict outputfmt, char * restrict output, int nsamples, int * restrict channelmap, int outputsamplesize) {
+pcm_write_samples_float_to_16 (
+    const ddb_waveformat_t *restrict inputfmt,
+    const char *restrict input,
+    const ddb_waveformat_t *restrict outputfmt,
+    char *restrict output,
+    int nsamples,
+    int *restrict channelmap,
+    int outputsamplesize) {
     fpu_control ctl = 0;
     (void)ctl;
     fpu_setround (&ctl);
@@ -397,9 +550,9 @@ pcm_write_samples_float_to_16 (const ddb_waveformat_t * restrict inputfmt, const
             if (channelmap[c] < 0) {
                 continue;
             }
-            int16_t *out = (int16_t*)(output + 2 * c);
-            float sample = *((float*)(input + 4 * channelmap[c]));
-            int isample = ftoi (sample*0x8000);
+            int16_t *out = (int16_t *)(output + 2 * c);
+            float sample = *((float *)(input + 4 * channelmap[c]));
+            int isample = ftoi (sample * 0x8000);
             if (isample > 0x7fff) {
                 isample = 0x7fff;
             }
@@ -415,7 +568,14 @@ pcm_write_samples_float_to_16 (const ddb_waveformat_t * restrict inputfmt, const
 }
 
 static inline void
-pcm_write_samples_float_to_24 (const ddb_waveformat_t * restrict inputfmt, const char * restrict input, const ddb_waveformat_t * restrict outputfmt, char * restrict output, int nsamples, int * restrict channelmap, int outputsamplesize) {
+pcm_write_samples_float_to_24 (
+    const ddb_waveformat_t *restrict inputfmt,
+    const char *restrict input,
+    const ddb_waveformat_t *restrict outputfmt,
+    char *restrict output,
+    int nsamples,
+    int *restrict channelmap,
+    int outputsamplesize) {
     fpu_control ctl = 0;
     (void)ctl;
     fpu_setround (&ctl);
@@ -425,7 +585,7 @@ pcm_write_samples_float_to_24 (const ddb_waveformat_t * restrict inputfmt, const
                 continue;
             }
             char *out = output + 3 * c;
-            float sample = *((float*)(input + channelmap[c] * 4));
+            float sample = *((float *)(input + channelmap[c] * 4));
             int32_t outsample = (int32_t)ftoi (sample * 0x800000);
             if (outsample >= 0x7fffff) {
                 outsample = 0x7fffff;
@@ -433,9 +593,9 @@ pcm_write_samples_float_to_24 (const ddb_waveformat_t * restrict inputfmt, const
             else if (outsample < -0x800000) {
                 outsample = -0x800000;
             }
-            out[0] = (outsample&0x0000ff);
-            out[1] = (outsample&0x00ff00)>>8;
-            out[2] = (outsample&0xff0000)>>16;
+            out[0] = (outsample & 0x0000ff);
+            out[1] = (outsample & 0x00ff00) >> 8;
+            out[2] = (outsample & 0xff0000) >> 16;
         }
         input += 4 * inputfmt->channels;
         output += outputsamplesize;
@@ -443,22 +603,28 @@ pcm_write_samples_float_to_24 (const ddb_waveformat_t * restrict inputfmt, const
     fpu_restore (ctl);
 }
 
-
 static inline void
-pcm_write_samples_float_to_32 (const ddb_waveformat_t * restrict inputfmt, const char * restrict input, const ddb_waveformat_t * restrict outputfmt, char * restrict output, int nsamples, int * restrict channelmap, int outputsamplesize) {
+pcm_write_samples_float_to_32 (
+    const ddb_waveformat_t *restrict inputfmt,
+    const char *restrict input,
+    const ddb_waveformat_t *restrict outputfmt,
+    char *restrict output,
+    int nsamples,
+    int *restrict channelmap,
+    int outputsamplesize) {
     for (int s = 0; s < nsamples; s++) {
         for (int c = 0; c < outputfmt->channels; c++) {
             if (channelmap[c] < 0) {
                 continue;
             }
-            float fsample = (*((float*)(input + channelmap[c] * 4)));
-            if (fsample > (float)0x7fffffff/0x80000000) {
-                fsample = (float)0x7fffffff/0x80000000;
+            float fsample = (*((float *)(input + channelmap[c] * 4)));
+            if (fsample > (float)0x7fffffff / 0x80000000) {
+                fsample = (float)0x7fffffff / 0x80000000;
             }
             else if (fsample < -1.f) {
                 fsample = -1.f;
             }
-            int32_t sample = ftoi(fsample * (float)0x80000000);
+            int32_t sample = ftoi (fsample * (float)0x80000000);
             *((int32_t *)(output + 4 * c)) = sample;
         }
         input += 4 * inputfmt->channels;
@@ -466,70 +632,58 @@ pcm_write_samples_float_to_32 (const ddb_waveformat_t * restrict inputfmt, const
     }
 }
 
-typedef void (*remap_fn_t) (const ddb_waveformat_t * restrict inputfmt, const char * restrict input, const ddb_waveformat_t * restrict outputfmt, char * restrict output, int nsamples, int * restrict channelmap, int outputsamplesize);
-
+typedef void (*remap_fn_t) (
+    const ddb_waveformat_t *restrict inputfmt,
+    const char *restrict input,
+    const ddb_waveformat_t *restrict outputfmt,
+    char *restrict output,
+    int nsamples,
+    int *restrict channelmap,
+    int outputsamplesize);
 
 remap_fn_t remappers[8][8] = {
     {
-        pcm_write_samples_8_to_8,
-        pcm_write_samples_8_to_16,
-        pcm_write_samples_8_to_24,
-        pcm_write_samples_8_to_32,
-        NULL,
-        NULL,
-        NULL,
-        pcm_write_samples_8_to_float,
-    },
+     pcm_write_samples_8_to_8, pcm_write_samples_8_to_16,
+     pcm_write_samples_8_to_24, pcm_write_samples_8_to_32,
+     NULL, NULL,
+     NULL, pcm_write_samples_8_to_float,
+     },
     {
-        pcm_write_samples_16_to_8,
-        pcm_write_samples_16_to_16,
-        pcm_write_samples_16_to_24,
-        pcm_write_samples_16_to_32,
-        NULL,
-        NULL,
-        NULL,
-        pcm_write_samples_16_to_float,
-    },
+     pcm_write_samples_16_to_8, pcm_write_samples_16_to_16,
+     pcm_write_samples_16_to_24, pcm_write_samples_16_to_32,
+     NULL, NULL,
+     NULL, pcm_write_samples_16_to_float,
+     },
     {
-        pcm_write_samples_24_to_8,
-        pcm_write_samples_24_to_16,
-        pcm_write_samples_24_to_24,
-        pcm_write_samples_24_to_32,
-        NULL,
-        NULL,
-        NULL,
-        pcm_write_samples_24_to_float,
-    },
+     pcm_write_samples_24_to_8, pcm_write_samples_24_to_16,
+     pcm_write_samples_24_to_24, pcm_write_samples_24_to_32,
+     NULL, NULL,
+     NULL, pcm_write_samples_24_to_float,
+     },
     {
-        pcm_write_samples_32_to_8,
-        pcm_write_samples_32_to_16,
-        pcm_write_samples_32_to_24,
-        pcm_write_samples_32_to_32,
-        NULL,
-        NULL,
-        NULL,
-        pcm_write_samples_32_to_float,
-    },
+     pcm_write_samples_32_to_8, pcm_write_samples_32_to_16,
+     pcm_write_samples_32_to_24, pcm_write_samples_32_to_32,
+     NULL, NULL,
+     NULL, pcm_write_samples_32_to_float,
+     },
+    {},
+    {},
+    {},
     {
-    },
-    {
-    },
-    {
-    },
-    {
-        pcm_write_samples_float_to_8,
-        pcm_write_samples_float_to_16,
-        pcm_write_samples_float_to_24,
-        pcm_write_samples_float_to_32,
-        NULL,
-        NULL,
-        NULL,
-        pcm_write_samples_32_to_32,
-    }
+     pcm_write_samples_float_to_8, pcm_write_samples_float_to_16,
+     pcm_write_samples_float_to_24, pcm_write_samples_float_to_32,
+     NULL, NULL,
+     NULL, pcm_write_samples_32_to_32,
+     }
 };
 
 int
-pcm_convert (const ddb_waveformat_t * restrict inputfmt, const char * restrict input, const ddb_waveformat_t * restrict outputfmt, char * restrict output, int inputsize) {
+pcm_convert (
+    const ddb_waveformat_t *restrict inputfmt,
+    const char *restrict input,
+    const ddb_waveformat_t *restrict outputfmt,
+    char *restrict output,
+    int inputsize) {
     // calculate output size
     int inputsamplesize = (inputfmt->bps >> 3) * inputfmt->channels;
     int outputsamplesize = (outputfmt->bps >> 3) * outputfmt->channels;
@@ -554,7 +708,10 @@ pcm_convert (const ddb_waveformat_t * restrict inputfmt, const char * restrict i
                 inputbitmask <<= 1;
             }
             if (!(inputfmt->channelmask & inputbitmask)) {
-                trace ("pcm_convert: channelmask doesn't correspond to the inputfmt (channels=%d, channelmask=%X)!\n", inputfmt->channels, inputfmt->channelmask);
+                trace (
+                    "pcm_convert: channelmask doesn't correspond to the inputfmt (channels=%d, channelmask=%X)!\n",
+                    inputfmt->channels,
+                    inputfmt->channelmask);
                 break;
             }
             if (outputfmt->channelmask & inputbitmask) {
@@ -583,12 +740,18 @@ pcm_convert (const ddb_waveformat_t * restrict inputfmt, const char * restrict i
         int outidx = ((outputfmt->bps >> 3) - 1) | (outputfmt->is_float << 2);
         int inidx = ((inputfmt->bps >> 3) - 1) | (inputfmt->is_float << 2);
         if (remappers[inidx][outidx]) {
-            remappers[inidx][outidx] (inputfmt, input, outputfmt, output, nsamples, channelmap, outputsamplesize);
+            remappers[inidx][outidx](inputfmt, input, outputfmt, output, nsamples, channelmap, outputsamplesize);
         }
         else {
-            trace ("no converter from %d %s to %d %s ([%d][%d])\n", inputfmt->bps, inputfmt->is_float ? "float" : "", outputfmt->bps, outputfmt->is_float ? "float" : "", inidx, outidx);
+            trace (
+                "no converter from %d %s to %d %s ([%d][%d])\n",
+                inputfmt->bps,
+                inputfmt->is_float ? "float" : "",
+                outputfmt->bps,
+                outputfmt->is_float ? "float" : "",
+                inidx,
+                outidx);
         }
     }
     return nsamples * outputsamplesize;
 }
-

--- a/src/premix.h
+++ b/src/premix.h
@@ -31,13 +31,18 @@
 #include <deadbeef/deadbeef.h>
 
 #ifdef __cplusplus
-#define restrict
+#    define restrict
 extern "C" {
 #endif
 
 // @returns number of output bytes
 int
-pcm_convert (const ddb_waveformat_t * restrict inputfmt, const char * restrict input, const ddb_waveformat_t * restrict outputfmt, char * restrict output, int inputsize);
+pcm_convert (
+    const ddb_waveformat_t *restrict inputfmt,
+    const char *restrict input,
+    const ddb_waveformat_t *restrict outputfmt,
+    char *restrict output,
+    int inputsize);
 
 #ifdef __cplusplus
 }

--- a/src/replaygain.c
+++ b/src/replaygain.c
@@ -63,7 +63,7 @@ replaygain_apply_with_settings (ddb_replaygain_settings_t *settings, ddb_wavefor
 
 void
 replaygain_apply (ddb_waveformat_t *fmt, char *bytes, int numbytes) {
-    replaygain_apply_with_settings(&current_settings, fmt, bytes, numbytes);
+    replaygain_apply_with_settings (&current_settings, fmt, bytes, numbytes);
 }
 
 void
@@ -95,20 +95,20 @@ replaygain_init_settings (ddb_replaygain_settings_t *settings, playItem_t *it) {
 
     if (settings->processing_flags & DDB_RG_PROCESSING_GAIN) {
         if (albumgain) {
-            settings->albumgain = db_to_amp((float)atof (albumgain));
+            settings->albumgain = db_to_amp ((float)atof (albumgain));
             settings->has_album_gain = 1;
         }
         else if (trackgain) {
-            settings->albumgain = db_to_amp((float)atof (trackgain));
+            settings->albumgain = db_to_amp ((float)atof (trackgain));
             settings->has_album_gain = 1;
         }
 
         if (trackgain) {
-            settings->trackgain = db_to_amp((float)atof (trackgain));
+            settings->trackgain = db_to_amp ((float)atof (trackgain));
             settings->has_track_gain = 1;
         }
         else if (albumgain) {
-            settings->trackgain = db_to_amp((float)atof (albumgain));
+            settings->trackgain = db_to_amp ((float)atof (albumgain));
             settings->has_track_gain = 1;
         }
     }
@@ -155,7 +155,8 @@ get_int_volume (ddb_replaygain_settings_t *settings) {
     case DDB_RG_SOURCE_MODE_TRACK:
         if (!settings->has_track_gain) {
             vol = (int)(settings->preamp_without_rg * 1000);
-        } else {
+        }
+        else {
             vol = (int)(settings->preamp_with_rg * settings->trackgain * 1000);
         }
         if (settings->processing_flags & DDB_RG_PROCESSING_PREVENT_CLIPPING) {
@@ -166,8 +167,9 @@ get_int_volume (ddb_replaygain_settings_t *settings) {
         break;
     case DDB_RG_SOURCE_MODE_ALBUM:
         if (!settings->has_album_gain) {
-            vol = (int)(settings->preamp_without_rg *  1000);
-        } else {
+            vol = (int)(settings->preamp_without_rg * 1000);
+        }
+        else {
             vol = (int)(settings->preamp_with_rg * settings->albumgain * 1000);
         }
         if (settings->processing_flags & DDB_RG_PROCESSING_PREVENT_CLIPPING) {
@@ -188,7 +190,7 @@ apply_replay_gain_int8 (ddb_replaygain_settings_t *settings, char *bytes, int si
     if (vol < 0) {
         return;
     }
-    int8_t *s = (int8_t*)bytes;
+    int8_t *s = (int8_t *)bytes;
     for (int j = 0; j < size; j++) {
         int32_t sample = ((int8_t)(*s)) * vol / 1000;
         if (sample > 0x7f) {
@@ -208,8 +210,8 @@ apply_replay_gain_int16 (ddb_replaygain_settings_t *settings, char *bytes, int s
     if (vol < 0) {
         return;
     }
-    int16_t *s = (int16_t*)bytes;
-    for (int j = 0; j < size/2; j++) {
+    int16_t *s = (int16_t *)bytes;
+    for (int j = 0; j < size / 2; j++) {
         int32_t sample = ((int32_t)(*s)) * vol / 1000;
         if (sample > 0x7fff) {
             sample = 0x7fff;
@@ -228,9 +230,9 @@ apply_replay_gain_int24 (ddb_replaygain_settings_t *settings, char *bytes, int s
     if (vol < 0) {
         return;
     }
-    char *s = (char*)bytes;
-    for (int j = 0; j < size/3; j++) {
-        int32_t sample = ((unsigned char)s[0]) | ((unsigned char)s[1]<<8) | ((signed char)s[2]<<16);
+    char *s = (char *)bytes;
+    for (int j = 0; j < size / 3; j++) {
+        int32_t sample = ((unsigned char)s[0]) | ((unsigned char)s[1] << 8) | ((signed char)s[2] << 16);
         sample = (int32_t)(sample * vol / 1000);
         if (sample > 0x7fffff) {
             sample = 0x7fffff;
@@ -238,9 +240,9 @@ apply_replay_gain_int24 (ddb_replaygain_settings_t *settings, char *bytes, int s
         else if (sample < -0x800000) {
             sample = -0x800000;
         }
-        s[0] = (sample&0x0000ff);
-        s[1] = (sample&0x00ff00)>>8;
-        s[2] = (sample&0xff0000)>>16;
+        s[0] = (sample & 0x0000ff);
+        s[1] = (sample & 0x00ff00) >> 8;
+        s[2] = (sample & 0xff0000) >> 16;
         s += 3;
     }
 }
@@ -251,8 +253,8 @@ apply_replay_gain_int32 (ddb_replaygain_settings_t *settings, char *bytes, int s
     if (vol < 0) {
         return;
     }
-    int32_t *s = (int32_t*)bytes;
-    for (int j = 0; j < size/4; j++) {
+    int32_t *s = (int32_t *)bytes;
+    for (int j = 0; j < size / 4; j++) {
         int64_t sample = ((int32_t)(*s)) * vol / 1000;
         *s = (int32_t)sample;
         s++;
@@ -267,7 +269,8 @@ apply_replay_gain_float32 (ddb_replaygain_settings_t *settings, char *bytes, int
     case DDB_RG_SOURCE_MODE_TRACK:
         if (!settings->has_track_gain) {
             vol = settings->preamp_without_rg;
-        } else {
+        }
+        else {
             vol = settings->preamp_with_rg * settings->trackgain;
         }
         if (settings->processing_flags & DDB_RG_PROCESSING_PREVENT_CLIPPING) {
@@ -279,7 +282,8 @@ apply_replay_gain_float32 (ddb_replaygain_settings_t *settings, char *bytes, int
     case DDB_RG_SOURCE_MODE_ALBUM:
         if (!settings->has_album_gain) {
             vol = settings->preamp_without_rg;
-        } else {
+        }
+        else {
             vol = settings->preamp_with_rg * settings->albumgain;
         }
         if (settings->processing_flags & DDB_RG_PROCESSING_PREVENT_CLIPPING) {
@@ -296,8 +300,8 @@ apply_replay_gain_float32 (ddb_replaygain_settings_t *settings, char *bytes, int
         return;
     }
 
-    float *s = (float*)bytes;
-    for (int j = 0; j < size/4; j++) {
+    float *s = (float *)bytes;
+    for (int j = 0; j < size / 4; j++) {
         float sample = ((float)*s) * vol;
         if (sample > 1.f) {
             sample = 1.f;

--- a/src/resizable_buffer.c
+++ b/src/resizable_buffer.c
@@ -25,7 +25,7 @@
 #include <string.h>
 
 void
-resizable_buffer_ensure_size(resizable_buffer_t *buffer, size_t size) {
+resizable_buffer_ensure_size (resizable_buffer_t *buffer, size_t size) {
     if (buffer->size < size) {
         free (buffer->buffer);
         buffer->buffer = calloc (1, size);

--- a/src/ringbuf.c
+++ b/src/ringbuf.c
@@ -40,7 +40,6 @@ ringbuf_deinit (ringbuf_t *p) {
     memset (p, 0, sizeof (ringbuf_t));
 }
 
-
 void
 ringbuf_flush (ringbuf_t *p) {
     p->cursor = 0;
@@ -76,7 +75,7 @@ ringbuf_write (ringbuf_t *p, char *bytes, size_t size) {
 }
 
 size_t
-ringbuf_read_int (ringbuf_t * restrict p, char *bytes, size_t size, int keep, off_t offset) {
+ringbuf_read_int (ringbuf_t *restrict p, char *bytes, size_t size, int keep, off_t offset) {
     if (p->remaining < size) {
         size = p->remaining;
     }
@@ -109,15 +108,15 @@ ringbuf_read_int (ringbuf_t * restrict p, char *bytes, size_t size, int keep, of
 
 size_t
 ringbuf_read (ringbuf_t *p, char *bytes, size_t size) {
-    return ringbuf_read_int(p, bytes, size, 0, 0);
+    return ringbuf_read_int (p, bytes, size, 0, 0);
 }
 
 size_t
 ringbuf_read_keep (ringbuf_t *p, char *bytes, size_t size) {
-    return ringbuf_read_int(p, bytes, size, 1, 0);
+    return ringbuf_read_int (p, bytes, size, 1, 0);
 }
 
 size_t
 ringbuf_read_keep_offset (ringbuf_t *p, char *bytes, size_t size, off_t offset) {
-    return ringbuf_read_int(p, bytes, size, 1, offset);
+    return ringbuf_read_int (p, bytes, size, 1, offset);
 }

--- a/src/sort.c
+++ b/src/sort.c
@@ -36,7 +36,7 @@
 #include "undo/undo_playlist.h"
 
 //#define trace(...) { fprintf(stderr, __VA_ARGS__); }
-#define trace(fmt,...)
+#define trace(fmt, ...)
 
 static void
 plt_sort_internal (playlist_t *playlist, int iter, int id, const char *format, int order, int version);
@@ -53,7 +53,7 @@ plt_sort_v2 (playlist_t *plt, int iter, int id, const char *format, int order) {
             for (playItem_t *it = plt->head[PL_MAIN]; it != NULL; it = it->next[PL_MAIN]) {
                 tracks[index++] = it;
             }
-            undo_remove_items(undobuffer, plt, tracks, count);
+            undo_remove_items (undobuffer, plt, tracks, count);
             free (tracks);
         }
     }
@@ -68,7 +68,7 @@ plt_sort_v2 (playlist_t *plt, int iter, int id, const char *format, int order) {
             for (playItem_t *it = plt->head[PL_MAIN]; it != NULL; it = it->next[PL_MAIN]) {
                 tracks[index++] = it;
             }
-            undo_insert_items(undobuffer, plt, tracks, count);
+            undo_insert_items (undobuffer, plt, tracks, count);
             free (tracks);
         }
         pl_unlock ();
@@ -93,18 +93,18 @@ static ddb_tf_context_t pl_sort_tf_ctx;
 static int
 strcasecmp_numeric (const char *a, const char *b) {
     if (isdigit (*a) && isdigit (*b)) {
-        int anum = *a-'0';
-        const char *ae = a+1;
+        int anum = *a - '0';
+        const char *ae = a + 1;
         while (*ae && isdigit (*ae)) {
             anum *= 10;
-            anum += *ae-'0';
+            anum += *ae - '0';
             ae++;
         }
-        int bnum = *b-'0';
-        const char *be = b+1;
+        int bnum = *b - '0';
+        const char *be = b + 1;
         while (*be && isdigit (*be)) {
             bnum *= 10;
-            bnum += *be-'0';
+            bnum += *be - '0';
             be++;
         }
         if (anum == bnum) {
@@ -112,7 +112,7 @@ strcasecmp_numeric (const char *a, const char *b) {
         }
         return anum - bnum;
     }
-    return u8_strcasecmp (a,b);
+    return u8_strcasecmp (a, b);
 }
 
 static int
@@ -152,9 +152,9 @@ pl_sort_compare_str (playItem_t *a, playItem_t *b) {
         else {
             pl_sort_tf_ctx.id = pl_sort_id;
             pl_sort_tf_ctx.it = (ddb_playItem_t *)a;
-            tf_eval(&pl_sort_tf_ctx, pl_sort_tf_bytecode, tmp1, sizeof(tmp1));
+            tf_eval (&pl_sort_tf_ctx, pl_sort_tf_bytecode, tmp1, sizeof (tmp1));
             pl_sort_tf_ctx.it = (ddb_playItem_t *)b;
-            tf_eval(&pl_sort_tf_ctx, pl_sort_tf_bytecode, tmp2, sizeof(tmp2));
+            tf_eval (&pl_sort_tf_ctx, pl_sort_tf_bytecode, tmp2, sizeof (tmp2));
         }
         int res = strcasecmp_numeric (tmp1, tmp2);
         if (!pl_sort_ascending) {
@@ -191,13 +191,12 @@ plt_sort_random (playlist_t *playlist, int iter) {
     //randomize array
     for (int swap_a = 0; swap_a < playlist_count - 1; swap_a++) {
         //select random item above swap_a-1
-        const int swap_b = (int)(swap_a + (rand() / (float)RAND_MAX * (playlist_count - swap_a)));
+        const int swap_b = (int)(swap_a + (rand () / (float)RAND_MAX * (playlist_count - swap_a)));
 
         //swap a with b
-        playItem_t* const swap_temp = array[swap_a];
+        playItem_t *const swap_temp = array[swap_a];
         array[swap_a] = array[swap_b];
         array[swap_b] = swap_temp;
-
     }
 
     playItem_t *prev = NULL;
@@ -214,7 +213,7 @@ plt_sort_random (playlist_t *playlist, int iter) {
         }
         prev = it;
     }
-    playlist->tail[iter] = array[playlist->count[iter]-1];
+    playlist->tail[iter] = array[playlist->count[iter] - 1];
 
     free (array);
 
@@ -263,19 +262,16 @@ plt_sort_internal (playlist_t *playlist, int iter, int id, const char *format, i
         pl_sort_tf_ctx.id = id;
     }
 
-    if (format && id == -1
-        && ((version == 0 && !strcmp (format, "%l"))
-            || (version == 1 && !strcmp (format, "%length%")))
-        ) {
+    if (format && id == -1 &&
+        ((version == 0 && !strcmp (format, "%l")) || (version == 1 && !strcmp (format, "%length%")))) {
         pl_sort_is_duration = 1;
     }
     else {
         pl_sort_is_duration = 0;
     }
-    if (format && id == -1
-        && ((version == 0 && !strcmp (format, "%n"))
-            || (version == 1 && (!strcmp (format, "%track number%") || !strcmp (format, "%tracknumber%"))))
-        ) {
+    if (format && id == -1 &&
+        ((version == 0 && !strcmp (format, "%n")) ||
+         (version == 1 && (!strcmp (format, "%track number%") || !strcmp (format, "%tracknumber%"))))) {
         pl_sort_is_track = 1;
     }
     else {
@@ -313,7 +309,7 @@ plt_sort_internal (playlist_t *playlist, int iter, int id, const char *format, i
         prev = it;
     }
 
-    playlist->tail[iter] = array[playlist->count[iter]-1];
+    playlist->tail[iter] = array[playlist->count[iter] - 1];
 
     free (array);
 
@@ -363,15 +359,13 @@ sort_track_array (playlist_t *playlist, playItem_t **tracks, int num_tracks, con
     pl_sort_tf_ctx.idx = -1;
     pl_sort_tf_ctx.id = -1;
 
-    if (format
-        && !strcmp (format, "%length%")) {
+    if (format && !strcmp (format, "%length%")) {
         pl_sort_is_duration = 1;
     }
     else {
         pl_sort_is_duration = 0;
     }
-    if (format
-        && (!strcmp (format, "%track number%") || !strcmp (format, "%tracknumber%"))) {
+    if (format && (!strcmp (format, "%track number%") || !strcmp (format, "%tracknumber%"))) {
         pl_sort_is_track = 1;
     }
     else {

--- a/src/streamer.c
+++ b/src/streamer.c
@@ -946,12 +946,12 @@ streamer_song_removed_notify (playItem_t *it) {
         streamer_set_next_track_to_play (NULL);
         next = get_next_track (it, shuffle, repeat);
         if (next == it) {
-            pl_item_unref(next);
+            pl_item_unref (next);
             next = NULL;
         }
         prev = get_prev_track (it, shuffle, repeat);
         if (prev == it) {
-            pl_item_unref(prev);
+            pl_item_unref (prev);
             prev = NULL;
         }
         streamer_set_next_track_to_play (next);

--- a/src/streamreader.c
+++ b/src/streamreader.c
@@ -97,7 +97,7 @@ streamreader_configchanged (void) {
 int
 streamreader_read_block (streamblock_t *block, playItem_t *track, DB_fileinfo_t *fileinfo, uint64_t mutex) {
     int size = BLOCK_SIZE;
-    int samplesize = fileinfo->fmt.channels * (fileinfo->fmt.bps>>3);
+    int samplesize = fileinfo->fmt.channels * (fileinfo->fmt.bps >> 3);
 
     // NOTE: samplesize has to be checked to protect against faulty input plugins
 
@@ -152,7 +152,7 @@ streamreader_read_block (streamblock_t *block, playItem_t *track, DB_fileinfo_t 
     memcpy (&block->fmt, &fileinfo->fmt, sizeof (ddb_waveformat_t));
     block->track = track;
     if (block->track != NULL) {
-        pl_item_ref(block->track);
+        pl_item_ref (block->track);
     }
 
     if (size > 0) {
@@ -193,7 +193,7 @@ streamreader_silence_block (streamblock_t *block, playItem_t *track, DB_fileinfo
     memcpy (&block->fmt, &fileinfo->fmt, sizeof (ddb_waveformat_t));
     block->track = track;
     if (block->track != NULL) {
-        pl_item_ref(block->track);
+        pl_item_ref (block->track);
     }
     block->is_silent_header = 1;
 
@@ -241,7 +241,7 @@ static void
 _streamreader_release_block (streamblock_t *block) {
     block->pos = -1;
     if (block->track != NULL) {
-        pl_item_unref(block->track);
+        pl_item_unref (block->track);
     }
     block->track = NULL;
     block->queued = 0;
@@ -268,14 +268,13 @@ streamreader_next_block (void) {
     }
 }
 
-
 void
 streamreader_reset (void) {
     streamblock_t *b = blocks;
     while (b) {
         b->pos = -1;
         if (b->track != NULL) {
-            pl_item_unref(b->track);
+            pl_item_unref (b->track);
             b->track = NULL;
         }
         b->queued = 0;

--- a/src/tf.c
+++ b/src/tf.c
@@ -43,10 +43,10 @@
 // !0: plain text
 
 #ifdef HAVE_CONFIG_H
-#include "config.h"
+#    include "config.h"
 #endif
 #ifdef HAVE_ALLOCA_H
-#include <alloca.h>
+#    include <alloca.h>
 #endif
 #include <stdio.h>
 #include <stdlib.h>
@@ -68,13 +68,13 @@
 #include "junklib.h"
 #include "external/wcwidth/wcwidth.h"
 
-#define min(x,y) ((x)<(y)?(x):(y))
+#define min(x, y) ((x) < (y) ? (x) : (y))
 
 //#define trace(...) { fprintf(stderr, __VA_ARGS__); }
-#define trace(fmt,...)
+#define trace(fmt, ...)
 
 #define TEMP_BUFFER_SIZE 1000
-#define TF_INTERNAL_FLAG_LOCKED (1<<16)
+#define TF_INTERNAL_FLAG_LOCKED (1 << 16)
 
 typedef struct ddb_tf_var_t {
     char *key;
@@ -115,7 +115,14 @@ typedef struct {
  *
  * @param outlen Available bytes in `out`, not including space for any terminating null.
  */
-typedef int (*tf_func_ptr_t)(ddb_tf_context_t *ctx, int argc, const uint16_t *arglens, const char *args, char *out, int outlen, int fail_on_undef);
+typedef int (*tf_func_ptr_t) (
+    ddb_tf_context_t *ctx,
+    int argc,
+    const uint16_t *arglens,
+    const char *args,
+    char *out,
+    int outlen,
+    int fail_on_undef);
 
 #define TF_MAX_FUNCS 0xff
 
@@ -124,42 +131,51 @@ typedef struct {
     tf_func_ptr_t func;
 } tf_func_def;
 
-
 /*
  * @param out output buffer to write to
  * @param outlen Available bytes in the buffer `out`, not including the terminating null byte.
  */
 static int
-tf_eval_int (ddb_tf_context_t *ctx, const char *code, int size, char *out, int outlen, int *bool_out, int fail_on_undef);
+tf_eval_int (
+    ddb_tf_context_t *ctx,
+    const char *code,
+    int size,
+    char *out,
+    int outlen,
+    int *bool_out,
+    int fail_on_undef);
 
 static const char *
 _tf_get_combined_value (playItem_t *it, const char *key, int *needs_free, int item_index);
 
 static void
-_tf_vars_free(ddb_tf_context_int_t *ctx);
+_tf_vars_free (ddb_tf_context_int_t *ctx);
 
-#define TF_EVAL_CHECK(res, ctx, arg, arg_len, out, outlen, fail_on_undef)\
-res = tf_eval_int (ctx, arg, arg_len, out, outlen, &bool_out, fail_on_undef);\
-if (res < 0) { *out = 0; return -1; }
+#define TF_EVAL_CHECK(res, ctx, arg, arg_len, out, outlen, fail_on_undef)         \
+    res = tf_eval_int (ctx, arg, arg_len, out, outlen, &bool_out, fail_on_undef); \
+    if (res < 0) {                                                                \
+        *out = 0;                                                                 \
+        return -1;                                                                \
+    }
 
 // empty track is used when ctx.it is null
 static playItem_t empty_track;
 // empty playlist is used when ctx.plt is null
 static playlist_t empty_playlist;
 // empty code is used when "code" argument is null
-static char empty_code[4] = {0};
+static char empty_code[4] = { 0 };
 
 static int
 snprintf_clip (char *buf, size_t len, const char *fmt, ...) {
     va_list ap;
-    va_start(ap, fmt);
-    int n = vsnprintf(buf, len, fmt, ap);
-    va_end(ap);
+    va_start (ap, fmt);
+    int n = vsnprintf (buf, len, fmt, ap);
+    va_end (ap);
     if (n < 0) {
         *buf = 0;
         return 0;
     }
-    return (int)min (n, len-1);
+    return (int)min (n, len - 1);
 }
 
 /*
@@ -174,7 +190,7 @@ tf_eval (ddb_tf_context_t *_ctx, const char *code, char *out, int outlen) {
     }
 
     // normalize the context
-    ddb_tf_context_int_t ctx = {0};
+    ddb_tf_context_int_t ctx = { 0 };
     ctx._ctx._size = sizeof (ddb_tf_context_t);
     ctx._ctx.flags = _ctx->flags;
     ctx._ctx.it = _ctx->it;
@@ -183,10 +199,9 @@ tf_eval (ddb_tf_context_t *_ctx, const char *code, char *out, int outlen) {
     ctx._ctx.id = _ctx->id;
     ctx._ctx.iter = _ctx->iter;
     ctx._ctx.update = _ctx->update;
-    if (_ctx->_size >= (char *)&_ctx->metadata_transformer - (char *)_ctx + sizeof(_ctx->metadata_transformer)) {
+    if (_ctx->_size >= (char *)&_ctx->metadata_transformer - (char *)_ctx + sizeof (_ctx->metadata_transformer)) {
         ctx._ctx.metadata_transformer = _ctx->metadata_transformer;
     }
-
 
     if (!code) {
         code = empty_code;
@@ -214,11 +229,11 @@ tf_eval (ddb_tf_context_t *_ctx, const char *code, char *out, int outlen) {
     switch (id) {
     case DB_COLUMN_FILENUMBER:
         if (ctx._ctx.flags & DDB_TF_CONTEXT_HAS_INDEX) {
-            l = snprintf_clip (out, outlen, "%d", ctx._ctx.idx+1);
+            l = snprintf_clip (out, outlen, "%d", ctx._ctx.idx + 1);
         }
         else if (ctx._ctx.plt) {
             int idx = plt_get_item_idx ((playlist_t *)ctx._ctx.plt, (playItem_t *)ctx._ctx.it, PL_MAIN);
-            l = snprintf_clip (out, outlen, "%d", idx+1);
+            l = snprintf_clip (out, outlen, "%d", idx + 1);
         }
         break;
     case DB_COLUMN_PLAYING:
@@ -226,7 +241,7 @@ tf_eval (ddb_tf_context_t *_ctx, const char *code, char *out, int outlen) {
         break;
     default:
         // tf_eval_int expects outlen to not include the terminating zero
-        TF_EVAL_CHECK(l, &ctx._ctx, code, codelen, out, outlen - 1, 0);
+        TF_EVAL_CHECK (l, &ctx._ctx, code, codelen, out, outlen - 1, 0);
         break;
     }
 
@@ -243,18 +258,25 @@ tf_eval (ddb_tf_context_t *_ctx, const char *code, char *out, int outlen) {
     }
 
     _ctx->update = ctx._ctx.update;
-    if (_ctx->_size >= (char *)&_ctx->dimmed - (char *)_ctx + sizeof(_ctx->dimmed)) {
+    if (_ctx->_size >= (char *)&_ctx->dimmed - (char *)_ctx + sizeof (_ctx->dimmed)) {
         _ctx->dimmed = ctx._ctx.dimmed;
     }
 
-    _tf_vars_free(&ctx);
+    _tf_vars_free (&ctx);
 
     return l;
 }
 
 // $greater(a,b) returns true if a is greater than b, otherwise false
 int
-tf_func_greater (ddb_tf_context_t *ctx, int argc, const uint16_t *arglens, const char *args, char *out, int outlen, int fail_on_undef) {
+tf_func_greater (
+    ddb_tf_context_t *ctx,
+    int argc,
+    const uint16_t *arglens,
+    const char *args,
+    char *out,
+    int outlen,
+    int fail_on_undef) {
     if (argc != 2) {
         return -1;
     }
@@ -264,13 +286,13 @@ tf_func_greater (ddb_tf_context_t *ctx, int argc, const uint16_t *arglens, const
 
     char a[TEMP_BUFFER_SIZE];
     int len;
-    TF_EVAL_CHECK(len, ctx, arg, arglens[0], a, sizeof (a) - 1, fail_on_undef);
+    TF_EVAL_CHECK (len, ctx, arg, arglens[0], a, sizeof (a) - 1, fail_on_undef);
 
     int aa = atoi (a);
 
     arg += arglens[0];
     char b[TEMP_BUFFER_SIZE];
-    TF_EVAL_CHECK(len, ctx, arg, arglens[1], b, sizeof (b) - 1, fail_on_undef);
+    TF_EVAL_CHECK (len, ctx, arg, arglens[1], b, sizeof (b) - 1, fail_on_undef);
     int bb = atoi (b);
 
     *out = 0;
@@ -279,7 +301,14 @@ tf_func_greater (ddb_tf_context_t *ctx, int argc, const uint16_t *arglens, const
 
 // $strcmp(s1,s2) compares s1 and s2, returns true if equal, otherwise false
 int
-tf_func_strcmp (ddb_tf_context_t *ctx, int argc, const uint16_t *arglens, const char *args, char *out, int outlen, int fail_on_undef) {
+tf_func_strcmp (
+    ddb_tf_context_t *ctx,
+    int argc,
+    const uint16_t *arglens,
+    const char *args,
+    char *out,
+    int outlen,
+    int fail_on_undef) {
     if (argc != 2) {
         return -1;
     }
@@ -289,11 +318,11 @@ tf_func_strcmp (ddb_tf_context_t *ctx, int argc, const uint16_t *arglens, const 
 
     char s1[TEMP_BUFFER_SIZE];
     int len;
-    TF_EVAL_CHECK(len, ctx, arg, arglens[0], s1, sizeof (s1) - 1, fail_on_undef);
+    TF_EVAL_CHECK (len, ctx, arg, arglens[0], s1, sizeof (s1) - 1, fail_on_undef);
 
     arg += arglens[0];
     char s2[TEMP_BUFFER_SIZE];
-    TF_EVAL_CHECK(len, ctx, arg, arglens[1], s2, sizeof (s2) - 1, fail_on_undef);
+    TF_EVAL_CHECK (len, ctx, arg, arglens[1], s2, sizeof (s2) - 1, fail_on_undef);
 
     int res = strcmp (s1, s2);
     *out = 0;
@@ -301,7 +330,14 @@ tf_func_strcmp (ddb_tf_context_t *ctx, int argc, const uint16_t *arglens, const 
 }
 
 int
-tf_func_stricmp (ddb_tf_context_t *ctx, int argc, const uint16_t *arglens, const char *args, char *out, int outlen, int fail_on_undef) {
+tf_func_stricmp (
+    ddb_tf_context_t *ctx,
+    int argc,
+    const uint16_t *arglens,
+    const char *args,
+    char *out,
+    int outlen,
+    int fail_on_undef) {
     if (argc != 2) {
         return -1;
     }
@@ -311,11 +347,11 @@ tf_func_stricmp (ddb_tf_context_t *ctx, int argc, const uint16_t *arglens, const
 
     char s1[TEMP_BUFFER_SIZE];
     int len;
-    TF_EVAL_CHECK(len, ctx, arg, arglens[0], s1, sizeof (s1) - 1, fail_on_undef);
+    TF_EVAL_CHECK (len, ctx, arg, arglens[0], s1, sizeof (s1) - 1, fail_on_undef);
 
     arg += arglens[0];
     char s2[TEMP_BUFFER_SIZE];
-    TF_EVAL_CHECK(len, ctx, arg, arglens[1], s2, sizeof (s2) - 1, fail_on_undef);
+    TF_EVAL_CHECK (len, ctx, arg, arglens[1], s2, sizeof (s2) - 1, fail_on_undef);
 
     int res = u8_strcasecmp (s1, s2);
     *out = 0;
@@ -323,7 +359,15 @@ tf_func_stricmp (ddb_tf_context_t *ctx, int argc, const uint16_t *arglens, const
 }
 
 static int
-tf_prefix_helper (ddb_tf_context_t *ctx, int argc, const uint16_t *arglens, const char *args, char *out, int outlen, int fail_on_undef, int swap) {
+tf_prefix_helper (
+    ddb_tf_context_t *ctx,
+    int argc,
+    const uint16_t *arglens,
+    const char *args,
+    char *out,
+    int outlen,
+    int fail_on_undef,
+    int swap) {
     if (argc == 0) {
         return -1;
     }
@@ -334,7 +378,7 @@ tf_prefix_helper (ddb_tf_context_t *ctx, int argc, const uint16_t *arglens, cons
 
     char str[TEMP_BUFFER_SIZE];
     int len;
-    TF_EVAL_CHECK(len, ctx, arg, arglens[0], str, sizeof (str) - 1, fail_on_undef);
+    TF_EVAL_CHECK (len, ctx, arg, arglens[0], str, sizeof (str) - 1, fail_on_undef);
     arg += arglens[0];
 
     int prefix_count;
@@ -348,7 +392,7 @@ tf_prefix_helper (ddb_tf_context_t *ctx, int argc, const uint16_t *arglens, cons
     else {
         prefix_count = argc - 1;
         buffer_size = 2000;
-        buf = alloca(buffer_size);
+        buf = alloca (buffer_size);
     }
 
     const char *prefixes[prefix_count];
@@ -364,9 +408,16 @@ tf_prefix_helper (ddb_tf_context_t *ctx, int argc, const uint16_t *arglens, cons
         char *ptr = buf;
         for (i = 0; i < prefix_count; ++i) {
             prefixes[i] = ptr;
-            TF_EVAL_CHECK (prefix_lengths[i], ctx, arg, arglens[i+1], ptr, (int)(buf+buffer_size-ptr-1), fail_on_undef);
-            ptr += prefix_lengths[i]+1;
-            arg += arglens[i+1];
+            TF_EVAL_CHECK (
+                prefix_lengths[i],
+                ctx,
+                arg,
+                arglens[i + 1],
+                ptr,
+                (int)(buf + buffer_size - ptr - 1),
+                fail_on_undef);
+            ptr += prefix_lengths[i] + 1;
+            arg += arglens[i + 1];
         }
     }
 
@@ -375,7 +426,7 @@ tf_prefix_helper (ddb_tf_context_t *ctx, int argc, const uint16_t *arglens, cons
             continue;
         }
 
-        if (!strncasecmp(str, prefixes[i], prefix_lengths[i]) && str[prefix_lengths[i]] == ' ') {
+        if (!strncasecmp (str, prefixes[i], prefix_lengths[i]) && str[prefix_lengths[i]] == ' ') {
             int stripped_length = len - prefix_lengths[i] - 1;
             int new_len;
             if (swap) {
@@ -389,12 +440,12 @@ tf_prefix_helper (ddb_tf_context_t *ctx, int argc, const uint16_t *arglens, cons
                 return -1;
             }
 
-            memcpy(out, str + prefix_lengths[i] + 1, stripped_length);
+            memcpy (out, str + prefix_lengths[i] + 1, stripped_length);
 
             if (swap) {
                 out[stripped_length] = ',';
-                out[stripped_length+1] = ' ';
-                memcpy(out+stripped_length+2, str, prefix_lengths[i]);
+                out[stripped_length + 1] = ' ';
+                memcpy (out + stripped_length + 2, str, prefix_lengths[i]);
             }
 
             return new_len;
@@ -405,26 +456,47 @@ tf_prefix_helper (ddb_tf_context_t *ctx, int argc, const uint16_t *arglens, cons
         return -1;
     }
 
-    memcpy(out, str, len);
+    memcpy (out, str, len);
 
     return len;
 }
 
 // $stripprefix(str,...) strips a list of prefixes from a string. If no prefixes are supplied, 'A' and 'The' are used.
 int
-tf_func_stripprefix (ddb_tf_context_t *ctx, int argc, const uint16_t *arglens, const char *args, char *out, int outlen, int fail_on_undef) {
+tf_func_stripprefix (
+    ddb_tf_context_t *ctx,
+    int argc,
+    const uint16_t *arglens,
+    const char *args,
+    char *out,
+    int outlen,
+    int fail_on_undef) {
     return tf_prefix_helper (ctx, argc, arglens, args, out, outlen, fail_on_undef, 0);
 }
 
 // $swapprefix(str,...) moves a list of prefixes to the end of a string. If no prefixes are supplied, 'A' and 'The' are used.
 int
-tf_func_swapprefix (ddb_tf_context_t *ctx, int argc, const uint16_t *arglens, const char *args, char *out, int outlen, int fail_on_undef) {
+tf_func_swapprefix (
+    ddb_tf_context_t *ctx,
+    int argc,
+    const uint16_t *arglens,
+    const char *args,
+    char *out,
+    int outlen,
+    int fail_on_undef) {
     return tf_prefix_helper (ctx, argc, arglens, args, out, outlen, fail_on_undef, 1);
 }
 
 // $upper(str) converts a string to uppercase
 int
-tf_func_upper (ddb_tf_context_t *ctx, int argc, const uint16_t *arglens, const char *args, char *out, int outlen, int fail_on_undef) {
+tf_func_upper (
+    ddb_tf_context_t *ctx,
+    int argc,
+    const uint16_t *arglens,
+    const char *args,
+    char *out,
+    int outlen,
+    int fail_on_undef) {
     if (argc != 1) {
         return -1;
     }
@@ -433,7 +505,7 @@ tf_func_upper (ddb_tf_context_t *ctx, int argc, const uint16_t *arglens, const c
 
     int len;
     char temp_str[TEMP_BUFFER_SIZE];
-    TF_EVAL_CHECK(len, ctx, args, arglens[0], temp_str, sizeof (temp_str) - 1, fail_on_undef);
+    TF_EVAL_CHECK (len, ctx, args, arglens[0], temp_str, sizeof (temp_str) - 1, fail_on_undef);
 
     char *pout = out;
     char *p = temp_str;
@@ -454,7 +526,14 @@ tf_func_upper (ddb_tf_context_t *ctx, int argc, const uint16_t *arglens, const c
 
 // $lower(str) converts a string to lowercase
 int
-tf_func_lower (ddb_tf_context_t *ctx, int argc, const uint16_t *arglens, const char *args, char *out, int outlen, int fail_on_undef) {
+tf_func_lower (
+    ddb_tf_context_t *ctx,
+    int argc,
+    const uint16_t *arglens,
+    const char *args,
+    char *out,
+    int outlen,
+    int fail_on_undef) {
     if (argc != 1) {
         return -1;
     }
@@ -463,7 +542,7 @@ tf_func_lower (ddb_tf_context_t *ctx, int argc, const uint16_t *arglens, const c
 
     int len;
     char temp_str[TEMP_BUFFER_SIZE];
-    TF_EVAL_CHECK(len, ctx, args, arglens[0], temp_str, sizeof (temp_str) - 1, fail_on_undef);
+    TF_EVAL_CHECK (len, ctx, args, arglens[0], temp_str, sizeof (temp_str) - 1, fail_on_undef);
 
     char *pout = out;
     char *p = temp_str;
@@ -485,7 +564,14 @@ tf_func_lower (ddb_tf_context_t *ctx, int argc, const uint16_t *arglens, const c
 // $num(n,len) Formats the integer number n in decimal notation with len characters. Pads with zeros
 // from the left if necessary. len includes the dash when the number is negative. If n is not numeric, it is treated as zero.
 int
-tf_func_num (ddb_tf_context_t *ctx, int argc, const uint16_t *arglens, const char *args, char *out, int outlen, int fail_on_undef) {
+tf_func_num (
+    ddb_tf_context_t *ctx,
+    int argc,
+    const uint16_t *arglens,
+    const char *args,
+    char *out,
+    int outlen,
+    int fail_on_undef) {
     const char *arg = args;
     int bool_out = 0;
     int len;
@@ -494,11 +580,11 @@ tf_func_num (ddb_tf_context_t *ctx, int argc, const uint16_t *arglens, const cha
         return -1;
     }
 
-    TF_EVAL_CHECK(len, ctx, arg, arglens[0], out, outlen, fail_on_undef);
+    TF_EVAL_CHECK (len, ctx, arg, arglens[0], out, outlen, fail_on_undef);
     arg += arglens[0];
     int n = atoi (out);
 
-    TF_EVAL_CHECK(len, ctx, arg, arglens[1], out, outlen, fail_on_undef);
+    TF_EVAL_CHECK (len, ctx, arg, arglens[1], out, outlen, fail_on_undef);
     int n_len = atoi (out);
 
     if (outlen < 1 || outlen < n_len) {
@@ -545,7 +631,14 @@ tf_func_num (ddb_tf_context_t *ctx, int argc, const uint16_t *arglens, const cha
 // substring in `subject` with `replace`. Accepts multiple search and replace
 // substrings
 int
-tf_func_replace (ddb_tf_context_t *ctx, int argc, const uint16_t *arglens, const char *args, char *out, int outlen, int fail_on_undef) {
+tf_func_replace (
+    ddb_tf_context_t *ctx,
+    int argc,
+    const uint16_t *arglens,
+    const char *args,
+    char *out,
+    int outlen,
+    int fail_on_undef) {
     if (argc < 3 || argc % 2 == 0) {
         return -1;
     }
@@ -561,8 +654,8 @@ tf_func_replace (ddb_tf_context_t *ctx, int argc, const uint16_t *arglens, const
 
     for (i = 0; i < argc; ++i) {
         lines[i] = ptr;
-        TF_EVAL_CHECK (lens[i], ctx, arg, arglens[i], ptr, (int)(buf+sizeof(buf)-ptr-1), fail_on_undef);
-        ptr += lens[i]+1;
+        TF_EVAL_CHECK (lens[i], ctx, arg, arglens[i], ptr, (int)(buf + sizeof (buf) - ptr - 1), fail_on_undef);
+        ptr += lens[i] + 1;
         arg += arglens[i];
     }
 
@@ -575,10 +668,10 @@ tf_func_replace (ddb_tf_context_t *ctx, int argc, const uint16_t *arglens, const
 
         for (i = 0; i < (argc - 1) / 2; ++i) {
             // Check for empty string -- can't replace it with anything
-            if (*lines[i*2+1] == 0) {
+            if (*lines[i * 2 + 1] == 0) {
                 break;
             }
-            char *found = strstr (iptr, lines[i*2+1]);
+            char *found = strstr (iptr, lines[i * 2 + 1]);
             if (found && found - iptr < chunklen) {
                 chunklen = (int)(found - iptr);
                 idx = i;
@@ -593,20 +686,27 @@ tf_func_replace (ddb_tf_context_t *ctx, int argc, const uint16_t *arglens, const
         if (idx == -1) //nothing found
             break;
 
-        if (lens[idx*2+2] > out + outlen - optr)
+        if (lens[idx * 2 + 2] > out + outlen - optr)
             return -1;
 
-        memcpy (optr, lines[idx*2+2], lens[idx*2+2]);
-        optr += lens[idx*2+2];
+        memcpy (optr, lines[idx * 2 + 2], lens[idx * 2 + 2]);
+        optr += lens[idx * 2 + 2];
 
-        iptr += chunklen + lens[idx*2+1];
+        iptr += chunklen + lens[idx * 2 + 1];
     }
     *optr = 0;
     return (int)(optr - out);
 }
 
 int
-tf_func_abbr (ddb_tf_context_t *ctx, int argc, const uint16_t *arglens, const char *args, char *out, int outlen, int fail_on_undef) {
+tf_func_abbr (
+    ddb_tf_context_t *ctx,
+    int argc,
+    const uint16_t *arglens,
+    const char *args,
+    char *out,
+    int outlen,
+    int fail_on_undef) {
     if (argc != 1 && argc != 2) {
         return -1;
     }
@@ -616,13 +716,13 @@ tf_func_abbr (ddb_tf_context_t *ctx, int argc, const uint16_t *arglens, const ch
     int bool_out = 0;
 
     int len;
-    TF_EVAL_CHECK(len, ctx, arg, arglens[0], out, outlen, fail_on_undef);
+    TF_EVAL_CHECK (len, ctx, arg, arglens[0], out, outlen, fail_on_undef);
 
     if (argc == 2) {
         char num_chars_str[TEMP_BUFFER_SIZE];
         arg += arglens[0];
         int l;
-        TF_EVAL_CHECK(l, ctx, arg, arglens[1], num_chars_str, sizeof (num_chars_str) - 1, fail_on_undef);
+        TF_EVAL_CHECK (l, ctx, arg, arglens[1], num_chars_str, sizeof (num_chars_str) - 1, fail_on_undef);
         int num_chars = atoi (num_chars_str);
         if (len <= num_chars) {
             return len;
@@ -644,7 +744,7 @@ tf_func_abbr (ddb_tf_context_t *ctx, int argc, const uint16_t *arglens, const ch
         // take the first letter for abbrev
         int is_bracket = *p == '[' || *p == ']';
         int32_t size = 0;
-        u8_nextchar(p, &size);
+        u8_nextchar (p, &size);
         memmove (pout, p, size);
         pout += size;
         p += size;
@@ -656,7 +756,7 @@ tf_func_abbr (ddb_tf_context_t *ctx, int argc, const uint16_t *arglens, const ch
             }
             else {
                 size = 0;
-                u8_nextchar(p, &size);
+                u8_nextchar (p, &size);
                 memmove (pout, p, size);
                 pout += size;
                 p += size;
@@ -669,7 +769,14 @@ tf_func_abbr (ddb_tf_context_t *ctx, int argc, const uint16_t *arglens, const ch
 }
 
 int
-tf_func_ansi (ddb_tf_context_t *ctx, int argc, const uint16_t *arglens, const char *args, char *out, int outlen, int fail_on_undef) {
+tf_func_ansi (
+    ddb_tf_context_t *ctx,
+    int argc,
+    const uint16_t *arglens,
+    const char *args,
+    char *out,
+    int outlen,
+    int fail_on_undef) {
     if (argc != 1) {
         return -1;
     }
@@ -677,12 +784,19 @@ tf_func_ansi (ddb_tf_context_t *ctx, int argc, const uint16_t *arglens, const ch
     int bool_out = 0;
 
     int len;
-    TF_EVAL_CHECK(len, ctx, args, arglens[0], out, outlen, fail_on_undef);
+    TF_EVAL_CHECK (len, ctx, args, arglens[0], out, outlen, fail_on_undef);
     return len;
 }
 
 int
-tf_func_ascii (ddb_tf_context_t *ctx, int argc, const uint16_t *arglens, const char *args, char *out, int outlen, int fail_on_undef) {
+tf_func_ascii (
+    ddb_tf_context_t *ctx,
+    int argc,
+    const uint16_t *arglens,
+    const char *args,
+    char *out,
+    int outlen,
+    int fail_on_undef) {
     if (argc != 1) {
         return -1;
     }
@@ -691,7 +805,7 @@ tf_func_ascii (ddb_tf_context_t *ctx, int argc, const uint16_t *arglens, const c
 
     int len;
     char temp_str[TEMP_BUFFER_SIZE];
-    TF_EVAL_CHECK(len, ctx, args, arglens[0], temp_str, sizeof (temp_str) - 1, fail_on_undef);
+    TF_EVAL_CHECK (len, ctx, args, arglens[0], temp_str, sizeof (temp_str) - 1, fail_on_undef);
 
     len = junk_iconv (temp_str, len, out, outlen, "utf-8", "ascii");
 
@@ -699,7 +813,15 @@ tf_func_ascii (ddb_tf_context_t *ctx, int argc, const uint16_t *arglens, const c
 }
 
 int
-tf_caps_impl (ddb_tf_context_t *ctx, int argc, const uint16_t *arglens, const char *args, char *out, int outlen, int fail_on_undef, int do_lowercasing) {
+tf_caps_impl (
+    ddb_tf_context_t *ctx,
+    int argc,
+    const uint16_t *arglens,
+    const char *args,
+    char *out,
+    int outlen,
+    int fail_on_undef,
+    int do_lowercasing) {
     if (argc != 1) {
         return -1;
     }
@@ -707,7 +829,7 @@ tf_caps_impl (ddb_tf_context_t *ctx, int argc, const uint16_t *arglens, const ch
     int bool_out = 0;
 
     int len;
-    TF_EVAL_CHECK(len, ctx, args, arglens[0], out, outlen, fail_on_undef);
+    TF_EVAL_CHECK (len, ctx, args, arglens[0], out, outlen, fail_on_undef);
 
     char *p = out;
     char *end = p + len;
@@ -730,7 +852,7 @@ tf_caps_impl (ddb_tf_context_t *ctx, int argc, const uint16_t *arglens, const ch
         u8_nextchar (p, &size);
         int32_t uppersize = u8_toupper ((const signed char *)p, size, temp);
         if (uppersize != size) {
-            memmove (p+uppersize, p+size, end-(p+size));
+            memmove (p + uppersize, p + size, end - (p + size));
             end += uppersize - size;
             *end = 0;
         }
@@ -749,7 +871,7 @@ tf_caps_impl (ddb_tf_context_t *ctx, int argc, const uint16_t *arglens, const ch
                 if (do_lowercasing) {
                     int32_t lowersize = u8_tolower ((const signed char *)p, size, temp);
                     if (lowersize != size) {
-                        memmove (p+lowersize, p+size, end-(p+size));
+                        memmove (p + lowersize, p + size, end - (p + size));
                         end += lowersize - size;
                         *end = 0;
                     }
@@ -767,17 +889,38 @@ tf_caps_impl (ddb_tf_context_t *ctx, int argc, const uint16_t *arglens, const ch
 }
 
 int
-tf_func_caps (ddb_tf_context_t *ctx, int argc, const uint16_t *arglens, const char *args, char *out, int outlen, int fail_on_undef) {
+tf_func_caps (
+    ddb_tf_context_t *ctx,
+    int argc,
+    const uint16_t *arglens,
+    const char *args,
+    char *out,
+    int outlen,
+    int fail_on_undef) {
     return tf_caps_impl (ctx, argc, arglens, args, out, outlen, fail_on_undef, 1);
 }
 
 int
-tf_func_caps2 (ddb_tf_context_t *ctx, int argc, const uint16_t *arglens, const char *args, char *out, int outlen, int fail_on_undef) {
+tf_func_caps2 (
+    ddb_tf_context_t *ctx,
+    int argc,
+    const uint16_t *arglens,
+    const char *args,
+    char *out,
+    int outlen,
+    int fail_on_undef) {
     return tf_caps_impl (ctx, argc, arglens, args, out, outlen, fail_on_undef, 0);
 }
 
 int
-tf_func_char (ddb_tf_context_t *ctx, int argc, const uint16_t *arglens, const char *args, char *out, int outlen, int fail_on_undef) {
+tf_func_char (
+    ddb_tf_context_t *ctx,
+    int argc,
+    const uint16_t *arglens,
+    const char *args,
+    char *out,
+    int outlen,
+    int fail_on_undef) {
     if (argc != 1) {
         return -1;
     }
@@ -785,7 +928,7 @@ tf_func_char (ddb_tf_context_t *ctx, int argc, const uint16_t *arglens, const ch
     int bool_out = 0;
 
     int len;
-    TF_EVAL_CHECK(len, ctx, args, arglens[0], out, outlen, fail_on_undef);
+    TF_EVAL_CHECK (len, ctx, args, arglens[0], out, outlen, fail_on_undef);
 
     int n = atoi (out);
     *out = 0;
@@ -798,61 +941,54 @@ tf_func_char (ddb_tf_context_t *ctx, int argc, const uint16_t *arglens, const ch
 }
 
 int
-tf_func_crc32 (ddb_tf_context_t *ctx, int argc, const uint16_t *arglens, const char *args, char *out, int outlen, int fail_on_undef) {
+tf_func_crc32 (
+    ddb_tf_context_t *ctx,
+    int argc,
+    const uint16_t *arglens,
+    const char *args,
+    char *out,
+    int outlen,
+    int fail_on_undef) {
     if (argc != 1) {
         return -1;
     }
 
     static const uint32_t tab[256] = {
-        0x00000000, 0x77073096, 0xee0e612c, 0x990951ba, 0x076dc419, 0x706af48f,
-        0xe963a535, 0x9e6495a3, 0x0edb8832, 0x79dcb8a4, 0xe0d5e91e, 0x97d2d988,
-        0x09b64c2b, 0x7eb17cbd, 0xe7b82d07, 0x90bf1d91, 0x1db71064, 0x6ab020f2,
-        0xf3b97148, 0x84be41de, 0x1adad47d, 0x6ddde4eb, 0xf4d4b551, 0x83d385c7,
-        0x136c9856, 0x646ba8c0, 0xfd62f97a, 0x8a65c9ec, 0x14015c4f, 0x63066cd9,
-        0xfa0f3d63, 0x8d080df5, 0x3b6e20c8, 0x4c69105e, 0xd56041e4, 0xa2677172,
-        0x3c03e4d1, 0x4b04d447, 0xd20d85fd, 0xa50ab56b, 0x35b5a8fa, 0x42b2986c,
-        0xdbbbc9d6, 0xacbcf940, 0x32d86ce3, 0x45df5c75, 0xdcd60dcf, 0xabd13d59,
-        0x26d930ac, 0x51de003a, 0xc8d75180, 0xbfd06116, 0x21b4f4b5, 0x56b3c423,
-        0xcfba9599, 0xb8bda50f, 0x2802b89e, 0x5f058808, 0xc60cd9b2, 0xb10be924,
-        0x2f6f7c87, 0x58684c11, 0xc1611dab, 0xb6662d3d, 0x76dc4190, 0x01db7106,
-        0x98d220bc, 0xefd5102a, 0x71b18589, 0x06b6b51f, 0x9fbfe4a5, 0xe8b8d433,
-        0x7807c9a2, 0x0f00f934, 0x9609a88e, 0xe10e9818, 0x7f6a0dbb, 0x086d3d2d,
-        0x91646c97, 0xe6635c01, 0x6b6b51f4, 0x1c6c6162, 0x856530d8, 0xf262004e,
-        0x6c0695ed, 0x1b01a57b, 0x8208f4c1, 0xf50fc457, 0x65b0d9c6, 0x12b7e950,
-        0x8bbeb8ea, 0xfcb9887c, 0x62dd1ddf, 0x15da2d49, 0x8cd37cf3, 0xfbd44c65,
-        0x4db26158, 0x3ab551ce, 0xa3bc0074, 0xd4bb30e2, 0x4adfa541, 0x3dd895d7,
-        0xa4d1c46d, 0xd3d6f4fb, 0x4369e96a, 0x346ed9fc, 0xad678846, 0xda60b8d0,
-        0x44042d73, 0x33031de5, 0xaa0a4c5f, 0xdd0d7cc9, 0x5005713c, 0x270241aa,
-        0xbe0b1010, 0xc90c2086, 0x5768b525, 0x206f85b3, 0xb966d409, 0xce61e49f,
-        0x5edef90e, 0x29d9c998, 0xb0d09822, 0xc7d7a8b4, 0x59b33d17, 0x2eb40d81,
-        0xb7bd5c3b, 0xc0ba6cad, 0xedb88320, 0x9abfb3b6, 0x03b6e20c, 0x74b1d29a,
-        0xead54739, 0x9dd277af, 0x04db2615, 0x73dc1683, 0xe3630b12, 0x94643b84,
-        0x0d6d6a3e, 0x7a6a5aa8, 0xe40ecf0b, 0x9309ff9d, 0x0a00ae27, 0x7d079eb1,
-        0xf00f9344, 0x8708a3d2, 0x1e01f268, 0x6906c2fe, 0xf762575d, 0x806567cb,
-        0x196c3671, 0x6e6b06e7, 0xfed41b76, 0x89d32be0, 0x10da7a5a, 0x67dd4acc,
-        0xf9b9df6f, 0x8ebeeff9, 0x17b7be43, 0x60b08ed5, 0xd6d6a3e8, 0xa1d1937e,
-        0x38d8c2c4, 0x4fdff252, 0xd1bb67f1, 0xa6bc5767, 0x3fb506dd, 0x48b2364b,
-        0xd80d2bda, 0xaf0a1b4c, 0x36034af6, 0x41047a60, 0xdf60efc3, 0xa867df55,
-        0x316e8eef, 0x4669be79, 0xcb61b38c, 0xbc66831a, 0x256fd2a0, 0x5268e236,
-        0xcc0c7795, 0xbb0b4703, 0x220216b9, 0x5505262f, 0xc5ba3bbe, 0xb2bd0b28,
-        0x2bb45a92, 0x5cb36a04, 0xc2d7ffa7, 0xb5d0cf31, 0x2cd99e8b, 0x5bdeae1d,
-        0x9b64c2b0, 0xec63f226, 0x756aa39c, 0x026d930a, 0x9c0906a9, 0xeb0e363f,
-        0x72076785, 0x05005713, 0x95bf4a82, 0xe2b87a14, 0x7bb12bae, 0x0cb61b38,
-        0x92d28e9b, 0xe5d5be0d, 0x7cdcefb7, 0x0bdbdf21, 0x86d3d2d4, 0xf1d4e242,
-        0x68ddb3f8, 0x1fda836e, 0x81be16cd, 0xf6b9265b, 0x6fb077e1, 0x18b74777,
-        0x88085ae6, 0xff0f6a70, 0x66063bca, 0x11010b5c, 0x8f659eff, 0xf862ae69,
-        0x616bffd3, 0x166ccf45, 0xa00ae278, 0xd70dd2ee, 0x4e048354, 0x3903b3c2,
-        0xa7672661, 0xd06016f7, 0x4969474d, 0x3e6e77db, 0xaed16a4a, 0xd9d65adc,
-        0x40df0b66, 0x37d83bf0, 0xa9bcae53, 0xdebb9ec5, 0x47b2cf7f, 0x30b5ffe9,
-        0xbdbdf21c, 0xcabac28a, 0x53b39330, 0x24b4a3a6, 0xbad03605, 0xcdd70693,
-        0x54de5729, 0x23d967bf, 0xb3667a2e, 0xc4614ab8, 0x5d681b02, 0x2a6f2b94,
+        0x00000000, 0x77073096, 0xee0e612c, 0x990951ba, 0x076dc419, 0x706af48f, 0xe963a535, 0x9e6495a3, 0x0edb8832,
+        0x79dcb8a4, 0xe0d5e91e, 0x97d2d988, 0x09b64c2b, 0x7eb17cbd, 0xe7b82d07, 0x90bf1d91, 0x1db71064, 0x6ab020f2,
+        0xf3b97148, 0x84be41de, 0x1adad47d, 0x6ddde4eb, 0xf4d4b551, 0x83d385c7, 0x136c9856, 0x646ba8c0, 0xfd62f97a,
+        0x8a65c9ec, 0x14015c4f, 0x63066cd9, 0xfa0f3d63, 0x8d080df5, 0x3b6e20c8, 0x4c69105e, 0xd56041e4, 0xa2677172,
+        0x3c03e4d1, 0x4b04d447, 0xd20d85fd, 0xa50ab56b, 0x35b5a8fa, 0x42b2986c, 0xdbbbc9d6, 0xacbcf940, 0x32d86ce3,
+        0x45df5c75, 0xdcd60dcf, 0xabd13d59, 0x26d930ac, 0x51de003a, 0xc8d75180, 0xbfd06116, 0x21b4f4b5, 0x56b3c423,
+        0xcfba9599, 0xb8bda50f, 0x2802b89e, 0x5f058808, 0xc60cd9b2, 0xb10be924, 0x2f6f7c87, 0x58684c11, 0xc1611dab,
+        0xb6662d3d, 0x76dc4190, 0x01db7106, 0x98d220bc, 0xefd5102a, 0x71b18589, 0x06b6b51f, 0x9fbfe4a5, 0xe8b8d433,
+        0x7807c9a2, 0x0f00f934, 0x9609a88e, 0xe10e9818, 0x7f6a0dbb, 0x086d3d2d, 0x91646c97, 0xe6635c01, 0x6b6b51f4,
+        0x1c6c6162, 0x856530d8, 0xf262004e, 0x6c0695ed, 0x1b01a57b, 0x8208f4c1, 0xf50fc457, 0x65b0d9c6, 0x12b7e950,
+        0x8bbeb8ea, 0xfcb9887c, 0x62dd1ddf, 0x15da2d49, 0x8cd37cf3, 0xfbd44c65, 0x4db26158, 0x3ab551ce, 0xa3bc0074,
+        0xd4bb30e2, 0x4adfa541, 0x3dd895d7, 0xa4d1c46d, 0xd3d6f4fb, 0x4369e96a, 0x346ed9fc, 0xad678846, 0xda60b8d0,
+        0x44042d73, 0x33031de5, 0xaa0a4c5f, 0xdd0d7cc9, 0x5005713c, 0x270241aa, 0xbe0b1010, 0xc90c2086, 0x5768b525,
+        0x206f85b3, 0xb966d409, 0xce61e49f, 0x5edef90e, 0x29d9c998, 0xb0d09822, 0xc7d7a8b4, 0x59b33d17, 0x2eb40d81,
+        0xb7bd5c3b, 0xc0ba6cad, 0xedb88320, 0x9abfb3b6, 0x03b6e20c, 0x74b1d29a, 0xead54739, 0x9dd277af, 0x04db2615,
+        0x73dc1683, 0xe3630b12, 0x94643b84, 0x0d6d6a3e, 0x7a6a5aa8, 0xe40ecf0b, 0x9309ff9d, 0x0a00ae27, 0x7d079eb1,
+        0xf00f9344, 0x8708a3d2, 0x1e01f268, 0x6906c2fe, 0xf762575d, 0x806567cb, 0x196c3671, 0x6e6b06e7, 0xfed41b76,
+        0x89d32be0, 0x10da7a5a, 0x67dd4acc, 0xf9b9df6f, 0x8ebeeff9, 0x17b7be43, 0x60b08ed5, 0xd6d6a3e8, 0xa1d1937e,
+        0x38d8c2c4, 0x4fdff252, 0xd1bb67f1, 0xa6bc5767, 0x3fb506dd, 0x48b2364b, 0xd80d2bda, 0xaf0a1b4c, 0x36034af6,
+        0x41047a60, 0xdf60efc3, 0xa867df55, 0x316e8eef, 0x4669be79, 0xcb61b38c, 0xbc66831a, 0x256fd2a0, 0x5268e236,
+        0xcc0c7795, 0xbb0b4703, 0x220216b9, 0x5505262f, 0xc5ba3bbe, 0xb2bd0b28, 0x2bb45a92, 0x5cb36a04, 0xc2d7ffa7,
+        0xb5d0cf31, 0x2cd99e8b, 0x5bdeae1d, 0x9b64c2b0, 0xec63f226, 0x756aa39c, 0x026d930a, 0x9c0906a9, 0xeb0e363f,
+        0x72076785, 0x05005713, 0x95bf4a82, 0xe2b87a14, 0x7bb12bae, 0x0cb61b38, 0x92d28e9b, 0xe5d5be0d, 0x7cdcefb7,
+        0x0bdbdf21, 0x86d3d2d4, 0xf1d4e242, 0x68ddb3f8, 0x1fda836e, 0x81be16cd, 0xf6b9265b, 0x6fb077e1, 0x18b74777,
+        0x88085ae6, 0xff0f6a70, 0x66063bca, 0x11010b5c, 0x8f659eff, 0xf862ae69, 0x616bffd3, 0x166ccf45, 0xa00ae278,
+        0xd70dd2ee, 0x4e048354, 0x3903b3c2, 0xa7672661, 0xd06016f7, 0x4969474d, 0x3e6e77db, 0xaed16a4a, 0xd9d65adc,
+        0x40df0b66, 0x37d83bf0, 0xa9bcae53, 0xdebb9ec5, 0x47b2cf7f, 0x30b5ffe9, 0xbdbdf21c, 0xcabac28a, 0x53b39330,
+        0x24b4a3a6, 0xbad03605, 0xcdd70693, 0x54de5729, 0x23d967bf, 0xb3667a2e, 0xc4614ab8, 0x5d681b02, 0x2a6f2b94,
         0xb40bbe37, 0xc30c8ea1, 0x5a05df1b, 0x2d02ef8d
     };
 
     int bool_out = 0;
 
     int len;
-    TF_EVAL_CHECK(len, ctx, args, arglens[0], out, outlen, fail_on_undef);
+    TF_EVAL_CHECK (len, ctx, args, arglens[0], out, outlen, fail_on_undef);
 
     uint32_t crc = 0xffffffff;
 
@@ -866,7 +1002,14 @@ tf_func_crc32 (ddb_tf_context_t *ctx, int argc, const uint16_t *arglens, const c
 }
 
 int
-tf_func_crlf (ddb_tf_context_t *ctx, int argc, const uint16_t *arglens, const char *args, char *out, int outlen, int fail_on_undef) {
+tf_func_crlf (
+    ddb_tf_context_t *ctx,
+    int argc,
+    const uint16_t *arglens,
+    const char *args,
+    char *out,
+    int outlen,
+    int fail_on_undef) {
     if (argc != 0 || outlen < 2) {
         return -1;
     }
@@ -876,7 +1019,7 @@ tf_func_crlf (ddb_tf_context_t *ctx, int argc, const uint16_t *arglens, const ch
 }
 
 static int
-_escape_size(const char *str) {
+_escape_size (const char *str) {
     int bytes = 1;
     while (*str != 0 && *str != 'm') {
         str++;
@@ -886,12 +1029,12 @@ _escape_size(const char *str) {
 }
 
 static int
-_u8_escaped_offset(const char *str, int32_t charnum) {
+_u8_escaped_offset (const char *str, int32_t charnum) {
     int size = 0;
     int32_t bytes = 0;
     // skip leading sequences
     while (*str != 0 && *str == '\033') {
-        size = _escape_size(str);
+        size = _escape_size (str);
         str += size;
         bytes += size;
     }
@@ -900,13 +1043,13 @@ _u8_escaped_offset(const char *str, int32_t charnum) {
         return bytes;
     }
 
-    size = u8_offset(str, charnum);
+    size = u8_offset (str, charnum);
     bytes += size;
     str += size;
 
     // skip trailing sequences
     while (*str != 0 && *str == '\033') {
-        size = _escape_size(str);
+        size = _escape_size (str);
         str += size;
         bytes += size;
     }
@@ -916,7 +1059,14 @@ _u8_escaped_offset(const char *str, int32_t charnum) {
 
 // $left(text,n) returns the first n characters of text
 int
-tf_func_left (ddb_tf_context_t *ctx, int argc, const uint16_t *arglens, const char *args, char *out, int outlen, int fail_on_undef) {
+tf_func_left (
+    ddb_tf_context_t *ctx,
+    int argc,
+    const uint16_t *arglens,
+    const char *args,
+    char *out,
+    int outlen,
+    int fail_on_undef) {
     if (argc != 2) {
         return -1;
     }
@@ -928,7 +1078,7 @@ tf_func_left (ddb_tf_context_t *ctx, int argc, const uint16_t *arglens, const ch
     char num_chars_str[TEMP_BUFFER_SIZE];
     arg += arglens[0];
     int len;
-    TF_EVAL_CHECK(len, ctx, arg, arglens[1], num_chars_str, sizeof (num_chars_str) - 1, fail_on_undef);
+    TF_EVAL_CHECK (len, ctx, arg, arglens[1], num_chars_str, sizeof (num_chars_str) - 1, fail_on_undef);
     int num_chars = atoi (num_chars_str);
     if (num_chars <= 0 || num_chars > outlen) {
         *out = 0;
@@ -938,19 +1088,26 @@ tf_func_left (ddb_tf_context_t *ctx, int argc, const uint16_t *arglens, const ch
     // get text
     char text[TEMP_BUFFER_SIZE];
     arg = args;
-    TF_EVAL_CHECK(len, ctx, arg, arglens[0], text, sizeof (text) - 1, fail_on_undef);
+    TF_EVAL_CHECK (len, ctx, arg, arglens[0], text, sizeof (text) - 1, fail_on_undef);
 
     // convert num_chars to num_bytes
     // count characters
-    int num_bytes = _u8_escaped_offset(text, num_chars);
+    int num_bytes = _u8_escaped_offset (text, num_chars);
 
-    int res = u8_strnbcpy (out, text, min(num_bytes, outlen));
+    int res = u8_strnbcpy (out, text, min (num_bytes, outlen));
     return res;
 }
 
 // $repeat(expr,count): repeat `count` copies of `expr`
 int
-tf_func_repeat (ddb_tf_context_t *ctx, int argc, const uint16_t *arglens, const char *args, char *out, int outlen, int fail_on_undef) {
+tf_func_repeat (
+    ddb_tf_context_t *ctx,
+    int argc,
+    const uint16_t *arglens,
+    const char *args,
+    char *out,
+    int outlen,
+    int fail_on_undef) {
     if (argc != 2) {
         return -1;
     }
@@ -962,7 +1119,7 @@ tf_func_repeat (ddb_tf_context_t *ctx, int argc, const uint16_t *arglens, const 
     char num_chars_str[TEMP_BUFFER_SIZE];
     arg += arglens[0];
     int len;
-    TF_EVAL_CHECK(len, ctx, arg, arglens[1], num_chars_str, sizeof (num_chars_str) - 1, fail_on_undef);
+    TF_EVAL_CHECK (len, ctx, arg, arglens[1], num_chars_str, sizeof (num_chars_str) - 1, fail_on_undef);
     int repeat_count = atoi (num_chars_str);
     if (repeat_count < 0) {
         *out = 0;
@@ -977,9 +1134,9 @@ tf_func_repeat (ddb_tf_context_t *ctx, int argc, const uint16_t *arglens, const 
     // get expr
     char text[TEMP_BUFFER_SIZE];
     arg = args;
-    TF_EVAL_CHECK(len, ctx, arg, arglens[0], text, sizeof (text) - 1, fail_on_undef);
+    TF_EVAL_CHECK (len, ctx, arg, arglens[0], text, sizeof (text) - 1, fail_on_undef);
 
-    int res=0;
+    int res = 0;
     for (int i = 0; i < repeat_count; i++) {
         if (res + len > outlen) {
             break;
@@ -992,7 +1149,14 @@ tf_func_repeat (ddb_tf_context_t *ctx, int argc, const uint16_t *arglens, const 
 
 // $insert(str,insert,n): Inserts `insert` into `str` after `n` characters.
 int
-tf_func_insert (ddb_tf_context_t *ctx, int argc, const uint16_t *arglens, const char *args, char *out, int outlen, int fail_on_undef) {
+tf_func_insert (
+    ddb_tf_context_t *ctx,
+    int argc,
+    const uint16_t *arglens,
+    const char *args,
+    char *out,
+    int outlen,
+    int fail_on_undef) {
     if (argc != 3) {
         return -1;
     }
@@ -1005,18 +1169,18 @@ tf_func_insert (ddb_tf_context_t *ctx, int argc, const uint16_t *arglens, const 
     // get str
     char str[TEMP_BUFFER_SIZE];
     arg = args;
-    TF_EVAL_CHECK(str_len, ctx, arg, arglens[0], str, sizeof (str) - 1, fail_on_undef);
-    int str_chars = u8_strlen(str);
+    TF_EVAL_CHECK (str_len, ctx, arg, arglens[0], str, sizeof (str) - 1, fail_on_undef);
+    int str_chars = u8_strlen (str);
 
     // get insert
     char insert[TEMP_BUFFER_SIZE];
     arg += arglens[0];
-    TF_EVAL_CHECK(insert_len, ctx, arg, arglens[1], insert, sizeof (insert) - 1, fail_on_undef);
+    TF_EVAL_CHECK (insert_len, ctx, arg, arglens[1], insert, sizeof (insert) - 1, fail_on_undef);
 
     // get insertion point
     char num_chars_str[TEMP_BUFFER_SIZE];
     arg += arglens[1];
-    TF_EVAL_CHECK(len, ctx, arg, arglens[2], num_chars_str, sizeof (num_chars_str) - 1, fail_on_undef);
+    TF_EVAL_CHECK (len, ctx, arg, arglens[2], num_chars_str, sizeof (num_chars_str) - 1, fail_on_undef);
     int insertion_point = atoi (num_chars_str);
     if (insertion_point < 0) {
         *out = 0;
@@ -1033,17 +1197,17 @@ tf_func_insert (ddb_tf_context_t *ctx, int argc, const uint16_t *arglens, const 
     int l;
     int res = 0;
 
-    l = u8_strnbcpy(out, str, min (nb_before, outlen));
+    l = u8_strnbcpy (out, str, min (nb_before, outlen));
     outlen -= l;
     out += l;
     res += l;
 
-    l = u8_strnbcpy(out, insert, min (insert_len, outlen));
+    l = u8_strnbcpy (out, insert, min (insert_len, outlen));
     outlen -= l;
     out += l;
     res += l;
 
-    l = u8_strnbcpy(out, str + nb_before, min (nb_after, outlen));
+    l = u8_strnbcpy (out, str + nb_before, min (nb_after, outlen));
     outlen -= l;
     out += l;
     res += l;
@@ -1053,7 +1217,14 @@ tf_func_insert (ddb_tf_context_t *ctx, int argc, const uint16_t *arglens, const 
 
 // $len(expr): returns length of `expr`
 int
-tf_func_len (ddb_tf_context_t *ctx, int argc, const uint16_t *arglens, const char *args, char *out, int outlen, int fail_on_undef) {
+tf_func_len (
+    ddb_tf_context_t *ctx,
+    int argc,
+    const uint16_t *arglens,
+    const char *args,
+    char *out,
+    int outlen,
+    int fail_on_undef) {
     if (argc != 1) {
         return -1;
     }
@@ -1061,13 +1232,20 @@ tf_func_len (ddb_tf_context_t *ctx, int argc, const uint16_t *arglens, const cha
     int bool_out = 0;
     int len;
 
-    TF_EVAL_CHECK(len, ctx, args, arglens[0], out, outlen, fail_on_undef);
+    TF_EVAL_CHECK (len, ctx, args, arglens[0], out, outlen, fail_on_undef);
 
-    return snprintf_clip(out, outlen, "%d", u8_strlen(out));
+    return snprintf_clip (out, outlen, "%d", u8_strlen (out));
 }
 
 int
-tf_func_len2 (ddb_tf_context_t *ctx, int argc, const uint16_t *arglens, const char *args, char *out, int outlen, int fail_on_undef) {
+tf_func_len2 (
+    ddb_tf_context_t *ctx,
+    int argc,
+    const uint16_t *arglens,
+    const char *args,
+    char *out,
+    int outlen,
+    int fail_on_undef) {
     if (argc != 1) {
         return -1;
     }
@@ -1075,20 +1253,28 @@ tf_func_len2 (ddb_tf_context_t *ctx, int argc, const uint16_t *arglens, const ch
     int bool_out = 0;
     int len;
 
-    TF_EVAL_CHECK(len, ctx, args, arglens[0], out, outlen, fail_on_undef);
+    TF_EVAL_CHECK (len, ctx, args, arglens[0], out, outlen, fail_on_undef);
 
     int wcsz = 0;
     int32_t i = 0;
     uint32_t c;
-    while (out[i] && (c = u8_nextchar(out, &i)) != 0) {
-        wcsz += mk_wcwidth(c);
+    while (out[i] && (c = u8_nextchar (out, &i)) != 0) {
+        wcsz += mk_wcwidth (c);
     }
 
-    return snprintf_clip(out, outlen, "%d", wcsz);
+    return snprintf_clip (out, outlen, "%d", wcsz);
 }
 
 int
-tf_func_extremest_impl(ddb_tf_context_t *ctx, int argc, const uint16_t *arglens, const char *args, char *out, int outlen, int fail_on_undef, int shortest) {
+tf_func_extremest_impl (
+    ddb_tf_context_t *ctx,
+    int argc,
+    const uint16_t *arglens,
+    const char *args,
+    char *out,
+    int outlen,
+    int fail_on_undef,
+    int shortest) {
     if (argc < 1) {
         return -1;
     }
@@ -1099,35 +1285,56 @@ tf_func_extremest_impl(ddb_tf_context_t *ctx, int argc, const uint16_t *arglens,
 
     char tmp[outlen + 1];
 
-    TF_EVAL_CHECK(best_blen, ctx, pos, arglens[0], out, outlen, fail_on_undef);
-    int best_clen = u8_strlen(out);
+    TF_EVAL_CHECK (best_blen, ctx, pos, arglens[0], out, outlen, fail_on_undef);
+    int best_clen = u8_strlen (out);
 
     for (int i = 1; i != argc; ++i) {
         pos += arglens[i - 1];
-        TF_EVAL_CHECK(this_blen, ctx, pos, arglens[i], tmp, outlen, fail_on_undef);
-        this_clen = u8_strlen(tmp);
+        TF_EVAL_CHECK (this_blen, ctx, pos, arglens[i], tmp, outlen, fail_on_undef);
+        this_clen = u8_strlen (tmp);
         if (shortest ? this_clen < best_clen : this_clen > best_clen) {
             best_clen = this_clen;
             best_blen = this_blen;
-            u8_strnbcpy(out, tmp, min(best_blen, outlen));
-       }
+            u8_strnbcpy (out, tmp, min (best_blen, outlen));
+        }
     }
 
     return best_blen;
 }
 
 int
-tf_func_shortest(ddb_tf_context_t *ctx, int argc, const uint16_t *arglens, const char *args, char *out, int outlen, int fail_on_undef) {
-    return tf_func_extremest_impl(ctx, argc, arglens, args, out, outlen, fail_on_undef, 1);
+tf_func_shortest (
+    ddb_tf_context_t *ctx,
+    int argc,
+    const uint16_t *arglens,
+    const char *args,
+    char *out,
+    int outlen,
+    int fail_on_undef) {
+    return tf_func_extremest_impl (ctx, argc, arglens, args, out, outlen, fail_on_undef, 1);
 }
 
 int
-tf_func_longest(ddb_tf_context_t *ctx, int argc, const uint16_t *arglens, const char *args, char *out, int outlen, int fail_on_undef) {
-    return tf_func_extremest_impl(ctx, argc, arglens, args, out, outlen, fail_on_undef, 0);
+tf_func_longest (
+    ddb_tf_context_t *ctx,
+    int argc,
+    const uint16_t *arglens,
+    const char *args,
+    char *out,
+    int outlen,
+    int fail_on_undef) {
+    return tf_func_extremest_impl (ctx, argc, arglens, args, out, outlen, fail_on_undef, 0);
 }
 
 int
-tf_func_longer(ddb_tf_context_t *ctx, int argc, const uint16_t *arglens, const char *args, char *out, int outlen, int fail_on_undef) {
+tf_func_longer (
+    ddb_tf_context_t *ctx,
+    int argc,
+    const uint16_t *arglens,
+    const char *args,
+    char *out,
+    int outlen,
+    int fail_on_undef) {
     if (argc != 2) {
         return -1;
     }
@@ -1136,11 +1343,11 @@ tf_func_longer(ddb_tf_context_t *ctx, int argc, const uint16_t *arglens, const c
 
     const char *arg = args;
     int len;
-    TF_EVAL_CHECK(len, ctx, arg, arglens[0], out, outlen, fail_on_undef);
+    TF_EVAL_CHECK (len, ctx, arg, arglens[0], out, outlen, fail_on_undef);
     size_t l1 = u8_strlen (out);
 
     arg += arglens[0];
-    TF_EVAL_CHECK(len, ctx, arg, arglens[1], out, outlen, fail_on_undef);
+    TF_EVAL_CHECK (len, ctx, arg, arglens[1], out, outlen, fail_on_undef);
     size_t l2 = u8_strlen (out);
 
     return l1 > l2;
@@ -1149,7 +1356,16 @@ tf_func_longer(ddb_tf_context_t *ctx, int argc, const uint16_t *arglens, const c
 // $pad(expr,len[, char]): If `expr` is shorter than len characters, the function adds `char` characters (if present otherwise
 // spaces) to the right of `expr` to make the result `len` characters long. Otherwise the function returns str unchanged.
 int
-tf_func_pad_impl (ddb_tf_context_t *ctx, int argc, const uint16_t *arglens, const char *args, char *out, int outlen, int fail_on_undef, int right, int cut) {
+tf_func_pad_impl (
+    ddb_tf_context_t *ctx,
+    int argc,
+    const uint16_t *arglens,
+    const char *args,
+    char *out,
+    int outlen,
+    int fail_on_undef,
+    int right,
+    int cut) {
     if (argc < 1 || argc > 3) {
         return -1;
     }
@@ -1158,16 +1374,16 @@ tf_func_pad_impl (ddb_tf_context_t *ctx, int argc, const uint16_t *arglens, cons
     int len, str_len;
     const char *arg = args;
     char pad_char_str[TEMP_BUFFER_SIZE] = " ";
-    int nb_pad_char=1;
+    int nb_pad_char = 1;
 
     // get expr
     char str[outlen];
-    TF_EVAL_CHECK(str_len, ctx, args, arglens[0], str, outlen, fail_on_undef);
+    TF_EVAL_CHECK (str_len, ctx, args, arglens[0], str, outlen, fail_on_undef);
 
     // get len
     char num_chars_str[TEMP_BUFFER_SIZE];
     arg += arglens[0];
-    TF_EVAL_CHECK(len, ctx, arg, arglens[1], num_chars_str, sizeof (num_chars_str) - 1, fail_on_undef);
+    TF_EVAL_CHECK (len, ctx, arg, arglens[1], num_chars_str, sizeof (num_chars_str) - 1, fail_on_undef);
     int padlen_chars = atoi (num_chars_str);
     if (padlen_chars < 0) {
         *out = 0;
@@ -1176,28 +1392,27 @@ tf_func_pad_impl (ddb_tf_context_t *ctx, int argc, const uint16_t *arglens, cons
     // get char
     if (argc == 3) {
         arg += arglens[1];
-        TF_EVAL_CHECK(len, ctx, arg, arglens[2], pad_char_str, sizeof (pad_char_str) - 1, fail_on_undef);
+        TF_EVAL_CHECK (len, ctx, arg, arglens[2], pad_char_str, sizeof (pad_char_str) - 1, fail_on_undef);
         // only accept first character
-        nb_pad_char = u8_offset(pad_char_str, 1);
+        nb_pad_char = u8_offset (pad_char_str, 1);
         pad_char_str[nb_pad_char] = 0;
     }
 
-    int str_chars = u8_strlen(str);
+    int str_chars = u8_strlen (str);
 
     if (str_chars >= padlen_chars) {
         if (str_chars > padlen_chars && cut) {
             // u8_strncpy has no limiter in byte units available. We rely on str being of size outlen above for safety
-            return u8_strncpy(out, str, padlen_chars);
+            return u8_strncpy (out, str, padlen_chars);
         }
-        return u8_strnbcpy(out, str, min (str_len, outlen));
+        return u8_strnbcpy (out, str, min (str_len, outlen));
     }
 
-    int res=0,l;
-    int repeat_count = padlen_chars-str_chars;
-
+    int res = 0, l;
+    int repeat_count = padlen_chars - str_chars;
 
     if (!right) {
-        l = u8_strnbcpy(out, str, min (str_len, outlen));
+        l = u8_strnbcpy (out, str, min (str_len, outlen));
         outlen -= l;
         out += l;
         res += l;
@@ -1211,7 +1426,7 @@ tf_func_pad_impl (ddb_tf_context_t *ctx, int argc, const uint16_t *arglens, cons
     }
 
     if (right) {
-        l = u8_strnbcpy(out, str, min (str_len, outlen));
+        l = u8_strnbcpy (out, str, min (str_len, outlen));
         outlen -= l;
         out += l;
         res += l;
@@ -1221,29 +1436,65 @@ tf_func_pad_impl (ddb_tf_context_t *ctx, int argc, const uint16_t *arglens, cons
 }
 
 int
-tf_func_pad (ddb_tf_context_t *ctx, int argc, const uint16_t *arglens, const char *args, char *out, int outlen, int fail_on_undef) {
+tf_func_pad (
+    ddb_tf_context_t *ctx,
+    int argc,
+    const uint16_t *arglens,
+    const char *args,
+    char *out,
+    int outlen,
+    int fail_on_undef) {
     return tf_func_pad_impl (ctx, argc, arglens, args, out, outlen, fail_on_undef, 0, 0);
 }
 
 // $pad_right(expr,len[,char]): same as $pad but right aligns string
 int
-tf_func_pad_right (ddb_tf_context_t *ctx, int argc, const uint16_t *arglens, const char *args, char *out, int outlen, int fail_on_undef) {
+tf_func_pad_right (
+    ddb_tf_context_t *ctx,
+    int argc,
+    const uint16_t *arglens,
+    const char *args,
+    char *out,
+    int outlen,
+    int fail_on_undef) {
     return tf_func_pad_impl (ctx, argc, arglens, args, out, outlen, fail_on_undef, 1, 0);
 }
 
 // _cut variants: same as above, but truncates string if too long
 int
-tf_func_padcut (ddb_tf_context_t *ctx, int argc, const uint16_t *arglens, const char *args, char *out, int outlen, int fail_on_undef) {
+tf_func_padcut (
+    ddb_tf_context_t *ctx,
+    int argc,
+    const uint16_t *arglens,
+    const char *args,
+    char *out,
+    int outlen,
+    int fail_on_undef) {
     return tf_func_pad_impl (ctx, argc, arglens, args, out, outlen, fail_on_undef, 0, 1);
 }
 
 int
-tf_func_padcut_right (ddb_tf_context_t *ctx, int argc, const uint16_t *arglens, const char *args, char *out, int outlen, int fail_on_undef) {
+tf_func_padcut_right (
+    ddb_tf_context_t *ctx,
+    int argc,
+    const uint16_t *arglens,
+    const char *args,
+    char *out,
+    int outlen,
+    int fail_on_undef) {
     return tf_func_pad_impl (ctx, argc, arglens, args, out, outlen, fail_on_undef, 1, 1);
 }
 
 int
-tf_func_progress_impl(ddb_tf_context_t *ctx, int argc, const uint16_t *arglens, const char *args, char *out, int outlen, int fail_on_undef, int alt) {
+tf_func_progress_impl (
+    ddb_tf_context_t *ctx,
+    int argc,
+    const uint16_t *arglens,
+    const char *args,
+    char *out,
+    int outlen,
+    int fail_on_undef,
+    int alt) {
     if (argc != 5) {
         return -1;
     }
@@ -1258,15 +1509,15 @@ tf_func_progress_impl(ddb_tf_context_t *ctx, int argc, const uint16_t *arglens, 
 
     const char *argpos = args;
 
-    TF_EVAL_CHECK(len, ctx, argpos, arglens[0], out, outlen - 1, fail_on_undef);
-    progress = atoi(out);
+    TF_EVAL_CHECK (len, ctx, argpos, arglens[0], out, outlen - 1, fail_on_undef);
+    progress = atoi (out);
     if (progress < 0) {
         return -1;
     }
     argpos += arglens[0];
 
-    TF_EVAL_CHECK(len, ctx, argpos, arglens[1], out, outlen - 1, fail_on_undef);
-    range = atoi(out);
+    TF_EVAL_CHECK (len, ctx, argpos, arglens[1], out, outlen - 1, fail_on_undef);
+    range = atoi (out);
     if (range < 0) {
         return -1;
     }
@@ -1275,14 +1526,14 @@ tf_func_progress_impl(ddb_tf_context_t *ctx, int argc, const uint16_t *arglens, 
     }
     argpos += arglens[1];
 
-    TF_EVAL_CHECK(len, ctx, argpos, arglens[2], out, outlen - 1, fail_on_undef);
-    barsize = atoi(out);
+    TF_EVAL_CHECK (len, ctx, argpos, arglens[2], out, outlen - 1, fail_on_undef);
+    barsize = atoi (out);
     if (range < 0) {
         return -1;
     }
     argpos += arglens[2];
 
-    TF_EVAL_CHECK(len, ctx, argpos, arglens[3], out, outlen - 1, fail_on_undef);
+    TF_EVAL_CHECK (len, ctx, argpos, arglens[3], out, outlen - 1, fail_on_undef);
     notch = strdup (out);
     argpos += arglens[3];
 
@@ -1317,10 +1568,11 @@ tf_func_progress_impl(ddb_tf_context_t *ctx, int argc, const uint16_t *arglens, 
         char *p = NULL;
         if (alt ? i < replaced : i == replaced) {
             p = notch;
-        } else {
+        }
+        else {
             p = bar;
         }
-        size_t l = min(strlen (p), remaining);
+        size_t l = min (strlen (p), remaining);
         l = u8_strncpy (cur, p, (int)l);
         cur += l;
         remaining -= l;
@@ -1333,17 +1585,38 @@ tf_func_progress_impl(ddb_tf_context_t *ctx, int argc, const uint16_t *arglens, 
 }
 
 int
-tf_func_progress (ddb_tf_context_t *ctx, int argc, const uint16_t *arglens, const char *args, char *out, int outlen, int fail_on_undef) {
+tf_func_progress (
+    ddb_tf_context_t *ctx,
+    int argc,
+    const uint16_t *arglens,
+    const char *args,
+    char *out,
+    int outlen,
+    int fail_on_undef) {
     return tf_func_progress_impl (ctx, argc, arglens, args, out, outlen, fail_on_undef, 0);
 }
 
 int
-tf_func_progress2 (ddb_tf_context_t *ctx, int argc, const uint16_t *arglens, const char *args, char *out, int outlen, int fail_on_undef) {
+tf_func_progress2 (
+    ddb_tf_context_t *ctx,
+    int argc,
+    const uint16_t *arglens,
+    const char *args,
+    char *out,
+    int outlen,
+    int fail_on_undef) {
     return tf_func_progress_impl (ctx, argc, arglens, args, out, outlen, fail_on_undef, 1);
 }
 
 int
-tf_func_right (ddb_tf_context_t *ctx, int argc, const uint16_t *arglens, const char *args, char *out, int outlen, int fail_on_undef) {
+tf_func_right (
+    ddb_tf_context_t *ctx,
+    int argc,
+    const uint16_t *arglens,
+    const char *args,
+    char *out,
+    int outlen,
+    int fail_on_undef) {
     if (argc != 2) {
         return -1;
     }
@@ -1351,14 +1624,14 @@ tf_func_right (ddb_tf_context_t *ctx, int argc, const uint16_t *arglens, const c
     int bool_out = 0;
     int len;
 
-    TF_EVAL_CHECK(len, ctx, args + arglens[0], arglens[1], out, outlen, fail_on_undef);
-    int desired_chars = atoi(out);
+    TF_EVAL_CHECK (len, ctx, args + arglens[0], arglens[1], out, outlen, fail_on_undef);
+    int desired_chars = atoi (out);
     if (desired_chars < 0) {
         return -1;
     }
 
-    TF_EVAL_CHECK(len, ctx, args, arglens[0], out, outlen, fail_on_undef);
-    int clen = u8_strlen(out);
+    TF_EVAL_CHECK (len, ctx, args, arglens[0], out, outlen, fail_on_undef);
+    int clen = u8_strlen (out);
 
     if (clen < desired_chars) {
         return len;
@@ -1366,25 +1639,32 @@ tf_func_right (ddb_tf_context_t *ctx, int argc, const uint16_t *arglens, const c
 
     int32_t index = 0;
     for (int remaining = clen - desired_chars; remaining; --remaining) {
-        u8_nextchar(out, &index);
+        u8_nextchar (out, &index);
     }
 
     int newblen = len - index;
 
-    memmove(out, out + index, newblen);
+    memmove (out, out + index, newblen);
     return newblen;
 }
 
 int
-tf_func_roman (ddb_tf_context_t *ctx, int argc, const uint16_t *arglens, const char *args, char *out, int outlen, int fail_on_undef) {
+tf_func_roman (
+    ddb_tf_context_t *ctx,
+    int argc,
+    const uint16_t *arglens,
+    const char *args,
+    char *out,
+    int outlen,
+    int fail_on_undef) {
     if (argc != 1) {
         return -1;
     }
 
     int bool_out = 0;
     int len;
-    TF_EVAL_CHECK(len, ctx, args, arglens[0], out, outlen, fail_on_undef);
-    int value = atoi(out);
+    TF_EVAL_CHECK (len, ctx, args, arglens[0], out, outlen, fail_on_undef);
+    int value = atoi (out);
     // fb2k (presumably, it goes off my screen) formats 100000; but not 100001
     if (value < 0 || value > 100000) {
         return -1;
@@ -1398,40 +1678,52 @@ tf_func_roman (ddb_tf_context_t *ctx, int argc, const uint16_t *arglens, const c
         if (value >= 1000) {
             out[pos++] = 'M';
             value -= 1000;
-        } else if (value >= 900) {
+        }
+        else if (value >= 900) {
             out[pos++] = 'C';
             value += 100;
-        } else if (value >= 500) {
+        }
+        else if (value >= 500) {
             out[pos++] = 'D';
             value -= 500;
-        } else if (value >= 400) {
+        }
+        else if (value >= 400) {
             out[pos++] = 'C';
             value += 100;
-        } else if (value >= 100) {
+        }
+        else if (value >= 100) {
             out[pos++] = 'C';
             value -= 100;
-        } else if (value >= 90) {
+        }
+        else if (value >= 90) {
             out[pos++] = 'X';
             value += 10;
-        } else if (value >= 50) {
+        }
+        else if (value >= 50) {
             out[pos++] = 'L';
             value -= 50;
-        } else if (value >= 40) {
+        }
+        else if (value >= 40) {
             out[pos++] = 'X';
             value += 10;
-        } else if (value >= 10) {
+        }
+        else if (value >= 10) {
             out[pos++] = 'X';
             value -= 10;
-        } else if (value >= 9) {
+        }
+        else if (value >= 9) {
             out[pos++] = 'I';
             value += 1;
-        } else if (value >= 5) {
+        }
+        else if (value >= 5) {
             out[pos++] = 'V';
             value -= 5;
-        } else if (value >= 4) {
+        }
+        else if (value >= 4) {
             out[pos++] = 'I';
             value += 1;
-        } else if (value >= 1) {
+        }
+        else if (value >= 1) {
             out[pos++] = 'I';
             value -= 1;
         }
@@ -1441,7 +1733,14 @@ tf_func_roman (ddb_tf_context_t *ctx, int argc, const uint16_t *arglens, const c
 }
 
 int
-tf_func_rot13 (ddb_tf_context_t *ctx, int argc, const uint16_t *arglens, const char *args, char *out, int outlen, int fail_on_undef) {
+tf_func_rot13 (
+    ddb_tf_context_t *ctx,
+    int argc,
+    const uint16_t *arglens,
+    const char *args,
+    char *out,
+    int outlen,
+    int fail_on_undef) {
     if (argc != 1) {
         return -1;
     }
@@ -1449,21 +1748,25 @@ tf_func_rot13 (ddb_tf_context_t *ctx, int argc, const uint16_t *arglens, const c
     int bool_out = 0;
     int len;
 
-    TF_EVAL_CHECK(len, ctx, args, arglens[0], out, outlen, fail_on_undef);
+    TF_EVAL_CHECK (len, ctx, args, arglens[0], out, outlen, fail_on_undef);
 
     int32_t offset = 0;
     while (offset < outlen && out[offset]) {
         char c = out[offset];
         if (c >= 'A' && c <= 'M') {
             out[offset++] += 13;
-        } else if (c >= 'N' && c <= 'Z') {
+        }
+        else if (c >= 'N' && c <= 'Z') {
             out[offset++] -= 13;
-        } else if (c >= 'a' && c <= 'm') {
+        }
+        else if (c >= 'a' && c <= 'm') {
             out[offset++] += 13;
-        } else if (c >= 'n' && c <= 'z') {
+        }
+        else if (c >= 'n' && c <= 'z') {
             out[offset++] -= 13;
-        } else {
-            u8_nextchar(out, &offset);
+        }
+        else {
+            u8_nextchar (out, &offset);
         }
     }
 
@@ -1471,7 +1774,14 @@ tf_func_rot13 (ddb_tf_context_t *ctx, int argc, const uint16_t *arglens, const c
 }
 
 int
-tf_func_strchr(ddb_tf_context_t *ctx, int argc, const uint16_t *arglens, const char *args, char *out, int outlen, int fail_on_undef) {
+tf_func_strchr (
+    ddb_tf_context_t *ctx,
+    int argc,
+    const uint16_t *arglens,
+    const char *args,
+    char *out,
+    int outlen,
+    int fail_on_undef) {
     if (argc < 1) {
         return -1;
     }
@@ -1479,29 +1789,37 @@ tf_func_strchr(ddb_tf_context_t *ctx, int argc, const uint16_t *arglens, const c
     int bool_out = 0;
     int len;
 
-    TF_EVAL_CHECK(len, ctx, args + arglens[0], arglens[1], out, outlen, fail_on_undef);
+    TF_EVAL_CHECK (len, ctx, args + arglens[0], arglens[1], out, outlen, fail_on_undef);
     int dummy = 0;
     // fb2k permits strings with many characters as the needle, but uses exactly the first character from them.
-    uint32_t needle = u8_nextchar(out, &dummy);
+    uint32_t needle = u8_nextchar (out, &dummy);
 
-    TF_EVAL_CHECK(len, ctx, args, arglens[0], out, outlen, fail_on_undef);
+    TF_EVAL_CHECK (len, ctx, args, arglens[0], out, outlen, fail_on_undef);
 
     int32_t charpos;
-    const char *pos = u8_strchr(out, needle, &charpos);
+    const char *pos = u8_strchr (out, needle, &charpos);
 
     if (!pos) {
         // 0 is used to indicate not found
         charpos = 0;
-    } else {
+    }
+    else {
         // Convert from 0- to 1- based indexing.
         charpos += 1;
     }
 
-    return snprintf_clip(out, outlen, "%" PRId32, charpos);
+    return snprintf_clip (out, outlen, "%" PRId32, charpos);
 }
 
 int
-tf_func_strrchr(ddb_tf_context_t *ctx, int argc, const uint16_t *arglens, const char *args, char *out, int outlen, int fail_on_undef) {
+tf_func_strrchr (
+    ddb_tf_context_t *ctx,
+    int argc,
+    const uint16_t *arglens,
+    const char *args,
+    char *out,
+    int outlen,
+    int fail_on_undef) {
     if (argc < 1) {
         return -1;
     }
@@ -1509,17 +1827,17 @@ tf_func_strrchr(ddb_tf_context_t *ctx, int argc, const uint16_t *arglens, const 
     int bool_out = 0;
     int len;
 
-    TF_EVAL_CHECK(len, ctx, args, arglens[0], out, outlen, fail_on_undef);
+    TF_EVAL_CHECK (len, ctx, args, arglens[0], out, outlen, fail_on_undef);
 
     char str[TEMP_BUFFER_SIZE];
-    TF_EVAL_CHECK(len, ctx, args + arglens[0], arglens[1], str, sizeof(str) - 1, fail_on_undef);
+    TF_EVAL_CHECK (len, ctx, args + arglens[0], arglens[1], str, sizeof (str) - 1, fail_on_undef);
     int dummy = 0;
-    uint32_t needle = u8_nextchar(str, &dummy);
+    uint32_t needle = u8_nextchar (str, &dummy);
 
     int32_t acc = 0, charpos;
     const char *pos = out;
     do {
-        pos = u8_strchr(pos, needle, &charpos);
+        pos = u8_strchr (pos, needle, &charpos);
         if (pos) {
             /*
              * Simultaneously and efficiently:
@@ -1538,11 +1856,18 @@ tf_func_strrchr(ddb_tf_context_t *ctx, int argc, const uint16_t *arglens, const 
         }
     } while (pos);
 
-    return snprintf_clip(out, outlen, "%" PRId32, acc);
+    return snprintf_clip (out, outlen, "%" PRId32, acc);
 }
 
 int
-tf_func_strstr(ddb_tf_context_t *ctx, int argc, const uint16_t *arglens, const char *args, char *out, int outlen, int fail_on_undef) {
+tf_func_strstr (
+    ddb_tf_context_t *ctx,
+    int argc,
+    const uint16_t *arglens,
+    const char *args,
+    char *out,
+    int outlen,
+    int fail_on_undef) {
     if (argc != 2) {
         return -1;
     }
@@ -1550,13 +1875,13 @@ tf_func_strstr(ddb_tf_context_t *ctx, int argc, const uint16_t *arglens, const c
     int bool_out = 0;
     int len;
 
-    TF_EVAL_CHECK(len, ctx, args, arglens[0], out, outlen, fail_on_undef);
+    TF_EVAL_CHECK (len, ctx, args, arglens[0], out, outlen, fail_on_undef);
 
     char needle[TEMP_BUFFER_SIZE];
 
-    TF_EVAL_CHECK(len, ctx, args + arglens[0], arglens[1], needle, sizeof(needle) - 1, fail_on_undef);
+    TF_EVAL_CHECK (len, ctx, args + arglens[0], arglens[1], needle, sizeof (needle) - 1, fail_on_undef);
 
-    char *pos = strstr(out, needle);
+    char *pos = strstr (out, needle);
 
     int clen = 0;
     if (pos) {
@@ -1565,16 +1890,23 @@ tf_func_strstr(ddb_tf_context_t *ctx, int argc, const uint16_t *arglens, const c
          * overall length to find the offset in characters
          */
         *pos = 0;
-        clen = u8_strlen(out);
+        clen = u8_strlen (out);
         // Convert from 0-based offset to 1-based indexing
         clen += 1;
     }
-    return snprintf_clip(out, outlen, "%d", clen);
+    return snprintf_clip (out, outlen, "%d", clen);
 }
 
 // fb2k uses 1-based indexing for $substr, with both points inclusive, and all arguments mandatory.
 int
-tf_func_substr(ddb_tf_context_t *ctx, int argc, const uint16_t *arglens, const char *args, char *out, int outlen, int fail_on_undef) {
+tf_func_substr (
+    ddb_tf_context_t *ctx,
+    int argc,
+    const uint16_t *arglens,
+    const char *args,
+    char *out,
+    int outlen,
+    int fail_on_undef) {
     if (argc != 3) {
         return -1;
     }
@@ -1582,11 +1914,11 @@ tf_func_substr(ddb_tf_context_t *ctx, int argc, const uint16_t *arglens, const c
     int bool_out = 0;
     int len;
 
-    TF_EVAL_CHECK(len, ctx, args, arglens[0], out, outlen, fail_on_undef);
+    TF_EVAL_CHECK (len, ctx, args, arglens[0], out, outlen, fail_on_undef);
 
     char str[TEMP_BUFFER_SIZE];
-    TF_EVAL_CHECK(len, ctx, args + arglens[0], arglens[1], str, sizeof(str) - 1, fail_on_undef);
-    int from = atoi(str);
+    TF_EVAL_CHECK (len, ctx, args + arglens[0], arglens[1], str, sizeof (str) - 1, fail_on_undef);
+    int from = atoi (str);
     if (from <= 0) {
         // fb2k tolerates negative 'from' values
         from = 1;
@@ -1595,8 +1927,8 @@ tf_func_substr(ddb_tf_context_t *ctx, int argc, const uint16_t *arglens, const c
     from -= 1;
 
     char *temp = malloc (outlen);
-    TF_EVAL_CHECK(len, ctx, args + arglens[0] + arglens[1], arglens[2], temp, outlen, fail_on_undef);
-    int to = atoi(temp);
+    TF_EVAL_CHECK (len, ctx, args + arglens[0] + arglens[1], arglens[2], temp, outlen, fail_on_undef);
+    int to = atoi (temp);
     free (temp);
     if (to <= 0) {
         // If we don't want anything, finish early
@@ -1608,25 +1940,31 @@ tf_func_substr(ddb_tf_context_t *ctx, int argc, const uint16_t *arglens, const c
     int bpos = 0;
     int chars;
     for (chars = 0; out[bpos] && chars != from; ++chars) {
-        u8_nextchar(out, &bpos);
+        u8_nextchar (out, &bpos);
     }
     int bfrom = bpos;
 
-    for ( ; out[bpos] && chars <= to; ++chars) {
-        u8_nextchar(out, &bpos);
+    for (; out[bpos] && chars <= to; ++chars) {
+        u8_nextchar (out, &bpos);
     }
     int bto = bpos;
 
     int bdiff = bto - bfrom;
 
-    memmove(out, out + bfrom, bdiff);
+    memmove (out, out + bfrom, bdiff);
 
     return bdiff;
-
 }
 
 int
-tf_func_tab(ddb_tf_context_t *ctx, int argc, const uint16_t *arglens, const char *args, char *out, int outlen, int fail_on_undef) {
+tf_func_tab (
+    ddb_tf_context_t *ctx,
+    int argc,
+    const uint16_t *arglens,
+    const char *args,
+    char *out,
+    int outlen,
+    int fail_on_undef) {
     if (argc > 1) {
         return -1;
     }
@@ -1637,8 +1975,8 @@ tf_func_tab(ddb_tf_context_t *ctx, int argc, const uint16_t *arglens, const char
         int len;
 
         char str[TEMP_BUFFER_SIZE];
-        TF_EVAL_CHECK(len, ctx, args, arglens[0], str, sizeof(str) - 1, fail_on_undef);
-        amount = atoi(str);
+        TF_EVAL_CHECK (len, ctx, args, arglens[0], str, sizeof (str) - 1, fail_on_undef);
+        amount = atoi (str);
         if (amount < 0) {
             return -1;
         }
@@ -1647,12 +1985,19 @@ tf_func_tab(ddb_tf_context_t *ctx, int argc, const uint16_t *arglens, const char
         amount = outlen;
     }
 
-    memset(out, '\t', amount);
+    memset (out, '\t', amount);
     return amount;
 }
 
 int
-tf_func_trim(ddb_tf_context_t *ctx, int argc, const uint16_t *arglens, const char *args, char *out, int outlen, int fail_on_undef) {
+tf_func_trim (
+    ddb_tf_context_t *ctx,
+    int argc,
+    const uint16_t *arglens,
+    const char *args,
+    char *out,
+    int outlen,
+    int fail_on_undef) {
     if (argc == 0) {
         return 0;
     }
@@ -1663,13 +2008,13 @@ tf_func_trim(ddb_tf_context_t *ctx, int argc, const uint16_t *arglens, const cha
     int bool_out = 0;
     int len;
 
-    TF_EVAL_CHECK(len, ctx, args, arglens[0], out, outlen, fail_on_undef);
+    TF_EVAL_CHECK (len, ctx, args, arglens[0], out, outlen, fail_on_undef);
 
     int bfrom = -1, bto = 0;
 
-    for (int offset = 0; offset != len && out[offset]; ) {
+    for (int offset = 0; offset != len && out[offset];) {
         const int last = offset;
-        u8_nextchar(out, &offset);
+        u8_nextchar (out, &offset);
         if (out[last] != ' ') {
             if (bfrom == -1) {
                 bfrom = last;
@@ -1683,12 +2028,19 @@ tf_func_trim(ddb_tf_context_t *ctx, int argc, const uint16_t *arglens, const cha
     }
 
     int bdiff = bto - bfrom;
-    memmove(out, out + bfrom, bdiff);
+    memmove (out, out + bfrom, bdiff);
     return bdiff;
 }
 
 int
-tf_func_directory (ddb_tf_context_t *ctx, int argc, const uint16_t *arglens, const char *args, char *out, int outlen, int fail_on_undef) {
+tf_func_directory (
+    ddb_tf_context_t *ctx,
+    int argc,
+    const uint16_t *arglens,
+    const char *args,
+    char *out,
+    int outlen,
+    int fail_on_undef) {
     if (argc < 1 || argc > 2) {
         return -1;
     }
@@ -1696,7 +2048,7 @@ tf_func_directory (ddb_tf_context_t *ctx, int argc, const uint16_t *arglens, con
     int bool_out = 0;
 
     int len;
-    TF_EVAL_CHECK(len, ctx, args, arglens[0], out, outlen, fail_on_undef);
+    TF_EVAL_CHECK (len, ctx, args, arglens[0], out, outlen, fail_on_undef);
 
     int path_len = len;
 
@@ -1704,7 +2056,7 @@ tf_func_directory (ddb_tf_context_t *ctx, int argc, const uint16_t *arglens, con
     if (argc == 2) {
         char temp[20];
         args += arglens[0];
-        TF_EVAL_CHECK(len, ctx, args, arglens[1], temp, sizeof (temp) - 1, fail_on_undef);
+        TF_EVAL_CHECK (len, ctx, args, arglens[1], temp, sizeof (temp) - 1, fail_on_undef);
         levels = atoi (temp);
         if (levels < 0) {
             return -1;
@@ -1754,12 +2106,19 @@ tf_func_directory (ddb_tf_context_t *ctx, int argc, const uint16_t *arglens, con
         }
     }
 
-    memmove (out, start, end-start);
-    return (int)(end-start);
+    memmove (out, start, end - start);
+    return (int)(end - start);
 }
 
 int
-tf_func_directory_path (ddb_tf_context_t *ctx, int argc, const uint16_t *arglens, const char *args, char *out, int outlen, int fail_on_undef) {
+tf_func_directory_path (
+    ddb_tf_context_t *ctx,
+    int argc,
+    const uint16_t *arglens,
+    const char *args,
+    char *out,
+    int outlen,
+    int fail_on_undef) {
     if (argc < 1 || argc > 2) {
         return -1;
     }
@@ -1767,7 +2126,7 @@ tf_func_directory_path (ddb_tf_context_t *ctx, int argc, const uint16_t *arglens
     int bool_out = 0;
 
     int len;
-    TF_EVAL_CHECK(len, ctx, args, arglens[0], out, outlen, fail_on_undef);
+    TF_EVAL_CHECK (len, ctx, args, arglens[0], out, outlen, fail_on_undef);
 
     char *p = out + len - 1;
 
@@ -1783,11 +2142,18 @@ tf_func_directory_path (ddb_tf_context_t *ctx, int argc, const uint16_t *arglens
     }
 
     p++;
-    return (int)(p-out);
+    return (int)(p - out);
 }
 
 int
-tf_func_ext (ddb_tf_context_t *ctx, int argc, const uint16_t *arglens, const char *args, char *out, int outlen, int fail_on_undef) {
+tf_func_ext (
+    ddb_tf_context_t *ctx,
+    int argc,
+    const uint16_t *arglens,
+    const char *args,
+    char *out,
+    int outlen,
+    int fail_on_undef) {
     if (argc < 1 || argc > 2) {
         return -1;
     }
@@ -1795,15 +2161,15 @@ tf_func_ext (ddb_tf_context_t *ctx, int argc, const uint16_t *arglens, const cha
     int bool_out = 0;
 
     int len;
-    TF_EVAL_CHECK(len, ctx, args, arglens[0], out, outlen, fail_on_undef);
-    
+    TF_EVAL_CHECK (len, ctx, args, arglens[0], out, outlen, fail_on_undef);
+
     char *e = out + len;
     char *c = e - 1;
     char *p = NULL;
 
     while (c >= out && *c != '/') {
         if (*c == '.') {
-            p = c+1;
+            p = c + 1;
             break;
         }
         c--;
@@ -1814,12 +2180,19 @@ tf_func_ext (ddb_tf_context_t *ctx, int argc, const uint16_t *arglens, const cha
         return 0;
     }
 
-    memmove (out, p, e-p+1);
-    return (int)(e-p);
+    memmove (out, p, e - p + 1);
+    return (int)(e - p);
 }
 
 int
-tf_func_filename (ddb_tf_context_t *ctx, int argc, const uint16_t *arglens, const char *args, char *out, int outlen, int fail_on_undef) {
+tf_func_filename (
+    ddb_tf_context_t *ctx,
+    int argc,
+    const uint16_t *arglens,
+    const char *args,
+    char *out,
+    int outlen,
+    int fail_on_undef) {
     if (argc < 1 || argc > 2) {
         return -1;
     }
@@ -1827,7 +2200,7 @@ tf_func_filename (ddb_tf_context_t *ctx, int argc, const uint16_t *arglens, cons
     int bool_out = 0;
 
     int len;
-    TF_EVAL_CHECK(len, ctx, args, arglens[0], out, outlen, fail_on_undef);
+    TF_EVAL_CHECK (len, ctx, args, arglens[0], out, outlen, fail_on_undef);
 
     char *e = out + len;
     char *p = e - 1;
@@ -1837,19 +2210,26 @@ tf_func_filename (ddb_tf_context_t *ctx, int argc, const uint16_t *arglens, cons
 
     p++;
 
-    memmove (out, p, e-p+1);
-    return (int)(e-p);
+    memmove (out, p, e - p + 1);
+    return (int)(e - p);
 }
 
 int
-tf_func_add (ddb_tf_context_t *ctx, int argc, const uint16_t *arglens, const char *args, char *out, int outlen, int fail_on_undef) {
+tf_func_add (
+    ddb_tf_context_t *ctx,
+    int argc,
+    const uint16_t *arglens,
+    const char *args,
+    char *out,
+    int outlen,
+    int fail_on_undef) {
     int bool_out = 0;
 
     int outval = 0;
     const char *arg = args;
     for (int i = 0; i < argc; i++) {
         int len;
-        TF_EVAL_CHECK(len, ctx, arg, arglens[i], out, outlen, fail_on_undef);
+        TF_EVAL_CHECK (len, ctx, arg, arglens[i], out, outlen, fail_on_undef);
         outval += atoi (out);
         arg += arglens[i];
     }
@@ -1857,7 +2237,14 @@ tf_func_add (ddb_tf_context_t *ctx, int argc, const uint16_t *arglens, const cha
 }
 
 int
-tf_func_div (ddb_tf_context_t *ctx, int argc, const uint16_t *arglens, const char *args, char *out, int outlen, int fail_on_undef) {
+tf_func_div (
+    ddb_tf_context_t *ctx,
+    int argc,
+    const uint16_t *arglens,
+    const char *args,
+    char *out,
+    int outlen,
+    int fail_on_undef) {
     int bool_out = 0;
 
     if (argc < 2) {
@@ -1868,7 +2255,7 @@ tf_func_div (ddb_tf_context_t *ctx, int argc, const uint16_t *arglens, const cha
     const char *arg = args;
     for (int i = 0; i < argc; i++) {
         int len;
-        TF_EVAL_CHECK(len, ctx, arg, arglens[i], out, outlen, fail_on_undef);
+        TF_EVAL_CHECK (len, ctx, arg, arglens[i], out, outlen, fail_on_undef);
         if (i == 0) {
             outval = atoi (out);
         }
@@ -1887,7 +2274,14 @@ tf_func_div (ddb_tf_context_t *ctx, int argc, const uint16_t *arglens, const cha
 }
 
 int
-tf_func_max (ddb_tf_context_t *ctx, int argc, const uint16_t *arglens, const char *args, char *out, int outlen, int fail_on_undef) {
+tf_func_max (
+    ddb_tf_context_t *ctx,
+    int argc,
+    const uint16_t *arglens,
+    const char *args,
+    char *out,
+    int outlen,
+    int fail_on_undef) {
     int bool_out = 0;
 
     if (argc == 0) {
@@ -1898,7 +2292,7 @@ tf_func_max (ddb_tf_context_t *ctx, int argc, const uint16_t *arglens, const cha
     const char *arg = args;
     for (int i = 0; i < argc; i++) {
         int len;
-        TF_EVAL_CHECK(len, ctx, arg, arglens[i], out, outlen, fail_on_undef);
+        TF_EVAL_CHECK (len, ctx, arg, arglens[i], out, outlen, fail_on_undef);
         int n = atoi (out);
         if (n > nmax) {
             nmax = n;
@@ -1910,7 +2304,14 @@ tf_func_max (ddb_tf_context_t *ctx, int argc, const uint16_t *arglens, const cha
 }
 
 int
-tf_func_min (ddb_tf_context_t *ctx, int argc, const uint16_t *arglens, const char *args, char *out, int outlen, int fail_on_undef) {
+tf_func_min (
+    ddb_tf_context_t *ctx,
+    int argc,
+    const uint16_t *arglens,
+    const char *args,
+    char *out,
+    int outlen,
+    int fail_on_undef) {
     int bool_out = 0;
 
     if (argc == 0) {
@@ -1921,7 +2322,7 @@ tf_func_min (ddb_tf_context_t *ctx, int argc, const uint16_t *arglens, const cha
     const char *arg = args;
     for (int i = 0; i < argc; i++) {
         int len;
-        TF_EVAL_CHECK(len, ctx, arg, arglens[i], out, outlen, fail_on_undef);
+        TF_EVAL_CHECK (len, ctx, arg, arglens[i], out, outlen, fail_on_undef);
         int n = atoi (out);
         if (n < nmin) {
             nmin = n;
@@ -1933,7 +2334,14 @@ tf_func_min (ddb_tf_context_t *ctx, int argc, const uint16_t *arglens, const cha
 }
 
 int
-tf_func_mod (ddb_tf_context_t *ctx, int argc, const uint16_t *arglens, const char *args, char *out, int outlen, int fail_on_undef) {
+tf_func_mod (
+    ddb_tf_context_t *ctx,
+    int argc,
+    const uint16_t *arglens,
+    const char *args,
+    char *out,
+    int outlen,
+    int fail_on_undef) {
     int bool_out = 0;
 
     if (argc < 2) {
@@ -1944,7 +2352,7 @@ tf_func_mod (ddb_tf_context_t *ctx, int argc, const uint16_t *arglens, const cha
     const char *arg = args;
     for (int i = 0; i < argc; i++) {
         int len;
-        TF_EVAL_CHECK(len, ctx, arg, arglens[i], out, outlen, fail_on_undef);
+        TF_EVAL_CHECK (len, ctx, arg, arglens[i], out, outlen, fail_on_undef);
         if (i == 0) {
             outval = atoi (out);
         }
@@ -1963,7 +2371,14 @@ tf_func_mod (ddb_tf_context_t *ctx, int argc, const uint16_t *arglens, const cha
 }
 
 int
-tf_func_mul (ddb_tf_context_t *ctx, int argc, const uint16_t *arglens, const char *args, char *out, int outlen, int fail_on_undef) {
+tf_func_mul (
+    ddb_tf_context_t *ctx,
+    int argc,
+    const uint16_t *arglens,
+    const char *args,
+    char *out,
+    int outlen,
+    int fail_on_undef) {
     int bool_out = 0;
 
     if (argc < 2) {
@@ -1974,7 +2389,7 @@ tf_func_mul (ddb_tf_context_t *ctx, int argc, const uint16_t *arglens, const cha
     const char *arg = args;
     for (int i = 0; i < argc; i++) {
         int len;
-        TF_EVAL_CHECK(len, ctx, arg, arglens[i], out, outlen, fail_on_undef);
+        TF_EVAL_CHECK (len, ctx, arg, arglens[i], out, outlen, fail_on_undef);
         if (i == 0) {
             outval = atoi (out);
         }
@@ -1988,7 +2403,14 @@ tf_func_mul (ddb_tf_context_t *ctx, int argc, const uint16_t *arglens, const cha
 }
 
 int
-tf_func_muldiv (ddb_tf_context_t *ctx, int argc, const uint16_t *arglens, const char *args, char *out, int outlen, int fail_on_undef) {
+tf_func_muldiv (
+    ddb_tf_context_t *ctx,
+    int argc,
+    const uint16_t *arglens,
+    const char *args,
+    char *out,
+    int outlen,
+    int fail_on_undef) {
     int bool_out = 0;
 
     if (argc != 3) {
@@ -1999,7 +2421,7 @@ tf_func_muldiv (ddb_tf_context_t *ctx, int argc, const uint16_t *arglens, const 
     const char *arg = args;
     for (int i = 0; i < argc; i++) {
         int len;
-        TF_EVAL_CHECK(len, ctx, arg, arglens[i], out, outlen, fail_on_undef);
+        TF_EVAL_CHECK (len, ctx, arg, arglens[i], out, outlen, fail_on_undef);
         vals[i] = atoi (out);
         arg += arglens[i];
     }
@@ -2009,14 +2431,21 @@ tf_func_muldiv (ddb_tf_context_t *ctx, int argc, const uint16_t *arglens, const 
         return -1;
     }
 
-    int outval = (int)round(vals[0] * vals[1] / (float)vals[2]);
+    int outval = (int)round (vals[0] * vals[1] / (float)vals[2]);
 
     int res = snprintf_clip (out, outlen, "%d", outval);
     return res;
 }
 
 int
-tf_func_rand (ddb_tf_context_t *ctx, int argc, const uint16_t *arglens, const char *args, char *out, int outlen, int fail_on_undef) {
+tf_func_rand (
+    ddb_tf_context_t *ctx,
+    int argc,
+    const uint16_t *arglens,
+    const char *args,
+    char *out,
+    int outlen,
+    int fail_on_undef) {
     if (argc != 0) {
         return -1;
     }
@@ -2028,7 +2457,14 @@ tf_func_rand (ddb_tf_context_t *ctx, int argc, const uint16_t *arglens, const ch
 }
 
 int
-tf_func_sub (ddb_tf_context_t *ctx, int argc, const uint16_t *arglens, const char *args, char *out, int outlen, int fail_on_undef) {
+tf_func_sub (
+    ddb_tf_context_t *ctx,
+    int argc,
+    const uint16_t *arglens,
+    const char *args,
+    char *out,
+    int outlen,
+    int fail_on_undef) {
     int bool_out = 0;
 
     if (argc < 2) {
@@ -2039,7 +2475,7 @@ tf_func_sub (ddb_tf_context_t *ctx, int argc, const uint16_t *arglens, const cha
     const char *arg = args;
     for (int i = 0; i < argc; i++) {
         int len;
-        TF_EVAL_CHECK(len, ctx, arg, arglens[i], out, outlen, fail_on_undef);
+        TF_EVAL_CHECK (len, ctx, arg, arglens[i], out, outlen, fail_on_undef);
         if (i == 0) {
             outval = atoi (out);
         }
@@ -2053,7 +2489,14 @@ tf_func_sub (ddb_tf_context_t *ctx, int argc, const uint16_t *arglens, const cha
 }
 
 int
-tf_func_if (ddb_tf_context_t *ctx, int argc, const uint16_t *arglens, const char *args, char *out, int outlen, int fail_on_undef) {
+tf_func_if (
+    ddb_tf_context_t *ctx,
+    int argc,
+    const uint16_t *arglens,
+    const char *args,
+    char *out,
+    int outlen,
+    int fail_on_undef) {
     if (argc < 2 || argc > 3) {
         return -1;
     }
@@ -2061,23 +2504,30 @@ tf_func_if (ddb_tf_context_t *ctx, int argc, const uint16_t *arglens, const char
 
     const char *arg = args;
     int res;
-    TF_EVAL_CHECK(res, ctx, arg, arglens[0], out, outlen, fail_on_undef);
+    TF_EVAL_CHECK (res, ctx, arg, arglens[0], out, outlen, fail_on_undef);
     arg += arglens[0];
     if (bool_out) {
         trace ("condition true, eval then block\n");
-        TF_EVAL_CHECK(res, ctx, arg, arglens[1], out, outlen, fail_on_undef);
+        TF_EVAL_CHECK (res, ctx, arg, arglens[1], out, outlen, fail_on_undef);
     }
     else if (argc == 3) {
         trace ("condition false, eval else block\n");
         arg += arglens[1];
-        TF_EVAL_CHECK(res, ctx, arg, arglens[2], out, outlen, fail_on_undef);
+        TF_EVAL_CHECK (res, ctx, arg, arglens[2], out, outlen, fail_on_undef);
     }
 
     return res;
 }
 
 int
-tf_func_if2 (ddb_tf_context_t *ctx, int argc, const uint16_t *arglens, const char *args, char *out, int outlen, int fail_on_undef) {
+tf_func_if2 (
+    ddb_tf_context_t *ctx,
+    int argc,
+    const uint16_t *arglens,
+    const char *args,
+    char *out,
+    int outlen,
+    int fail_on_undef) {
     if (argc != 2) {
         return -1;
     }
@@ -2085,20 +2535,27 @@ tf_func_if2 (ddb_tf_context_t *ctx, int argc, const uint16_t *arglens, const cha
 
     const char *arg = args;
     int res;
-    TF_EVAL_CHECK(res, ctx, arg, arglens[0], out, outlen, fail_on_undef);
+    TF_EVAL_CHECK (res, ctx, arg, arglens[0], out, outlen, fail_on_undef);
     arg += arglens[0];
     if (bool_out) {
         return res;
     }
     else {
-        TF_EVAL_CHECK(res, ctx, arg, arglens[1], out, outlen, fail_on_undef);
+        TF_EVAL_CHECK (res, ctx, arg, arglens[1], out, outlen, fail_on_undef);
     }
 
     return res;
 }
 
 int
-tf_func_if3 (ddb_tf_context_t *ctx, int argc, const uint16_t *arglens, const char *args, char *out, int outlen, int fail_on_undef) {
+tf_func_if3 (
+    ddb_tf_context_t *ctx,
+    int argc,
+    const uint16_t *arglens,
+    const char *args,
+    char *out,
+    int outlen,
+    int fail_on_undef) {
     if (argc < 2) {
         return -1;
     }
@@ -2107,9 +2564,9 @@ tf_func_if3 (ddb_tf_context_t *ctx, int argc, const uint16_t *arglens, const cha
     const char *arg = args;
     for (int i = 0; i < argc; i++) {
         int res;
-        TF_EVAL_CHECK(res, ctx, arg, arglens[i], out, outlen, fail_on_undef);
+        TF_EVAL_CHECK (res, ctx, arg, arglens[i], out, outlen, fail_on_undef);
         arg += arglens[i];
-        if (bool_out || i == argc-1) {
+        if (bool_out || i == argc - 1) {
             return res;
         }
     }
@@ -2118,7 +2575,14 @@ tf_func_if3 (ddb_tf_context_t *ctx, int argc, const uint16_t *arglens, const cha
 }
 
 int
-tf_func_ifequal (ddb_tf_context_t *ctx, int argc, const uint16_t *arglens, const char *args, char *out, int outlen, int fail_on_undef) {
+tf_func_ifequal (
+    ddb_tf_context_t *ctx,
+    int argc,
+    const uint16_t *arglens,
+    const char *args,
+    char *out,
+    int outlen,
+    int fail_on_undef) {
     if (argc != 4) {
         return -1;
     }
@@ -2127,12 +2591,12 @@ tf_func_ifequal (ddb_tf_context_t *ctx, int argc, const uint16_t *arglens, const
 
     const char *arg = args;
     int len;
-    TF_EVAL_CHECK(len, ctx, arg, arglens[0], out, outlen, fail_on_undef);
+    TF_EVAL_CHECK (len, ctx, arg, arglens[0], out, outlen, fail_on_undef);
 
     int arg1 = atoi (out);
 
     arg += arglens[0];
-    TF_EVAL_CHECK(len, ctx, arg, arglens[1], out, outlen, fail_on_undef);
+    TF_EVAL_CHECK (len, ctx, arg, arglens[1], out, outlen, fail_on_undef);
 
     int arg2 = atoi (out);
 
@@ -2144,12 +2608,19 @@ tf_func_ifequal (ddb_tf_context_t *ctx, int argc, const uint16_t *arglens, const
         idx = 3;
     }
 
-    TF_EVAL_CHECK(len, ctx, arg, arglens[idx], out, outlen, fail_on_undef);
+    TF_EVAL_CHECK (len, ctx, arg, arglens[idx], out, outlen, fail_on_undef);
     return len;
 }
 
 int
-tf_func_ifgreater (ddb_tf_context_t *ctx, int argc, const uint16_t *arglens, const char *args, char *out, int outlen, int fail_on_undef) {
+tf_func_ifgreater (
+    ddb_tf_context_t *ctx,
+    int argc,
+    const uint16_t *arglens,
+    const char *args,
+    char *out,
+    int outlen,
+    int fail_on_undef) {
     if (argc != 4) {
         return -1;
     }
@@ -2158,12 +2629,12 @@ tf_func_ifgreater (ddb_tf_context_t *ctx, int argc, const uint16_t *arglens, con
 
     const char *arg = args;
     int len;
-    TF_EVAL_CHECK(len, ctx, arg, arglens[0], out, outlen, fail_on_undef);
+    TF_EVAL_CHECK (len, ctx, arg, arglens[0], out, outlen, fail_on_undef);
 
     int arg1 = atoi (out);
 
     arg += arglens[0];
-    TF_EVAL_CHECK(len, ctx, arg, arglens[1], out, outlen, fail_on_undef);
+    TF_EVAL_CHECK (len, ctx, arg, arglens[1], out, outlen, fail_on_undef);
 
     int arg2 = atoi (out);
 
@@ -2175,12 +2646,19 @@ tf_func_ifgreater (ddb_tf_context_t *ctx, int argc, const uint16_t *arglens, con
         idx = 3;
     }
 
-    TF_EVAL_CHECK(len, ctx, arg, arglens[idx], out, outlen, fail_on_undef);
+    TF_EVAL_CHECK (len, ctx, arg, arglens[idx], out, outlen, fail_on_undef);
     return len;
 }
 
 int
-tf_func_iflonger (ddb_tf_context_t *ctx, int argc, const uint16_t *arglens, const char *args, char *out, int outlen, int fail_on_undef) {
+tf_func_iflonger (
+    ddb_tf_context_t *ctx,
+    int argc,
+    const uint16_t *arglens,
+    const char *args,
+    char *out,
+    int outlen,
+    int fail_on_undef) {
     if (argc != 4) {
         return -1;
     }
@@ -2189,11 +2667,11 @@ tf_func_iflonger (ddb_tf_context_t *ctx, int argc, const uint16_t *arglens, cons
 
     const char *arg = args;
     int len;
-    TF_EVAL_CHECK(len, ctx, arg, arglens[0], out, outlen, fail_on_undef);
+    TF_EVAL_CHECK (len, ctx, arg, arglens[0], out, outlen, fail_on_undef);
     int l1 = (int)strlen (out);
 
     arg += arglens[0];
-    TF_EVAL_CHECK(len, ctx, arg, arglens[1], out, outlen, fail_on_undef);
+    TF_EVAL_CHECK (len, ctx, arg, arglens[1], out, outlen, fail_on_undef);
     int l2 = (int)atoi (out);
 
     arg += arglens[1];
@@ -2203,12 +2681,19 @@ tf_func_iflonger (ddb_tf_context_t *ctx, int argc, const uint16_t *arglens, cons
         idx = 3;
     }
 
-    TF_EVAL_CHECK(len, ctx, arg, arglens[idx], out, outlen, fail_on_undef);
+    TF_EVAL_CHECK (len, ctx, arg, arglens[idx], out, outlen, fail_on_undef);
     return len;
 }
 
 int
-tf_func_select (ddb_tf_context_t *ctx, int argc, const uint16_t *arglens, const char *args, char *out, int outlen, int fail_on_undef) {
+tf_func_select (
+    ddb_tf_context_t *ctx,
+    int argc,
+    const uint16_t *arglens,
+    const char *args,
+    char *out,
+    int outlen,
+    int fail_on_undef) {
     if (argc < 3) {
         return -1;
     }
@@ -2218,7 +2703,7 @@ tf_func_select (ddb_tf_context_t *ctx, int argc, const uint16_t *arglens, const 
     int bool_out = 0;
 
     int res;
-    TF_EVAL_CHECK(res, ctx, arg, arglens[0], out, outlen, fail_on_undef);
+    TF_EVAL_CHECK (res, ctx, arg, arglens[0], out, outlen, fail_on_undef);
 
     int n = atoi (out);
     if (n < 1 || n >= argc) {
@@ -2230,7 +2715,7 @@ tf_func_select (ddb_tf_context_t *ctx, int argc, const uint16_t *arglens, const 
     for (int i = 1; i < n; i++) {
         arg += arglens[i];
     }
-    TF_EVAL_CHECK(res, ctx, arg, arglens[n], out, outlen, fail_on_undef);
+    TF_EVAL_CHECK (res, ctx, arg, arglens[n], out, outlen, fail_on_undef);
     return res;
 }
 
@@ -2243,7 +2728,7 @@ tf_append_out (char **out, int *out_len, const char *in, int in_len) {
 }
 
 static int
-tf_item_index_for_context(ddb_tf_context_t *_ctx) {
+tf_item_index_for_context (ddb_tf_context_t *_ctx) {
     ddb_tf_context_int_t *ctx = (ddb_tf_context_int_t *)_ctx;
     if (ctx->getting_item_at_index) {
         return ctx->item_at_index;
@@ -2252,7 +2737,14 @@ tf_item_index_for_context(ddb_tf_context_t *_ctx) {
 }
 
 int
-tf_func_meta (ddb_tf_context_t *ctx, int argc, const uint16_t *arglens, const char *args, char *out, int outlen, int fail_on_undef) {
+tf_func_meta (
+    ddb_tf_context_t *ctx,
+    int argc,
+    const uint16_t *arglens,
+    const char *args,
+    char *out,
+    int outlen,
+    int fail_on_undef) {
     if (argc != 1) {
         return -1;
     }
@@ -2265,15 +2757,16 @@ tf_func_meta (ddb_tf_context_t *ctx, int argc, const uint16_t *arglens, const ch
 
     const char *arg = args;
     int len;
-    TF_EVAL_CHECK(len, ctx, arg, arglens[0], out, outlen, fail_on_undef);
+    TF_EVAL_CHECK (len, ctx, arg, arglens[0], out, outlen, fail_on_undef);
 
     int needs_free = 0;
-    const char *meta = _tf_get_combined_value ((playItem_t *)ctx->it, out, &needs_free, tf_item_index_for_context(ctx));
+    const char *meta =
+        _tf_get_combined_value ((playItem_t *)ctx->it, out, &needs_free, tf_item_index_for_context (ctx));
     if (!meta) {
         return 0;
     }
 
-    int res = u8_strnbcpy(out, meta, outlen);
+    int res = u8_strnbcpy (out, meta, outlen);
     if (needs_free) {
         free ((char *)meta);
     }
@@ -2286,20 +2779,27 @@ tf_get_channels_string_for_track (playItem_t *it) {
     if (val) {
         int ch = atoi (val);
         if (ch == 1) {
-            val = _("mono");
+            val = _ ("mono");
         }
         else if (ch == 2) {
-            val = _("stereo");
+            val = _ ("stereo");
         }
     }
     else {
-        val = _("stereo");
+        val = _ ("stereo");
     }
     return val;
 }
 
 int
-tf_func_channels (ddb_tf_context_t *ctx, int argc, const uint16_t *arglens, const char *args, char *out, int outlen, int fail_on_undef) {
+tf_func_channels (
+    ddb_tf_context_t *ctx,
+    int argc,
+    const uint16_t *arglens,
+    const char *args,
+    char *out,
+    int outlen,
+    int fail_on_undef) {
     if (argc != 0) {
         return -1;
     }
@@ -2309,18 +2809,25 @@ tf_func_channels (ddb_tf_context_t *ctx, int argc, const uint16_t *arglens, cons
     }
 
     const char *val = tf_get_channels_string_for_track ((playItem_t *)ctx->it);
-    return u8_strnbcpy(out, val, outlen);
+    return u8_strnbcpy (out, val, outlen);
 }
 
 // Boolean
 int
-tf_func_and (ddb_tf_context_t *ctx, int argc, const uint16_t *arglens, const char *args, char *out, int outlen, int fail_on_undef) {
+tf_func_and (
+    ddb_tf_context_t *ctx,
+    int argc,
+    const uint16_t *arglens,
+    const char *args,
+    char *out,
+    int outlen,
+    int fail_on_undef) {
     int bool_out = 0;
 
     const char *arg = args;
     for (int i = 0; i < argc; i++) {
         int len;
-        TF_EVAL_CHECK(len, ctx, arg, arglens[i], out, outlen, fail_on_undef);
+        TF_EVAL_CHECK (len, ctx, arg, arglens[i], out, outlen, fail_on_undef);
         if (!bool_out) {
             return 0;
         }
@@ -2331,13 +2838,20 @@ tf_func_and (ddb_tf_context_t *ctx, int argc, const uint16_t *arglens, const cha
 }
 
 int
-tf_func_or (ddb_tf_context_t *ctx, int argc, const uint16_t *arglens, const char *args, char *out, int outlen, int fail_on_undef) {
+tf_func_or (
+    ddb_tf_context_t *ctx,
+    int argc,
+    const uint16_t *arglens,
+    const char *args,
+    char *out,
+    int outlen,
+    int fail_on_undef) {
     int bool_out = 0;
 
     const char *arg = args;
     for (int i = 0; i < argc; i++) {
         int len;
-        TF_EVAL_CHECK(len, ctx, arg, arglens[i], out, outlen, fail_on_undef);
+        TF_EVAL_CHECK (len, ctx, arg, arglens[i], out, outlen, fail_on_undef);
         if (bool_out) {
             *out = 0;
             return 1;
@@ -2349,27 +2863,41 @@ tf_func_or (ddb_tf_context_t *ctx, int argc, const uint16_t *arglens, const char
 }
 
 int
-tf_func_not (ddb_tf_context_t *ctx, int argc, const uint16_t *arglens, const char *args, char *out, int outlen, int fail_on_undef) {
+tf_func_not (
+    ddb_tf_context_t *ctx,
+    int argc,
+    const uint16_t *arglens,
+    const char *args,
+    char *out,
+    int outlen,
+    int fail_on_undef) {
     if (argc != 1) {
         return -1;
     }
     int bool_out = 0;
 
     int len;
-    TF_EVAL_CHECK(len, ctx, args, arglens[0], out, outlen, fail_on_undef);
+    TF_EVAL_CHECK (len, ctx, args, arglens[0], out, outlen, fail_on_undef);
     *out = 0;
     return !bool_out;
 }
 
 int
-tf_func_xor (ddb_tf_context_t *ctx, int argc, const uint16_t *arglens, const char *args, char *out, int outlen, int fail_on_undef) {
+tf_func_xor (
+    ddb_tf_context_t *ctx,
+    int argc,
+    const uint16_t *arglens,
+    const char *args,
+    char *out,
+    int outlen,
+    int fail_on_undef) {
     int bool_out = 0;
     int result = 0;
 
     const char *arg = args;
     for (int i = 0; i < argc; i++) {
         int len;
-        TF_EVAL_CHECK(len, ctx, arg, arglens[i], out, outlen, fail_on_undef);
+        TF_EVAL_CHECK (len, ctx, arg, arglens[i], out, outlen, fail_on_undef);
         if (i == 0) {
             result = bool_out;
         }
@@ -2383,7 +2911,14 @@ tf_func_xor (ddb_tf_context_t *ctx, int argc, const uint16_t *arglens, const cha
 }
 
 int
-tf_func_fix_eol (ddb_tf_context_t *ctx, int argc, const uint16_t *arglens, const char *args, char *out, int outlen, int fail_on_undef) {
+tf_func_fix_eol (
+    ddb_tf_context_t *ctx,
+    int argc,
+    const uint16_t *arglens,
+    const char *args,
+    char *out,
+    int outlen,
+    int fail_on_undef) {
     if (argc != 1 && argc != 2) {
         return -1;
     }
@@ -2393,12 +2928,12 @@ tf_func_fix_eol (ddb_tf_context_t *ctx, int argc, const uint16_t *arglens, const
     int len;
 
     char *p = out;
-    TF_EVAL_CHECK(len, ctx, args, arglens[0], out, outlen, fail_on_undef);
+    TF_EVAL_CHECK (len, ctx, args, arglens[0], out, outlen, fail_on_undef);
 
     char ind[TEMP_BUFFER_SIZE];
     int indlen = sizeof (ind);
     if (argc == 2) {
-        TF_EVAL_CHECK(indlen, ctx, args + arglens[0], arglens[1], ind, indlen - 1, fail_on_undef);
+        TF_EVAL_CHECK (indlen, ctx, args + arglens[0], arglens[1], ind, indlen - 1, fail_on_undef);
     }
     else {
         strcpy (ind, " (...)");
@@ -2407,7 +2942,7 @@ tf_func_fix_eol (ddb_tf_context_t *ctx, int argc, const uint16_t *arglens, const
 
     for (int n = 0; n < len; n++, p++) {
         if (*p == '\n') {
-            if (outlen-n < indlen) {
+            if (outlen - n < indlen) {
                 *out = 0;
                 return -1;
             }
@@ -2421,7 +2956,14 @@ tf_func_fix_eol (ddb_tf_context_t *ctx, int argc, const uint16_t *arglens, const
 }
 
 int
-tf_func_hex (ddb_tf_context_t *ctx, int argc, const uint16_t *arglens, const char *args, char *out, int outlen, int fail_on_undef) {
+tf_func_hex (
+    ddb_tf_context_t *ctx,
+    int argc,
+    const uint16_t *arglens,
+    const char *args,
+    char *out,
+    int outlen,
+    int fail_on_undef) {
     if (argc != 1 && argc != 2) {
         return -1;
     }
@@ -2430,13 +2972,13 @@ tf_func_hex (ddb_tf_context_t *ctx, int argc, const uint16_t *arglens, const cha
 
     int len;
 
-    TF_EVAL_CHECK(len, ctx, args, arglens[0], out, outlen, fail_on_undef);
+    TF_EVAL_CHECK (len, ctx, args, arglens[0], out, outlen, fail_on_undef);
     int num = atoi (out);
     int pad = 0;
     *out = 0;
 
     if (argc == 2) {
-        TF_EVAL_CHECK(len, ctx, args + arglens[0], arglens[1], out, outlen, fail_on_undef);
+        TF_EVAL_CHECK (len, ctx, args + arglens[0], arglens[1], out, outlen, fail_on_undef);
         if (!isdigit (*out)) {
             *out = 0;
             return -1;
@@ -2459,7 +3001,7 @@ tf_func_hex (ddb_tf_context_t *ctx, int argc, const uint16_t *arglens, const cha
     }
 
     if (pad > cnt) {
-        for (n = 0; n < pad-cnt; n++, p++) {
+        for (n = 0; n < pad - cnt; n++, p++) {
             *p = '0';
         }
     }
@@ -2479,7 +3021,14 @@ tf_func_hex (ddb_tf_context_t *ctx, int argc, const uint16_t *arglens, const cha
 }
 
 int
-tf_func_rgb (ddb_tf_context_t *ctx, int argc, const uint16_t *arglens, const char *args, char *out, int outlen, int fail_on_undef) {
+tf_func_rgb (
+    ddb_tf_context_t *ctx,
+    int argc,
+    const uint16_t *arglens,
+    const char *args,
+    char *out,
+    int outlen,
+    int fail_on_undef) {
     if (argc != 0 && argc != 3) {
         return -1;
     }
@@ -2494,13 +3043,14 @@ tf_func_rgb (ddb_tf_context_t *ctx, int argc, const uint16_t *arglens, const cha
     if (argc == 3) {
         int i;
         for (i = 0; i < 3; i++) {
-            TF_EVAL_CHECK(len, ctx, arg, arglens[i], out, outlen, fail_on_undef);
+            TF_EVAL_CHECK (len, ctx, arg, arglens[i], out, outlen, fail_on_undef);
             rgb[i] = atoi (out);
             *out = 0;
 
             arg += arglens[i];
         }
-    } else {
+    }
+    else {
         // Use -1 as use fg color marker
         rgb[0] = rgb[1] = rgb[2] = -1;
     }
@@ -2511,7 +3061,7 @@ tf_func_rgb (ddb_tf_context_t *ctx, int argc, const uint16_t *arglens, const cha
     if (ctx->flags & DDB_TF_CONTEXT_TEXT_DIM) {
         // rgb color esc sequence
         // `\e2;R;G;Bm`
-        snprintf (rgbseq, sizeof(rgbseq), "\033%d;%d;%d;%dm", DDB_TF_ESC_RGB, rgb[0], rgb[1], rgb[2]);
+        snprintf (rgbseq, sizeof (rgbseq), "\033%d;%d;%d;%dm", DDB_TF_ESC_RGB, rgb[0], rgb[1], rgb[2]);
         rgbseqlen = (int)strlen (rgbseq);
 
         if (rgbseqlen > outlen) {
@@ -2527,7 +3077,14 @@ tf_func_rgb (ddb_tf_context_t *ctx, int argc, const uint16_t *arglens, const cha
 }
 
 int
-tf_func_year (ddb_tf_context_t *ctx, int argc, const uint16_t *arglens, const char *args, char *out, int outlen, int fail_on_undef) {
+tf_func_year (
+    ddb_tf_context_t *ctx,
+    int argc,
+    const uint16_t *arglens,
+    const char *args,
+    char *out,
+    int outlen,
+    int fail_on_undef) {
     if (argc != 1) {
         return -1;
     }
@@ -2536,7 +3093,7 @@ tf_func_year (ddb_tf_context_t *ctx, int argc, const uint16_t *arglens, const ch
 
     int len;
     char temp_str[TEMP_BUFFER_SIZE];
-    TF_EVAL_CHECK(len, ctx, args, arglens[0], temp_str, sizeof (temp_str) - 1, fail_on_undef);
+    TF_EVAL_CHECK (len, ctx, args, arglens[0], temp_str, sizeof (temp_str) - 1, fail_on_undef);
 
     // Shorter than 4 characters? return nothing
     if (len < 4) {
@@ -2545,7 +3102,7 @@ tf_func_year (ddb_tf_context_t *ctx, int argc, const uint16_t *arglens, const ch
 
     // First 4 characters are digits? extract
     for (int i = 0; i < 4; i++) {
-        if (!isdigit(temp_str[i])) {
+        if (!isdigit (temp_str[i])) {
             return 0;
         }
     }
@@ -2555,7 +3112,14 @@ tf_func_year (ddb_tf_context_t *ctx, int argc, const uint16_t *arglens, const ch
 }
 
 int
-tf_func_itematindex (ddb_tf_context_t *ctx, int argc, const uint16_t *arglens, const char *args, char *out, int outlen, int fail_on_undef) {
+tf_func_itematindex (
+    ddb_tf_context_t *ctx,
+    int argc,
+    const uint16_t *arglens,
+    const char *args,
+    char *out,
+    int outlen,
+    int fail_on_undef) {
     if (argc != 2) {
         return -1;
     }
@@ -2564,13 +3128,13 @@ tf_func_itematindex (ddb_tf_context_t *ctx, int argc, const uint16_t *arglens, c
 
     int len;
     char temp_str[TEMP_BUFFER_SIZE];
-    TF_EVAL_CHECK(len, ctx, args, arglens[0], temp_str, sizeof (temp_str) - 1, fail_on_undef);
+    TF_EVAL_CHECK (len, ctx, args, arglens[0], temp_str, sizeof (temp_str) - 1, fail_on_undef);
 
     ddb_tf_context_int_t *priv = (ddb_tf_context_int_t *)ctx;
     priv->getting_item_at_index = 1;
-    priv->item_at_index = atoi(temp_str);
+    priv->item_at_index = atoi (temp_str);
 
-    TF_EVAL_CHECK(len, ctx, args+arglens[0], arglens[1], out, outlen, fail_on_undef);
+    TF_EVAL_CHECK (len, ctx, args + arglens[0], arglens[1], out, outlen, fail_on_undef);
 
     priv->getting_item_at_index = 0;
 
@@ -2580,7 +3144,7 @@ tf_func_itematindex (ddb_tf_context_t *ctx, int argc, const uint16_t *arglens, c
 // Variable operations
 
 static void
-_tf_var_init (ddb_tf_var_t *var, const char *key, const char *value){
+_tf_var_init (ddb_tf_var_t *var, const char *key, const char *value) {
     var->key = strdup (key);
     var->value = strdup (value);
 }
@@ -2611,13 +3175,13 @@ _tf_vars_set_value_for_key (ddb_tf_context_int_t *ctx, const char *key, const ch
         if (!u8_strcasecmp (key, cur->key)) {
             size_t len = strlen (value) + 1;
             cur->value = realloc (cur->value, len);
-            memcpy(cur->value, value, len);
+            memcpy (cur->value, value, len);
             return;
         }
         cur = cur->next;
     }
 
-    ddb_tf_var_t *out = calloc(1, sizeof (ddb_tf_var_t));
+    ddb_tf_var_t *out = calloc (1, sizeof (ddb_tf_var_t));
     out->next = ctx->vars;
     ctx->vars = out;
     _tf_var_init (out, key, value);
@@ -2635,7 +3199,14 @@ _tf_vars_free (ddb_tf_context_int_t *ctx) {
 }
 
 static int
-tf_func_get (ddb_tf_context_t *ctx, int argc, const uint16_t *arglens, const char *args, char *out, int outlen, int fail_on_undef) {
+tf_func_get (
+    ddb_tf_context_t *ctx,
+    int argc,
+    const uint16_t *arglens,
+    const char *args,
+    char *out,
+    int outlen,
+    int fail_on_undef) {
     if (argc != 1) {
         return -1;
     }
@@ -2644,7 +3215,7 @@ tf_func_get (ddb_tf_context_t *ctx, int argc, const uint16_t *arglens, const cha
 
     int len;
     char temp_key[TEMP_BUFFER_SIZE];
-    TF_EVAL_CHECK(len, ctx, args, arglens[0], temp_key, sizeof (temp_key) - 1, fail_on_undef);
+    TF_EVAL_CHECK (len, ctx, args, arglens[0], temp_key, sizeof (temp_key) - 1, fail_on_undef);
 
     const char *value = _tf_var_get_value_for_key ((ddb_tf_context_int_t *)ctx, temp_key);
     if (value == NULL) {
@@ -2657,7 +3228,15 @@ tf_func_get (ddb_tf_context_t *ctx, int argc, const uint16_t *arglens, const cha
 }
 
 static int
-_tf_func_put (ddb_tf_context_t *ctx, int argc, const uint16_t *arglens, const char *args, char *out, int outlen, int fail_on_undef, int should_return) {
+_tf_func_put (
+    ddb_tf_context_t *ctx,
+    int argc,
+    const uint16_t *arglens,
+    const char *args,
+    char *out,
+    int outlen,
+    int fail_on_undef,
+    int should_return) {
     if (argc != 2) {
         return -1;
     }
@@ -2667,111 +3246,126 @@ _tf_func_put (ddb_tf_context_t *ctx, int argc, const uint16_t *arglens, const ch
     int len;
     char temp_key[TEMP_BUFFER_SIZE];
     char temp_value[TEMP_BUFFER_SIZE];
-    TF_EVAL_CHECK(len, ctx, args,            arglens[0], temp_key,   sizeof (temp_key)   - 1, fail_on_undef);
-    TF_EVAL_CHECK(len, ctx, args+arglens[0], arglens[1], temp_value, sizeof (temp_value) - 1, fail_on_undef);
+    TF_EVAL_CHECK (len, ctx, args, arglens[0], temp_key, sizeof (temp_key) - 1, fail_on_undef);
+    TF_EVAL_CHECK (len, ctx, args + arglens[0], arglens[1], temp_value, sizeof (temp_value) - 1, fail_on_undef);
 
     _tf_vars_set_value_for_key ((ddb_tf_context_int_t *)ctx, temp_key, temp_value);
     if (should_return) {
         len = u8_strncpy (out, temp_value, outlen);
         return len;
-    } else {
+    }
+    else {
         return 0;
     }
 }
 
 static int
-tf_func_put (ddb_tf_context_t *ctx, int argc, const uint16_t *arglens, const char *args, char *out, int outlen, int fail_on_undef) {
+tf_func_put (
+    ddb_tf_context_t *ctx,
+    int argc,
+    const uint16_t *arglens,
+    const char *args,
+    char *out,
+    int outlen,
+    int fail_on_undef) {
     return _tf_func_put (ctx, argc, arglens, args, out, outlen, fail_on_undef, 1);
 }
 
 static int
-tf_func_puts (ddb_tf_context_t *ctx, int argc, const uint16_t *arglens, const char *args, char *out, int outlen, int fail_on_undef) {
+tf_func_puts (
+    ddb_tf_context_t *ctx,
+    int argc,
+    const uint16_t *arglens,
+    const char *args,
+    char *out,
+    int outlen,
+    int fail_on_undef) {
     return _tf_func_put (ctx, argc, arglens, args, out, outlen, fail_on_undef, 0);
 }
 
 tf_func_def tf_funcs[TF_MAX_FUNCS] = {
     // Control flow
-    { "if", tf_func_if },
-    { "if2", tf_func_if2 },
-    { "if3", tf_func_if3 },
-    { "ifequal", tf_func_ifequal },
-    { "ifgreater", tf_func_ifgreater },
-    { "iflonger", tf_func_iflonger },
-    { "select", tf_func_select },
+    { "if",             tf_func_if             },
+    { "if2",            tf_func_if2            },
+    { "if3",            tf_func_if3            },
+    { "ifequal",        tf_func_ifequal        },
+    { "ifgreater",      tf_func_ifgreater      },
+    { "iflonger",       tf_func_iflonger       },
+    { "select",         tf_func_select         },
     // Arithmetic
-    { "add", tf_func_add },
-    { "div", tf_func_div },
-    { "greater", tf_func_greater },
-    { "max", tf_func_max },
-    { "min", tf_func_min },
-    { "mod", tf_func_mod },
-    { "mul", tf_func_mul },
-    { "muldiv", tf_func_muldiv },
-    { "rand", tf_func_rand },
-    { "sub", tf_func_sub },
+    { "add",            tf_func_add            },
+    { "div",            tf_func_div            },
+    { "greater",        tf_func_greater        },
+    { "max",            tf_func_max            },
+    { "min",            tf_func_min            },
+    { "mod",            tf_func_mod            },
+    { "mul",            tf_func_mul            },
+    { "muldiv",         tf_func_muldiv         },
+    { "rand",           tf_func_rand           },
+    { "sub",            tf_func_sub            },
     // Boolean
-    { "and", tf_func_and },
-    { "or", tf_func_or },
-    { "not", tf_func_not },
-    { "xor", tf_func_xor },
+    { "and",            tf_func_and            },
+    { "or",             tf_func_or             },
+    { "not",            tf_func_not            },
+    { "xor",            tf_func_xor            },
     // String
-    { "abbr", tf_func_abbr },
-    { "ansi", tf_func_ansi },
-    { "ascii", tf_func_ascii },
-    { "caps", tf_func_caps },
-    { "caps2", tf_func_caps2 },
-    { "char", tf_func_char },
-    { "crc32", tf_func_crc32 },
-    { "crlf", tf_func_crlf },
-    { "cut", tf_func_left },
-    { "directory", tf_func_directory },
+    { "abbr",           tf_func_abbr           },
+    { "ansi",           tf_func_ansi           },
+    { "ascii",          tf_func_ascii          },
+    { "caps",           tf_func_caps           },
+    { "caps2",          tf_func_caps2          },
+    { "char",           tf_func_char           },
+    { "crc32",          tf_func_crc32          },
+    { "crlf",           tf_func_crlf           },
+    { "cut",            tf_func_left           },
+    { "directory",      tf_func_directory      },
     { "directory_path", tf_func_directory_path },
-    { "ext", tf_func_ext },
-    { "filename", tf_func_filename },
-    { "fix_eol", tf_func_fix_eol },
-    { "hex", tf_func_hex },
-    { "insert", tf_func_insert },
-    { "left", tf_func_left }, // alias of 'cut'
-    { "len", tf_func_len },
-    { "len2", tf_func_len2 },
-    { "longer", tf_func_longer },
-    { "longest", tf_func_longest },
-    { "lower", tf_func_lower },
-    { "num", tf_func_num },
-    { "pad", tf_func_pad },
-    { "pad_right", tf_func_pad_right },
-    { "padcut", tf_func_padcut },
-    { "padcut_right", tf_func_padcut_right },
-    { "progress", tf_func_progress },
-    { "progress2", tf_func_progress2 },
-    { "repeat", tf_func_repeat },
-    { "replace", tf_func_replace },
-    { "right", tf_func_right },
-    { "roman", tf_func_roman },
-    { "rot13", tf_func_rot13 },
-    { "shortest", tf_func_shortest },
-    { "strchr", tf_func_strchr },
-    { "strcmp", tf_func_strcmp },
-    { "stricmp", tf_func_stricmp },
-    { "stripprefix", tf_func_stripprefix },
-    { "strrchr", tf_func_strrchr },
-    { "strstr", tf_func_strstr },
-    { "substr", tf_func_substr },
-    { "swapprefix", tf_func_swapprefix },
-    { "tab", tf_func_tab },
-    { "trim", tf_func_trim },
-    { "upper", tf_func_upper },
+    { "ext",            tf_func_ext            },
+    { "filename",       tf_func_filename       },
+    { "fix_eol",        tf_func_fix_eol        },
+    { "hex",            tf_func_hex            },
+    { "insert",         tf_func_insert         },
+    { "left",           tf_func_left           }, // alias of 'cut'
+    { "len",            tf_func_len            },
+    { "len2",           tf_func_len2           },
+    { "longer",         tf_func_longer         },
+    { "longest",        tf_func_longest        },
+    { "lower",          tf_func_lower          },
+    { "num",            tf_func_num            },
+    { "pad",            tf_func_pad            },
+    { "pad_right",      tf_func_pad_right      },
+    { "padcut",         tf_func_padcut         },
+    { "padcut_right",   tf_func_padcut_right   },
+    { "progress",       tf_func_progress       },
+    { "progress2",      tf_func_progress2      },
+    { "repeat",         tf_func_repeat         },
+    { "replace",        tf_func_replace        },
+    { "right",          tf_func_right          },
+    { "roman",          tf_func_roman          },
+    { "rot13",          tf_func_rot13          },
+    { "shortest",       tf_func_shortest       },
+    { "strchr",         tf_func_strchr         },
+    { "strcmp",         tf_func_strcmp         },
+    { "stricmp",        tf_func_stricmp        },
+    { "stripprefix",    tf_func_stripprefix    },
+    { "strrchr",        tf_func_strrchr        },
+    { "strstr",         tf_func_strstr         },
+    { "substr",         tf_func_substr         },
+    { "swapprefix",     tf_func_swapprefix     },
+    { "tab",            tf_func_tab            },
+    { "trim",           tf_func_trim           },
+    { "upper",          tf_func_upper          },
     // Track info
-    { "meta", tf_func_meta },
-    { "channels", tf_func_channels },
-    { "rgb", tf_func_rgb },
-    { "year", tf_func_year },
-    { "itematindex", tf_func_itematindex },
+    { "meta",           tf_func_meta           },
+    { "channels",       tf_func_channels       },
+    { "rgb",            tf_func_rgb            },
+    { "year",           tf_func_year           },
+    { "itematindex",    tf_func_itematindex    },
     // Variable operations
-    { "get", tf_func_get },
-    { "put", tf_func_put },
-    { "puts", tf_func_puts },
-    { NULL, NULL }
+    { "get",            tf_func_get            },
+    { "put",            tf_func_put            },
+    { "puts",           tf_func_puts           },
+    { NULL,             NULL                   }
 };
 
 static const char *
@@ -2786,13 +3380,13 @@ _tf_get_combined_value (playItem_t *it, const char *key, int *needs_free, int it
     size_t len = 0;
 
     const char *value = meta->value;
-    const char *end = meta->value +meta->valuesize;
+    const char *end = meta->value + meta->valuesize;
 
     // calculate size or return single value
     while (value < end) {
         size_t l = strlen (value);
 
-        if (l+1 == meta->valuesize) {
+        if (l + 1 == meta->valuesize) {
             *needs_free = 0;
             return meta->value;
         }
@@ -2807,7 +3401,7 @@ _tf_get_combined_value (playItem_t *it, const char *key, int *needs_free, int it
     char *p = out;
 
     value = meta->value;
-    end = meta->value +meta->valuesize;
+    end = meta->value + meta->valuesize;
 
     int index = 0;
 
@@ -2834,7 +3428,7 @@ _tf_get_combined_value (playItem_t *it, const char *key, int *needs_free, int it
 
 static int
 format_playback_time (char *out, int outlen, float t) {
-    int daystotal = (int)t / (3600*24);
+    int daystotal = (int)t / (3600 * 24);
     int hourtotal = ((int)t / 3600) % 24;
     int mintotal = ((int)t / 60) % 60;
     int sectotal = ((int)t) % 60;
@@ -2844,10 +3438,10 @@ format_playback_time (char *out, int outlen, float t) {
         len = snprintf_clip (out, outlen, "%d:%02d:%02d", hourtotal, mintotal, sectotal);
     }
     else if (daystotal == 1) {
-        len = snprintf_clip (out, outlen, _("1 day %d:%02d:%02d"), hourtotal, mintotal, sectotal);
+        len = snprintf_clip (out, outlen, _ ("1 day %d:%02d:%02d"), hourtotal, mintotal, sectotal);
     }
     else {
-        len = snprintf_clip (out, outlen, _("%d days %d:%02d:%02d"), daystotal, hourtotal, mintotal, sectotal);
+        len = snprintf_clip (out, outlen, _ ("%d days %d:%02d:%02d"), daystotal, hourtotal, mintotal, sectotal);
     }
 
     return len;
@@ -2859,7 +3453,14 @@ format_playback_time (char *out, int outlen, float t) {
  *          which is always written on nonnegative return
  */
 static int
-tf_eval_int (ddb_tf_context_t *ctx, const char *code, int size, char *out, int outlen, int *bool_out, int fail_on_undef) {
+tf_eval_int (
+    ddb_tf_context_t *ctx,
+    const char *code,
+    int size,
+    char *out,
+    int outlen,
+    int *bool_out,
+    int fail_on_undef) {
     playItem_t *it = (playItem_t *)ctx->it;
     char *init_out = out;
     *bool_out = 0;
@@ -2895,9 +3496,10 @@ tf_eval_int (ddb_tf_context_t *ctx, const char *code, int size, char *out, int o
                 if (numargs) {
                     // copy arg lengths, to make sure they're aligned
                     arglens = alloca (numargs * sizeof (uint16_t));
-                    memcpy (arglens, code+1, numargs * sizeof (uint16_t));
+                    memcpy (arglens, code + 1, numargs * sizeof (uint16_t));
                 };
-                int res = func (ctx, numargs, arglens, code+1+numargs*sizeof (uint16_t), out, outlen, fail_on_undef);
+                int res =
+                    func (ctx, numargs, arglens, code + 1 + numargs * sizeof (uint16_t), out, outlen, fail_on_undef);
                 if (res == -1) {
                     return -1;
                 }
@@ -2912,7 +3514,7 @@ tf_eval_int (ddb_tf_context_t *ctx, const char *code, int size, char *out, int o
                 out += res;
                 outlen -= res;
 
-                int blocksize = 1 + numargs*2;
+                int blocksize = 1 + numargs * 2;
                 for (int i = 0; i < numargs; i++) {
                     blocksize += arglens[i];
                 }
@@ -2927,7 +3529,7 @@ tf_eval_int (ddb_tf_context_t *ctx, const char *code, int size, char *out, int o
                 code++;
                 size--;
 
-                char name[len+1];
+                char name[len + 1];
                 memcpy (name, code, len);
                 name[len] = 0;
 
@@ -2940,16 +3542,17 @@ tf_eval_int (ddb_tf_context_t *ctx, const char *code, int size, char *out, int o
 
                 int pl_locked = 0;
 
-                if (!(ctx->flags&DDB_TF_CONTEXT_NO_MUTEX_LOCK)
-                    && !(ctx->flags&TF_INTERNAL_FLAG_LOCKED)) {
+                if (!(ctx->flags & DDB_TF_CONTEXT_NO_MUTEX_LOCK) && !(ctx->flags & TF_INTERNAL_FLAG_LOCKED)) {
                     pl_lock ();
                     ctx->flags |= TF_INTERNAL_FLAG_LOCKED;
                     pl_locked = 1;
                 }
                 const char *val = NULL;
                 int needs_free = 0;
-                const char *aa_fields[] = { "album artist", "albumartist", "band", "artist", "composer", "performer", NULL };
-                const char *a_fields[] = { "artist", "album artist", "albumartist", "band", "composer", "performer", NULL };
+                const char *aa_fields[] = { "album artist", "albumartist", "band", "artist",
+                                            "composer",     "performer",   NULL };
+                const char *a_fields[] = { "artist",   "album artist", "albumartist", "band",
+                                           "composer", "performer",    NULL };
                 const char *alb_fields[] = { "album", "venue", NULL };
 
                 // set to 1 if special case handler successfully wrote the output
@@ -2957,15 +3560,15 @@ tf_eval_int (ddb_tf_context_t *ctx, const char *code, int size, char *out, int o
 
                 // temp vars used for strcmp optimizations
                 int tmp_a = 0, tmp_b = 0, tmp_c = 0, tmp_d = 0, tmp_e = 0;
-                int item_index = tf_item_index_for_context(ctx);
+                int item_index = tf_item_index_for_context (ctx);
                 if (!strcmp (name, aa_fields[0])) {
                     for (int i = 0; !val && aa_fields[i]; i++) {
-                        val = _tf_get_combined_value(it, aa_fields[i], &needs_free, item_index);
+                        val = _tf_get_combined_value (it, aa_fields[i], &needs_free, item_index);
                     }
                 }
                 else if (!strcmp (name, a_fields[0])) {
                     for (int i = 0; !val && a_fields[i]; i++) {
-                        val = _tf_get_combined_value(it, a_fields[i], &needs_free, item_index);
+                        val = _tf_get_combined_value (it, a_fields[i], &needs_free, item_index);
                     }
                 }
                 else if (!strcmp (name, "album")) {
@@ -2997,8 +3600,8 @@ tf_eval_int (ddb_tf_context_t *ctx, const char *code, int size, char *out, int o
                             }
                             p++;
                         }
-                        if (p > v && *p == 0 && p-v == 1) {
-                            int l = snprintf_clip (out, outlen, "%02d", atoi(v));
+                        if (p > v && *p == 0 && p - v == 1) {
+                            int l = snprintf_clip (out, outlen, "%02d", atoi (v));
                             out += l;
                             outlen -= l;
                             skip_out = 1;
@@ -3022,11 +3625,11 @@ tf_eval_int (ddb_tf_context_t *ctx, const char *code, int size, char *out, int o
                             }
                             const char *startcol = strrchr (v, ':');
                             if (startcol > start) {
-                                start = startcol+1;
+                                start = startcol + 1;
                             }
                             const char *end = strrchr (start, '.');
                             if (end) {
-                                int n = (int)(end-start);
+                                int n = (int)(end - start);
                                 n = min (n, outlen);
                                 n = u8_strnbcpy (out, start, n);
                                 outlen -= n;
@@ -3057,13 +3660,13 @@ tf_eval_int (ddb_tf_context_t *ctx, const char *code, int size, char *out, int o
                 }
                 else if (!strcmp (name, "playback_bitrate")) {
                     if (ctx->flags & TF_INTERNAL_FLAG_LOCKED) {
-                        pl_unlock();
+                        pl_unlock ();
                     }
 
-                    playItem_t *playing_track = streamer_get_playing_track();
+                    playItem_t *playing_track = streamer_get_playing_track ();
 
                     if (playing_track) {
-                        int br = streamer_get_apx_bitrate();
+                        int br = streamer_get_apx_bitrate ();
                         if (br >= 0) {
                             int l = snprintf_clip (out, outlen, "%d", br);
                             out += l;
@@ -3087,12 +3690,12 @@ tf_eval_int (ddb_tf_context_t *ctx, const char *code, int size, char *out, int o
                     if (v) {
                         int64_t bs = atoll (v);
                         int l;
-                        if (bs >= 1024*1024*1024) {
-                            double gb = (double)bs / (double)(1024*1024*1024);
+                        if (bs >= 1024 * 1024 * 1024) {
+                            double gb = (double)bs / (double)(1024 * 1024 * 1024);
                             l = snprintf_clip (out, outlen, "%.3lf GB", gb);
                         }
-                        else if (bs >= 1024*1024) {
-                            double mb = (double)bs / (double)(1024*1024);
+                        else if (bs >= 1024 * 1024) {
+                            double mb = (double)bs / (double)(1024 * 1024);
                             l = snprintf_clip (out, outlen, "%.3lf MB", mb);
                         }
                         else if (bs >= 1024) {
@@ -3125,9 +3728,13 @@ tf_eval_int (ddb_tf_context_t *ctx, const char *code, int size, char *out, int o
                 else if (!strcmp (name, "replaygain_track_peak")) {
                     val = pl_find_meta_raw (it, ":REPLAYGAIN_TRACKPEAK");
                 }
-                else if ((tmp_a = !strcmp (name, "playback_time")) || (tmp_b = !strcmp (name, "playback_time_seconds")) || (tmp_c = !strcmp (name, "playback_time_remaining")) || (tmp_d = !strcmp (name, "playback_time_remaining_seconds")) || (tmp_e = !strcmp (name, "playback_time_ms"))) {
+                else if (
+                    (tmp_a = !strcmp (name, "playback_time")) || (tmp_b = !strcmp (name, "playback_time_seconds")) ||
+                    (tmp_c = !strcmp (name, "playback_time_remaining")) ||
+                    (tmp_d = !strcmp (name, "playback_time_remaining_seconds")) ||
+                    (tmp_e = !strcmp (name, "playback_time_ms"))) {
                     if (ctx->flags & TF_INTERNAL_FLAG_LOCKED) {
-                        pl_unlock();
+                        pl_unlock ();
                     }
                     playItem_t *playing = streamer_get_playing_track ();
                     if (it && playing == it && !(ctx->flags & DDB_TF_CONTEXT_NO_DYNAMIC)) {
@@ -3139,18 +3746,19 @@ tf_eval_int (ddb_tf_context_t *ctx, const char *code, int size, char *out, int o
                         if (t >= 0) {
                             int l = 0;
                             if (tmp_a || tmp_c || tmp_e) {
-                                int hr = (int)(t/3600);
-                                int mn = (int)((t-hr*3600)/60);
-                                int sc = (int)(t-hr*3600-mn*60);
+                                int hr = (int)(t / 3600);
+                                int mn = (int)((t - hr * 3600) / 60);
+                                int sc = (int)(t - hr * 3600 - mn * 60);
                                 if (tmp_e) {
-                                    int ms = (int)((t-hr*3600-mn*60-sc)*1000);
+                                    int ms = (int)((t - hr * 3600 - mn * 60 - sc) * 1000);
                                     if (hr) {
                                         l = snprintf_clip (out, outlen, "%d:%02d:%02d.%03d", hr, mn, sc, ms);
                                     }
                                     else {
                                         l = snprintf_clip (out, outlen, "%d:%02d.%03d", mn, sc, ms);
                                     }
-                                } else {
+                                }
+                                else {
                                     if (hr) {
                                         l = snprintf_clip (out, outlen, "%d:%02d:%02d", hr, mn, sc);
                                     }
@@ -3175,9 +3783,8 @@ tf_eval_int (ddb_tf_context_t *ctx, const char *code, int size, char *out, int o
                         pl_item_unref (playing);
                     }
                     if (ctx->flags & TF_INTERNAL_FLAG_LOCKED) {
-                        pl_lock();
+                        pl_lock ();
                     }
-
                 }
                 else if ((tmp_a = !strcmp (name, "length")) || (tmp_b = !strcmp (name, "length_ex"))) {
                     float t = pl_get_item_duration (it);
@@ -3185,13 +3792,13 @@ tf_eval_int (ddb_tf_context_t *ctx, const char *code, int size, char *out, int o
                         t = roundf (t);
                     }
                     else if (tmp_b) {
-                        t = roundf(t * 1000) / 1000.f;
+                        t = roundf (t * 1000) / 1000.f;
                     }
                     if (t >= 0) {
-                        int hr = (int)(t/3600);
-                        int mn = (int)((t-hr*3600)/60);
-                        int sc = (int)(tmp_a ? t-hr*3600-mn*60 : t-hr*3600-mn*60);
-                        int ms = (int)(tmp_b ? (t-hr*3600-mn*60-sc) * 1000.f : 0);
+                        int hr = (int)(t / 3600);
+                        int mn = (int)((t - hr * 3600) / 60);
+                        int sc = (int)(tmp_a ? t - hr * 3600 - mn * 60 : t - hr * 3600 - mn * 60);
+                        int ms = (int)(tmp_b ? (t - hr * 3600 - mn * 60 - sc) * 1000.f : 0);
                         int l = 0;
                         if (tmp_a) {
                             if (hr) {
@@ -3219,7 +3826,7 @@ tf_eval_int (ddb_tf_context_t *ctx, const char *code, int size, char *out, int o
                     if (t >= 0) {
                         int l;
                         if (tmp_a) {
-                            l = snprintf_clip (out, outlen, "%d", (int)roundf(t));
+                            l = snprintf_clip (out, outlen, "%d", (int)roundf (t));
                         }
                         else {
                             l = snprintf_clip (out, outlen, "%0.3f", t);
@@ -3230,19 +3837,24 @@ tf_eval_int (ddb_tf_context_t *ctx, const char *code, int size, char *out, int o
                     }
                 }
                 else if (!strcmp (name, "length_samples")) {
-                    int l = snprintf_clip (out, outlen, "%lld", pl_item_get_endsample ((playItem_t *)ctx->it) - pl_item_get_startsample ((playItem_t *)ctx->it));
+                    int l = snprintf_clip (
+                        out,
+                        outlen,
+                        "%lld",
+                        pl_item_get_endsample ((playItem_t *)ctx->it) -
+                            pl_item_get_startsample ((playItem_t *)ctx->it));
                     out += l;
                     outlen -= l;
                     skip_out = 1;
                 }
                 else if (!strcmp (name, "isplaying")) {
                     if (ctx->flags & TF_INTERNAL_FLAG_LOCKED) {
-                        pl_unlock();
+                        pl_unlock ();
                     }
 
                     playItem_t *playing = streamer_get_playing_track ();
                     if (ctx->flags & TF_INTERNAL_FLAG_LOCKED) {
-                        pl_lock();
+                        pl_lock ();
                     }
 
                     if (playing != NULL && ctx->it == (ddb_playItem_t *)playing) {
@@ -3256,14 +3868,15 @@ tf_eval_int (ddb_tf_context_t *ctx, const char *code, int size, char *out, int o
                 }
                 else if (!strcmp (name, "ispaused")) {
                     if (ctx->flags & TF_INTERNAL_FLAG_LOCKED) {
-                        pl_unlock();
+                        pl_unlock ();
                     }
                     playItem_t *playing = streamer_get_playing_track ();
                     if (ctx->flags & TF_INTERNAL_FLAG_LOCKED) {
-                        pl_lock();
+                        pl_lock ();
                     }
 
-                    if (playing != NULL && ctx->it == (ddb_playItem_t *)playing && plug_get_output ()->state () == DDB_PLAYBACK_STATE_PAUSED) {
+                    if (playing != NULL && ctx->it == (ddb_playItem_t *)playing &&
+                        plug_get_output ()->state () == DDB_PLAYBACK_STATE_PAUSED) {
                         *out++ = '1';
                         outlen--;
                         skip_out = 1;
@@ -3284,7 +3897,7 @@ tf_eval_int (ddb_tf_context_t *ctx, const char *code, int size, char *out, int o
                         }
                         const char *end = strrchr (start, '.');
                         if (end) {
-                            tf_append_out(&out, &outlen, start, (int)(end-start));
+                            tf_append_out (&out, &outlen, start, (int)(end - start));
                             skip_out = 1;
                         }
                     }
@@ -3314,7 +3927,7 @@ tf_eval_int (ddb_tf_context_t *ctx, const char *code, int size, char *out, int o
                             }
                             if (start && start != end) {
                                 start++;
-                                tf_append_out(&out, &outlen, start, (int)(end-start));
+                                tf_append_out (&out, &outlen, start, (int)(end - start));
                                 skip_out = 1;
                             }
                         }
@@ -3329,8 +3942,8 @@ tf_eval_int (ddb_tf_context_t *ctx, const char *code, int size, char *out, int o
                         struct stat sb;
                         struct tm localtm;
                         char mtime[20];
-                        if (!stat (v, &sb) && localtime_r (&sb.st_mtime, &localtm) != NULL
-                                && strftime (mtime, sizeof(mtime), "%F %T", &localtm)) {
+                        if (!stat (v, &sb) && localtime_r (&sb.st_mtime, &localtm) != NULL &&
+                            strftime (mtime, sizeof (mtime), "%F %T", &localtm)) {
                             tf_append_out (&out, &outlen, mtime, (int)strlen (mtime));
                             skip_out = 1;
                         }
@@ -3340,19 +3953,19 @@ tf_eval_int (ddb_tf_context_t *ctx, const char *code, int size, char *out, int o
                     const char *v = pl_find_meta_raw (it, ":URI");
 
                     if (v) {
-                        #ifdef _WIN32
+#ifdef _WIN32
                         int is_absolute = (isalpha (v[0]) && v[1] == ':' && v[2] == '/');
-                        #else
+#else
                         int is_absolute = (v[0] == '/');
-                        #endif
+#endif
 
                         if (is_absolute) {
-                            // This is an absolute path, just prepend proper prefix
-                            #ifdef _WIN32
+// This is an absolute path, just prepend proper prefix
+#ifdef _WIN32
                             const char prefix[] = "file:///";
-                            #else
+#else
                             const char prefix[] = "file://";
-                            #endif
+#endif
                             tf_append_out (&out, &outlen, prefix, sizeof (prefix) - 1);
                             tf_append_out (&out, &outlen, v, (int)strlen (v));
                         }
@@ -3505,7 +4118,7 @@ tf_eval_int (ddb_tf_context_t *ctx, const char *code, int size, char *out, int o
                     val = ((playlist_t *)ctx->plt)->title;
                 }
                 else if (!strcmp (name, "selection_playback_time")) {
-                    float seltime = plt_get_selection_playback_time((playlist_t *)ctx->plt);
+                    float seltime = plt_get_selection_playback_time ((playlist_t *)ctx->plt);
 
                     int l = format_playback_time (out, outlen, seltime);
 
@@ -3526,7 +4139,7 @@ tf_eval_int (ddb_tf_context_t *ctx, const char *code, int size, char *out, int o
                     int32_t l = u8_strnbcpy (out, val, outlen);
 
                     if (ctx->metadata_transformer != NULL && outlen > 0) {
-                        ctx->metadata_transformer(ctx, out, l);
+                        ctx->metadata_transformer (ctx, out, l);
                     }
 
                     out += l;
@@ -3576,7 +4189,7 @@ tf_eval_int (ddb_tf_context_t *ctx, const char *code, int size, char *out, int o
                 memcpy (&len, code, 4);
                 code += 4;
                 size -= 4;
-                int32_t l = u8_strnbcpy(out, code, len);
+                int32_t l = u8_strnbcpy (out, code, len);
                 out += l;
                 outlen -= l;
                 code += len;
@@ -3599,8 +4212,8 @@ tf_eval_int (ddb_tf_context_t *ctx, const char *code, int size, char *out, int o
                 if (ctx->flags & DDB_TF_CONTEXT_TEXT_DIM) {
                     // text dimming esc sequence
                     // `\eX,Ym` where X and Y are numbers, which can be negative
-                    snprintf (dim, sizeof(dim), "\033%d;%dm", DDB_TF_ESC_DIM, (int)amount);
-                    snprintf (undim, sizeof(undim), "\033%d;%dm", DDB_TF_ESC_DIM, -(int)amount);
+                    snprintf (dim, sizeof (dim), "\033%d;%dm", DDB_TF_ESC_DIM, (int)amount);
+                    snprintf (undim, sizeof (undim), "\033%d;%dm", DDB_TF_ESC_DIM, -(int)amount);
                     dimlen = (int)strlen (dim);
                     undimlen = (int)strlen (undim);
 
@@ -3650,7 +4263,7 @@ tf_eval_int (ddb_tf_context_t *ctx, const char *code, int size, char *out, int o
         return -1;
     }
 
-    return (int)(out-init_out);
+    return (int)(out - init_out);
 }
 
 int
@@ -3688,8 +4301,8 @@ tf_compile_func (tf_compiler_t *c) {
     }
 
     char func_name[c->i - name_start + 1];
-    memcpy (func_name, name_start, c->i-name_start);
-    func_name[c->i-name_start] = 0;
+    memcpy (func_name, name_start, c->i - name_start);
+    func_name[c->i - name_start] = 0;
 
     c->i++;
 
@@ -3710,17 +4323,17 @@ tf_compile_func (tf_compiler_t *c) {
             if (len == 0 && *(c->i) == ')' && (*start) == 0) {
                 break;
             }
-            assert(len<=0xffff);
+            assert (len <= 0xffff);
 
             // expand arg lengths buffer by 1
             int num_args = *start;
 
-            memmove (arglens+num_args+1, arglens+num_args, c->o - start - num_args*sizeof(uint16_t));
+            memmove (arglens + num_args + 1, arglens + num_args, c->o - start - num_args * sizeof (uint16_t));
             c->o += 2;
             // store arg length
             // FIXME: `arglens` comes in a byte stream without 16 bit alignment, this may cause unaligned access and crash.
             uint16_t len16 = (uint16_t)len;
-            memcpy(&arglens[*start], &len16, sizeof (uint16_t));
+            memcpy (&arglens[*start], &len16, sizeof (uint16_t));
             (*start)++; // num args++
             argstart = c->o;
 
@@ -3769,7 +4382,7 @@ tf_compile_field (tf_compiler_t *c) {
     }
     *plen = (char)len;
 
-    char field[len+1];
+    char field[len + 1];
     memcpy (field, fstart, len);
     field[len] = 0;
     return 0;
@@ -3809,7 +4422,7 @@ tf_compile_ifdef (tf_compiler_t *c) {
     int32_t len = (int32_t)(c->o - plen - 4);
     memcpy (plen, &len, 4);
 
-    char value[len+1];
+    char value[len + 1];
     memcpy (value, start, len);
     value[len] = 0;
     return 0;
@@ -3848,7 +4461,7 @@ tf_compile_text_dim (tf_compiler_t *c) {
         else if (*(c->i) == marker) {
             int cnt = 0;
             while (*(c->i) && *(c->i) == marker && cnt < count) {
-                cnt ++;
+                cnt++;
                 c->i++;
             }
             if (cnt != count) {
@@ -3870,7 +4483,7 @@ tf_compile_text_dim (tf_compiler_t *c) {
     int32_t len = (int32_t)(c->o - plen - 4);
     memcpy (plen, &len, 4);
 
-    char value[len+1];
+    char value[len + 1];
     memcpy (value, start, len);
     value[len] = 0;
     return 0;
@@ -3957,11 +4570,11 @@ tf_compile (const char *script) {
 
     c.i = script;
 
-    size_t len = strlen(script);
+    size_t len = strlen (script);
     if (len == 0) {
-        return calloc(1,4);
+        return calloc (1, 4);
     }
-    uint8_t *code = calloc(len * 3, 1);
+    uint8_t *code = calloc (len * 3, 1);
 
     c.o = code;
 
@@ -4044,18 +4657,26 @@ tf_import_legacy (const char *fmt, char *out, int outsize) {
                 while (*e && *e != '@') {
                     e++;
                 }
-#define APPEND(x) {size_t size = strlen (x); if (size >= outsize-1) break; memcpy (out, x, size); out += size; outsize -= size;}
+#define APPEND(x)                 \
+    {                             \
+        size_t size = strlen (x); \
+        if (size >= outsize - 1)  \
+            break;                \
+        memcpy (out, x, size);    \
+        out += size;              \
+        outsize -= size;          \
+    }
                 if (*e == '@') {
                     char nm[100];
-                    size_t l = e-fmt-1;
-                    l = min (l, sizeof (nm)-3);
-                    strncpy (nm+1, fmt+1, l);
-                    nm[l+2] = 0;
+                    size_t l = e - fmt - 1;
+                    l = min (l, sizeof (nm) - 3);
+                    strncpy (nm + 1, fmt + 1, l);
+                    nm[l + 2] = 0;
                     nm[0] = '%';
-                    nm[l+1] = '%';
+                    nm[l + 1] = '%';
 
                     APPEND (nm);
-                    fmt = e+1;
+                    fmt = e + 1;
                 }
                 continue;
             }

--- a/src/threading.h
+++ b/src/threading.h
@@ -34,10 +34,10 @@ extern "C" {
 #endif
 
 intptr_t
-thread_start (void (*fn)(void *ctx), void *ctx);
+thread_start (void (*fn) (void *ctx), void *ctx);
 
 intptr_t
-thread_start_low_priority (void (*fn)(void *ctx), void *ctx);
+thread_start_low_priority (void (*fn) (void *ctx), void *ctx);
 
 int
 thread_join (intptr_t tid);
@@ -83,4 +83,3 @@ cond_broadcast (uintptr_t cond);
 #endif
 
 #endif
-

--- a/src/threading_pthread.c
+++ b/src/threading_pthread.c
@@ -31,11 +31,11 @@
 #include <string.h>
 #include "threading.h"
 #ifdef HAVE_CONFIG_H
-#include <config.h>
+#    include <config.h>
 #endif
 
 intptr_t
-thread_start (void (*fn)(void *ctx), void *ctx) {
+thread_start (void (*fn) (void *ctx), void *ctx) {
     pthread_t tid;
     pthread_attr_t attr;
     int s = pthread_attr_init (&attr);
@@ -44,7 +44,7 @@ thread_start (void (*fn)(void *ctx), void *ctx) {
         return 0;
     }
 
-    s = pthread_create (&tid, &attr, (void *(*)(void *))fn, (void*)ctx);
+    s = pthread_create (&tid, &attr, (void *(*)(void *))fn, (void *)ctx);
     if (s != 0) {
         fprintf (stderr, "pthread_create failed: %s\n", strerror (s));
         return 0;
@@ -58,7 +58,7 @@ thread_start (void (*fn)(void *ctx), void *ctx) {
 }
 
 intptr_t
-thread_start_low_priority (void (*fn)(void *ctx), void *ctx) {
+thread_start_low_priority (void (*fn) (void *ctx), void *ctx) {
 #if defined(__linux__) && !defined(ANDROID)
     pthread_t tid;
     pthread_attr_t attr;
@@ -67,7 +67,7 @@ thread_start_low_priority (void (*fn)(void *ctx), void *ctx) {
         fprintf (stderr, "pthread_attr_init failed: %s\n", strerror (s));
         return 0;
     }
-#if !STATICLINK && __GLIBC__ >= 2 && __GLIBC_MINOR__ >= 4
+#    if !STATICLINK && __GLIBC__ >= 2 && __GLIBC_MINOR__ >= 4
     int policy;
     s = pthread_attr_getschedpolicy (&attr, &policy);
     if (s != 0) {
@@ -75,21 +75,21 @@ thread_start_low_priority (void (*fn)(void *ctx), void *ctx) {
         return 0;
     }
     int minprio = sched_get_priority_min (policy);
-#endif
+#    endif
 
-    s = pthread_create (&tid, &attr, (void *(*)(void *))fn, (void*)ctx);
+    s = pthread_create (&tid, &attr, (void *(*)(void *))fn, (void *)ctx);
     if (s != 0) {
         fprintf (stderr, "pthread_create failed: %s\n", strerror (s));
         return 0;
     }
-#if !STATICLINK && __GLIBC__ >= 2 && __GLIBC_MINOR__ >= 4
+#    if !STATICLINK && __GLIBC__ >= 2 && __GLIBC_MINOR__ >= 4
     s = pthread_setschedprio (tid, minprio);
     if (s != 0) {
         fprintf (stderr, "pthread_setschedprio failed: %s\n", strerror (s));
         pthread_cancel (tid);
         return 0;
     }
-#endif
+#    endif
 
     s = pthread_attr_destroy (&attr);
     if (s != 0) {
@@ -132,7 +132,7 @@ thread_exit (void *retval) {
 uintptr_t
 mutex_create_nonrecursive (void) {
     pthread_mutex_t *mtx = malloc (sizeof (pthread_mutex_t));
-    pthread_mutexattr_t attr = {0};
+    pthread_mutexattr_t attr = { 0 };
     pthread_mutexattr_init (&attr);
     pthread_mutexattr_settype (&attr, PTHREAD_MUTEX_NORMAL);
     int err = pthread_mutex_init (mtx, &attr);
@@ -148,7 +148,7 @@ mutex_create_nonrecursive (void) {
 uintptr_t
 mutex_create (void) {
     pthread_mutex_t *mtx = malloc (sizeof (pthread_mutex_t));
-    pthread_mutexattr_t attr = {0};
+    pthread_mutexattr_t attr = { 0 };
     pthread_mutexattr_init (&attr);
     pthread_mutexattr_settype (&attr, PTHREAD_MUTEX_RECURSIVE);
     int err = pthread_mutex_init (mtx, &attr);

--- a/src/utf8.c
+++ b/src/utf8.c
@@ -31,10 +31,10 @@
     placed in the public domain Fall 2005
 */
 #ifdef HAVE_CONFIG_H
-#  include "config.h"
+#    include "config.h"
 #endif
 #ifdef HAVE_ALLOCA_H
-#  include <alloca.h>
+#    include <alloca.h>
 #endif
 #include <stdlib.h>
 #include <stdio.h>
@@ -46,20 +46,17 @@
 #include "u8_lc_map.h"
 #include "u8_uc_map.h"
 
-static const uint32_t offsetsFromUTF8[6] = {
-    0x00000000UL, 0x00003080UL, 0x000E2080UL,
-    0x03C82080UL, 0xFA082080UL, 0x82082080UL
-};
+static const uint32_t offsetsFromUTF8[6] = { 0x00000000UL, 0x00003080UL, 0x000E2080UL,
+                                             0x03C82080UL, 0xFA082080UL, 0x82082080UL };
 
 static const char trailingBytesForUTF8[256] = {
-    0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0, 0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,
-    0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0, 0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,
-    0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0, 0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,
-    0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0, 0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,
-    0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0, 0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,
-    0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0, 0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,
-    1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1, 1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,
-    2,2,2,2,2,2,2,2,2,2,2,2,2,2,2,2, 3,3,3,3,3,3,3,3,4,4,4,4,5,5,5,5
+    0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+    0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+    0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+    0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+    0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+    0, 0, 0, 0, 0, 0, 0, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1,
+    1, 1, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 3, 3, 3, 3, 3, 3, 3, 3, 4, 4, 4, 4, 5, 5, 5, 5
 };
 
 /* conversions without error checking
@@ -72,14 +69,14 @@ static const char trailingBytesForUTF8[256] = {
    for all the characters.
    if sz = srcsz+1 (i.e. 4*srcsz+4 bytes), there will always be enough space.
 */
-int u8_toucs(uint32_t *dest, int32_t sz, const char *src, int32_t srcsz)
-{
+int
+u8_toucs (uint32_t *dest, int32_t sz, const char *src, int32_t srcsz) {
     uint32_t ch;
     const char *src_end = src + srcsz;
     int32_t nb;
-    int32_t i=0;
+    int32_t i = 0;
 
-    while (i < sz-1) {
+    while (i < sz - 1) {
         nb = trailingBytesForUTF8[(unsigned char)*src];
         if (srcsz == -1) {
             if (*src == 0)
@@ -92,15 +89,22 @@ int u8_toucs(uint32_t *dest, int32_t sz, const char *src, int32_t srcsz)
         ch = 0;
         switch (nb) {
             /* these fall through deliberately */
-        case 3: ch += (unsigned char)*src++; ch <<= 6;
-        case 2: ch += (unsigned char)*src++; ch <<= 6;
-        case 1: ch += (unsigned char)*src++; ch <<= 6;
-        case 0: ch += (unsigned char)*src++;
+        case 3:
+            ch += (unsigned char)*src++;
+            ch <<= 6;
+        case 2:
+            ch += (unsigned char)*src++;
+            ch <<= 6;
+        case 1:
+            ch += (unsigned char)*src++;
+            ch <<= 6;
+        case 0:
+            ch += (unsigned char)*src++;
         }
         ch -= offsetsFromUTF8[nb];
         dest[i++] = ch;
     }
- done_toucs:
+done_toucs:
     dest[i] = 0;
     return i;
 }
@@ -117,13 +121,13 @@ int u8_toucs(uint32_t *dest, int32_t sz, const char *src, int32_t srcsz)
    the NUL as well.
    the destination string will never be bigger than the source string.
 */
-int u8_toutf8(char *dest, int32_t sz, const uint32_t *src, int32_t srcsz)
-{
+int
+u8_toutf8 (char *dest, int32_t sz, const uint32_t *src, int32_t srcsz) {
     uint32_t ch;
     int32_t i = 0;
     char *dest_end = dest + sz;
 
-    while (srcsz<0 ? src[i]!=0 : i < srcsz) {
+    while (srcsz < 0 ? src[i] != 0 : i < srcsz) {
         ch = src[i];
         if (ch < 0x80) {
             if (dest >= dest_end)
@@ -131,24 +135,24 @@ int u8_toutf8(char *dest, int32_t sz, const uint32_t *src, int32_t srcsz)
             *dest++ = (char)ch;
         }
         else if (ch < 0x800) {
-            if (dest >= dest_end-1)
+            if (dest >= dest_end - 1)
                 return i;
-            *dest++ = (char)((ch>>6) | 0xC0);
+            *dest++ = (char)((ch >> 6) | 0xC0);
             *dest++ = (ch & 0x3F) | 0x80;
         }
         else if (ch < 0x10000) {
-            if (dest >= dest_end-2)
+            if (dest >= dest_end - 2)
                 return i;
-            *dest++ = (char)((ch>>12) | 0xE0);
-            *dest++ = ((ch>>6) & 0x3F) | 0x80;
+            *dest++ = (char)((ch >> 12) | 0xE0);
+            *dest++ = ((ch >> 6) & 0x3F) | 0x80;
             *dest++ = (ch & 0x3F) | 0x80;
         }
         else if (ch < 0x200000) {
-            if (dest >= dest_end-3)
+            if (dest >= dest_end - 3)
                 return i;
-            *dest++ = (char)((ch>>18) | 0xF0);
-            *dest++ = ((ch>>12) & 0x3F) | 0x80;
-            *dest++ = ((ch>>6) & 0x3F) | 0x80;
+            *dest++ = (char)((ch >> 18) | 0xF0);
+            *dest++ = ((ch >> 12) & 0x3F) | 0x80;
+            *dest++ = ((ch >> 6) & 0x3F) | 0x80;
             *dest++ = (ch & 0x3F) | 0x80;
         }
         i++;
@@ -158,27 +162,27 @@ int u8_toutf8(char *dest, int32_t sz, const uint32_t *src, int32_t srcsz)
     return i;
 }
 
-int u8_wc_toutf8(char *dest, uint32_t ch)
-{
+int
+u8_wc_toutf8 (char *dest, uint32_t ch) {
     if (ch < 0x80) {
         dest[0] = (char)ch;
         return 1;
     }
     if (ch < 0x800) {
-        dest[0] = (char)((ch>>6) | 0xC0);
+        dest[0] = (char)((ch >> 6) | 0xC0);
         dest[1] = (ch & 0x3F) | 0x80;
         return 2;
     }
     if (ch < 0x10000) {
-        dest[0] = (char)((ch>>12) | 0xE0);
-        dest[1] = ((ch>>6) & 0x3F) | 0x80;
+        dest[0] = (char)((ch >> 12) | 0xE0);
+        dest[1] = ((ch >> 6) & 0x3F) | 0x80;
         dest[2] = (ch & 0x3F) | 0x80;
         return 3;
     }
     if (ch < 0x200000) {
-        dest[0] = (char)((ch>>18) | 0xF0);
-        dest[1] = ((ch>>12) & 0x3F) | 0x80;
-        dest[2] = ((ch>>6) & 0x3F) | 0x80;
+        dest[0] = (char)((ch >> 18) | 0xF0);
+        dest[1] = ((ch >> 12) & 0x3F) | 0x80;
+        dest[2] = ((ch >> 6) & 0x3F) | 0x80;
         dest[3] = (ch & 0x3F) | 0x80;
         return 4;
     }
@@ -186,38 +190,36 @@ int u8_wc_toutf8(char *dest, uint32_t ch)
 }
 
 /* charnum => byte offset */
-int u8_offset(const char *str, int32_t charnum)
-{
-    int32_t offs=0;
+int
+u8_offset (const char *str, int32_t charnum) {
+    int32_t offs = 0;
 
     while (charnum > 0 && str[offs]) {
-        (void)(isutf(str[++offs]) || isutf(str[++offs]) ||
-               isutf(str[++offs]) || ++offs);
+        (void)(isutf (str[++offs]) || isutf (str[++offs]) || isutf (str[++offs]) || ++offs);
         charnum--;
     }
     return offs;
 }
 
 /* byte offset => charnum */
-int u8_charnum(const char *s, int32_t offset)
-{
-    int32_t charnum = 0, offs=0;
+int
+u8_charnum (const char *s, int32_t offset) {
+    int32_t charnum = 0, offs = 0;
 
     while (offs < offset && s[offs]) {
-        (void)(isutf(s[++offs]) || isutf(s[++offs]) ||
-               isutf(s[++offs]) || ++offs);
+        (void)(isutf (s[++offs]) || isutf (s[++offs]) || isutf (s[++offs]) || ++offs);
         charnum++;
     }
     return charnum;
 }
 
 /* number of characters, not including a null terminator */
-int u8_strlen(const char *s)
-{
+int
+u8_strlen (const char *s) {
     int32_t count = 0;
     int32_t i = 0;
 
-    while (s[i] && u8_nextchar(s, &i) != 0)
+    while (s[i] && u8_nextchar (s, &i) != 0)
         count++;
 
     return count;
@@ -225,8 +227,8 @@ int u8_strlen(const char *s)
 
 /* reads the next utf-8 sequence out of a string, updating an index */
 // NOTE: a valid UTF8 sequence is expected, no validity or 0 checks are performed.
-uint32_t u8_nextchar(const char *s, int32_t *i)
-{
+uint32_t
+u8_nextchar (const char *s, int32_t *i) {
     uint32_t ch = 0;
     int32_t sz = 0;
 
@@ -234,16 +236,16 @@ uint32_t u8_nextchar(const char *s, int32_t *i)
         ch <<= 6;
         ch += (unsigned char)s[(*i)++];
         sz++;
-    } while (s[*i] && !isutf(s[*i]));
-    ch -= offsetsFromUTF8[sz-1];
+    } while (s[*i] && !isutf (s[*i]));
+    ch -= offsetsFromUTF8[sz - 1];
 
     return ch;
 }
 
 /* copies num_chars characters from src to dest, return bytes written */
 /* returns the number of bytes copied, not counting a null terminator, which is always written */
-int u8_strncpy (char *dest, const char* src, int num_chars)
-{
+int
+u8_strncpy (char *dest, const char *src, int num_chars) {
     const char *s = src;
     int32_t num_bytes = 0;
     while (num_chars && *s) {
@@ -260,7 +262,8 @@ int u8_strncpy (char *dest, const char* src, int num_chars)
 
 /* copies as many characters from src as would not exceed num_bytes in the destination */
 /* returns the number of bytes copied, not counting a null terminator, which is not written */
-int u8_strnbcpy (char *dest, const char* src, int num_bytes) {
+int
+u8_strnbcpy (char *dest, const char *src, int num_bytes) {
     int32_t prev_index = 0;
     int32_t index = 0;
     int32_t nb = num_bytes;
@@ -280,7 +283,8 @@ int u8_strnbcpy (char *dest, const char* src, int num_bytes) {
 
 /* copies a character from src to dest provided it does not exceed num_bytes */
 /* returns the number of bytes copied, not counting a null terminator, which is not written */
-int u8_charcpy (char *dest, const char *src, int num_bytes) {
+int
+u8_charcpy (char *dest, const char *src, int num_bytes) {
     int32_t index = 0;
     u8_inc (src, &index);
     if (index > num_bytes) {
@@ -290,39 +294,35 @@ int u8_charcpy (char *dest, const char *src, int num_bytes) {
     return index;
 }
 
-void u8_inc(const char *s, int32_t *i)
-{
-    (void)(isutf(s[++(*i)]) || isutf(s[++(*i)]) ||
-           isutf(s[++(*i)]) || ++(*i));
+void
+u8_inc (const char *s, int32_t *i) {
+    (void)(isutf (s[++(*i)]) || isutf (s[++(*i)]) || isutf (s[++(*i)]) || ++(*i));
 }
 
-void u8_dec(const char *s, int32_t *i)
-{
-    (void)(isutf(s[--(*i)]) || isutf(s[--(*i)]) ||
-           isutf(s[--(*i)]) || --(*i));
+void
+u8_dec (const char *s, int32_t *i) {
+    (void)(isutf (s[--(*i)]) || isutf (s[--(*i)]) || isutf (s[--(*i)]) || --(*i));
 }
 
-int octal_digit(char c)
-{
+int
+octal_digit (char c) {
     return (c >= '0' && c <= '7');
 }
 
-int hex_digit(char c)
-{
-    return ((c >= '0' && c <= '9') ||
-            (c >= 'A' && c <= 'F') ||
-            (c >= 'a' && c <= 'f'));
+int
+hex_digit (char c) {
+    return ((c >= '0' && c <= '9') || (c >= 'A' && c <= 'F') || (c >= 'a' && c <= 'f'));
 }
 
 /* assumes that src points to the character after a backslash
    returns number of input characters processed */
-int u8_read_escape_sequence(const char *str, uint32_t *dest)
-{
+int
+u8_read_escape_sequence (const char *str, uint32_t *dest) {
     long ch;
-    char digs[]="\0\0\0\0\0\0\0\0\0";
-    int32_t dno=0, i=1;
+    char digs[] = "\0\0\0\0\0\0\0\0\0";
+    int32_t dno = 0, i = 1;
 
-    ch = (uint32_t)str[0];    /* take literal character */
+    ch = (uint32_t)str[0]; /* take literal character */
     if (str[0] == 'n')
         ch = L'\n';
     else if (str[0] == 't')
@@ -337,33 +337,33 @@ int u8_read_escape_sequence(const char *str, uint32_t *dest)
         ch = L'\v';
     else if (str[0] == 'a')
         ch = L'\a';
-    else if (octal_digit(str[0])) {
+    else if (octal_digit (str[0])) {
         i = 0;
         do {
             digs[dno++] = str[i++];
-        } while (octal_digit(str[i]) && dno < 3);
-        ch = strtol(digs, NULL, 8);
+        } while (octal_digit (str[i]) && dno < 3);
+        ch = strtol (digs, NULL, 8);
     }
     else if (str[0] == 'x') {
-        while (hex_digit(str[i]) && dno < 2) {
+        while (hex_digit (str[i]) && dno < 2) {
             digs[dno++] = str[i++];
         }
         if (dno > 0)
-            ch = strtol(digs, NULL, 16);
+            ch = strtol (digs, NULL, 16);
     }
     else if (str[0] == 'u') {
-        while (hex_digit(str[i]) && dno < 4) {
+        while (hex_digit (str[i]) && dno < 4) {
             digs[dno++] = str[i++];
         }
         if (dno > 0)
-            ch = strtol(digs, NULL, 16);
+            ch = strtol (digs, NULL, 16);
     }
     else if (str[0] == 'U') {
-        while (hex_digit(str[i]) && dno < 8) {
+        while (hex_digit (str[i]) && dno < 8) {
             digs[dno++] = str[i++];
         }
         if (dno > 0)
-            ch = strtol(digs, NULL, 16);
+            ch = strtol (digs, NULL, 16);
     }
     *dest = (uint32_t)ch;
 
@@ -373,26 +373,26 @@ int u8_read_escape_sequence(const char *str, uint32_t *dest)
 // convert a string with literal \uxxxx or \Uxxxxxxxx characters to UTF-8
 // example: u8_unescape(mybuf, 256, "hello\\u220e")
 // note the double backslash is needed if called on a C string literal
-int u8_unescape(char *buf, int32_t sz, const char *src)
-{
-    int32_t c=0, amt;
+int
+u8_unescape (char *buf, int32_t sz, const char *src) {
+    int32_t c = 0, amt;
     uint32_t ch;
     char temp[4];
 
     while (*src && c < sz) {
         if (*src == '\\') {
             src++;
-            amt = u8_read_escape_sequence(src, &ch);
+            amt = u8_read_escape_sequence (src, &ch);
         }
         else {
             ch = (uint32_t)*src;
             amt = 1;
         }
         src += amt;
-        amt = u8_wc_toutf8(temp, ch);
-        if (amt > sz-c)
+        amt = u8_wc_toutf8 (temp, ch);
+        if (amt > sz - c)
             break;
-        memcpy(&buf[c], temp, amt);
+        memcpy (&buf[c], temp, amt);
         c += amt;
     }
     if (c < sz)
@@ -400,45 +400,45 @@ int u8_unescape(char *buf, int32_t sz, const char *src)
     return c;
 }
 
-int u8_escape_wchar(char *buf, int32_t sz, uint32_t ch)
-{
+int
+u8_escape_wchar (char *buf, int32_t sz, uint32_t ch) {
     if (ch == L'\n')
-        return snprintf(buf, sz, "\\n");
+        return snprintf (buf, sz, "\\n");
     else if (ch == L'\t')
-        return snprintf(buf, sz, "\\t");
+        return snprintf (buf, sz, "\\t");
     else if (ch == L'\r')
-        return snprintf(buf, sz, "\\r");
+        return snprintf (buf, sz, "\\r");
     else if (ch == L'\b')
-        return snprintf(buf, sz, "\\b");
+        return snprintf (buf, sz, "\\b");
     else if (ch == L'\f')
-        return snprintf(buf, sz, "\\f");
+        return snprintf (buf, sz, "\\f");
     else if (ch == L'\v')
-        return snprintf(buf, sz, "\\v");
+        return snprintf (buf, sz, "\\v");
     else if (ch == L'\a')
-        return snprintf(buf, sz, "\\a");
+        return snprintf (buf, sz, "\\a");
     else if (ch == L'\\')
-        return snprintf(buf, sz, "\\\\");
+        return snprintf (buf, sz, "\\\\");
     else if (ch < 32 || ch == 0x7f)
-        return snprintf(buf, sz, "\\x%hhX", (unsigned char)ch);
+        return snprintf (buf, sz, "\\x%hhX", (unsigned char)ch);
     else if (ch > 0xFFFF)
-        return snprintf(buf, sz, "\\U%.8X", (uint32_t)ch);
+        return snprintf (buf, sz, "\\U%.8X", (uint32_t)ch);
     else if (ch >= 0x80 && ch <= 0xFFFF)
-        return snprintf(buf, sz, "\\u%.4hX", (unsigned short)ch);
+        return snprintf (buf, sz, "\\u%.4hX", (unsigned short)ch);
 
-    return snprintf(buf, sz, "%c", (char)ch);
+    return snprintf (buf, sz, "%c", (char)ch);
 }
 
-int u8_escape(char *buf, int32_t sz, const char *src, int32_t escape_quotes)
-{
-    int32_t c=0, i=0, amt;
+int
+u8_escape (char *buf, int32_t sz, const char *src, int32_t escape_quotes) {
+    int32_t c = 0, i = 0, amt;
 
     while (src[i] && c < sz) {
         if (escape_quotes && src[i] == '"') {
-            amt = snprintf(buf, sz - c, "\\\"");
+            amt = snprintf (buf, sz - c, "\\\"");
             i++;
         }
         else {
-            amt = u8_escape_wchar(buf, sz - c, u8_nextchar(src, &i));
+            amt = u8_escape_wchar (buf, sz - c, u8_nextchar (src, &i));
         }
         c += amt;
         buf += amt;
@@ -448,14 +448,14 @@ int u8_escape(char *buf, int32_t sz, const char *src, int32_t escape_quotes)
     return c;
 }
 
-const char *u8_strchr(const char *s, uint32_t ch, int32_t *charn)
-{
-    int32_t i = 0, lasti=0;
+const char *
+u8_strchr (const char *s, uint32_t ch, int32_t *charn) {
+    int32_t i = 0, lasti = 0;
     uint32_t c;
 
     *charn = 0;
     while (s[i]) {
-        c = u8_nextchar(s, &i);
+        c = u8_nextchar (s, &i);
         if (c == ch) {
             return &s[lasti];
         }
@@ -465,9 +465,9 @@ const char *u8_strchr(const char *s, uint32_t ch, int32_t *charn)
     return NULL;
 }
 
-const char *u8_memchr(const char *s, uint32_t ch, size_t sz, int32_t *charn)
-{
-    int32_t i = 0, lasti=0;
+const char *
+u8_memchr (const char *s, uint32_t ch, size_t sz, int32_t *charn) {
+    int32_t i = 0, lasti = 0;
     uint32_t c;
     int32_t csz;
 
@@ -478,8 +478,8 @@ const char *u8_memchr(const char *s, uint32_t ch, size_t sz, int32_t *charn)
             c <<= 6;
             c += (unsigned char)s[i++];
             csz++;
-        } while (i < sz && !isutf(s[i]));
-        c -= offsetsFromUTF8[csz-1];
+        } while (i < sz && !isutf (s[i]));
+        c -= offsetsFromUTF8[csz - 1];
 
         if (c == ch) {
             return &s[lasti];
@@ -490,18 +490,18 @@ const char *u8_memchr(const char *s, uint32_t ch, size_t sz, int32_t *charn)
     return NULL;
 }
 
-int u8_is_locale_utf8(const char *locale)
-{
+int
+u8_is_locale_utf8 (const char *locale) {
     /* this code based on libutf8 */
-    const char* cp = locale;
+    const char *cp = locale;
 
     for (; *cp != '\0' && *cp != '@' && *cp != '+' && *cp != ','; cp++) {
         if (*cp == '.') {
-            const char* encoding = ++cp;
+            const char *encoding = ++cp;
             for (; *cp != '\0' && *cp != '@' && *cp != '+' && *cp != ','; cp++)
                 ;
-            if ((cp-encoding == 5 && !strncmp(encoding, "UTF-8", 5))
-                || (cp-encoding == 4 && !strncmp(encoding, "utf8", 4)))
+            if ((cp - encoding == 5 && !strncmp (encoding, "UTF-8", 5)) ||
+                (cp - encoding == 4 && !strncmp (encoding, "utf8", 4)))
                 return 1; /* it's UTF-8 */
             break;
         }
@@ -509,108 +509,92 @@ int u8_is_locale_utf8(const char *locale)
     return 0;
 }
 
-int u8_vprintf(const char *fmt, va_list ap)
-{
-    int32_t cnt, sz=0;
+int
+u8_vprintf (const char *fmt, va_list ap) {
+    int32_t cnt, sz = 0;
     char *buf;
     uint32_t *wcs;
 
     sz = 512;
-    buf = (char*)alloca(sz);
- try_print:
-    cnt = vsnprintf(buf, sz, fmt, ap);
+    buf = (char *)alloca (sz);
+try_print:
+    cnt = vsnprintf (buf, sz, fmt, ap);
     if (cnt >= sz) {
-        buf = (char*)alloca(cnt - sz + 1);
+        buf = (char *)alloca (cnt - sz + 1);
         sz = cnt + 1;
         goto try_print;
     }
-    wcs = (uint32_t*)alloca((cnt+1) * sizeof(uint32_t));
-    cnt = u8_toucs(wcs, cnt+1, buf, cnt);
-    printf("%ls", (wchar_t*)wcs);
+    wcs = (uint32_t *)alloca ((cnt + 1) * sizeof (uint32_t));
+    cnt = u8_toucs (wcs, cnt + 1, buf, cnt);
+    printf ("%ls", (wchar_t *)wcs);
     return cnt;
 }
 
-int u8_printf(const char *fmt, ...)
-{
+int
+u8_printf (const char *fmt, ...) {
     int32_t cnt;
     va_list args;
 
-    va_start(args, fmt);
+    va_start (args, fmt);
 
-    cnt = u8_vprintf(fmt, args);
+    cnt = u8_vprintf (fmt, args);
 
-    va_end(args);
+    va_end (args);
     return cnt;
 }
 
 // adaptation of g_utf8_validate
 
-#define UTF8_COMPUTE(Char, Mask, Len)                                         \
-  if (Char < 128)                                                             \
-    {                                                                         \
-      Len = 1;                                                                \
-      Mask = 0x7f;                                                            \
-    }                                                                         \
-  else if ((Char & 0xe0) == 0xc0)                                             \
-    {                                                                         \
-      Len = 2;                                                                \
-      Mask = 0x1f;                                                            \
-    }                                                                         \
-  else if ((Char & 0xf0) == 0xe0)                                             \
-    {                                                                         \
-      Len = 3;                                                                \
-      Mask = 0x0f;                                                            \
-    }                                                                         \
-  else if ((Char & 0xf8) == 0xf0)                                             \
-    {                                                                         \
-      Len = 4;                                                                \
-      Mask = 0x07;                                                            \
-    }                                                                         \
-  else if ((Char & 0xfc) == 0xf8)                                             \
-    {                                                                         \
-      Len = 5;                                                                \
-      Mask = 0x03;                                                            \
-    }                                                                         \
-  else if ((Char & 0xfe) == 0xfc)                                             \
-    {                                                                         \
-      Len = 6;                                                                \
-      Mask = 0x01;                                                            \
-    }                                                                         \
-  else                                                                        \
-    Len = -1;
+#define UTF8_COMPUTE(Char, Mask, Len) \
+    if (Char < 128) {                 \
+        Len = 1;                      \
+        Mask = 0x7f;                  \
+    }                                 \
+    else if ((Char & 0xe0) == 0xc0) { \
+        Len = 2;                      \
+        Mask = 0x1f;                  \
+    }                                 \
+    else if ((Char & 0xf0) == 0xe0) { \
+        Len = 3;                      \
+        Mask = 0x0f;                  \
+    }                                 \
+    else if ((Char & 0xf8) == 0xf0) { \
+        Len = 4;                      \
+        Mask = 0x07;                  \
+    }                                 \
+    else if ((Char & 0xfc) == 0xf8) { \
+        Len = 5;                      \
+        Mask = 0x03;                  \
+    }                                 \
+    else if ((Char & 0xfe) == 0xfc) { \
+        Len = 6;                      \
+        Mask = 0x01;                  \
+    }                                 \
+    else                              \
+        Len = -1;
 
-#define UTF8_LENGTH(Char)              \
-  ((Char) < 0x80 ? 1 :                 \
-   ((Char) < 0x800 ? 2 :               \
-    ((Char) < 0x10000 ? 3 :            \
-     ((Char) < 0x200000 ? 4 :          \
-      ((Char) < 0x4000000 ? 5 : 6)))))
+#define UTF8_LENGTH(Char) \
+    ((Char) < 0x80        \
+         ? 1              \
+         : ((Char) < 0x800 ? 2 : ((Char) < 0x10000 ? 3 : ((Char) < 0x200000 ? 4 : ((Char) < 0x4000000 ? 5 : 6)))))
 
-
-#define UTF8_GET(Result, Chars, Count, Mask, Len)                             \
-  (Result) = (Chars)[0] & (Mask);                                             \
-  for ((Count) = 1; (Count) < (Len); ++(Count))                               \
-    {                                                                         \
-      if (((Chars)[(Count)] & 0xc0) != 0x80)                                  \
-        {                                                                     \
-          (Result) = -1;                                                      \
-          break;                                                              \
-        }                                                                     \
-      (Result) <<= 6;                                                         \
-      (Result) |= ((Chars)[(Count)] & 0x3f);                                  \
+#define UTF8_GET(Result, Chars, Count, Mask, Len)   \
+    (Result) = (Chars)[0] & (Mask);                 \
+    for ((Count) = 1; (Count) < (Len); ++(Count)) { \
+        if (((Chars)[(Count)] & 0xc0) != 0x80) {    \
+            (Result) = -1;                          \
+            break;                                  \
+        }                                           \
+        (Result) <<= 6;                             \
+        (Result) |= ((Chars)[(Count)] & 0x3f);      \
     }
 
-#define UNICODE_VALID(Char)                   \
-    ((Char) < 0x110000 &&                     \
-     (((Char) & 0xFFFFF800) != 0xD800) &&     \
-     ((Char) < 0xFDD0 || (Char) > 0xFDEF) &&  \
+#define UNICODE_VALID(Char)                                                                            \
+    ((Char) < 0x110000 && (((Char) & 0xFFFFF800) != 0xD800) && ((Char) < 0xFDD0 || (Char) > 0xFDEF) && \
      ((Char) & 0xFFFE) != 0xFFFE)
 
-
-int u8_valid (const char  *str,
-        int max_len,
-        const char **end)
-{
+int
+u8_valid (const char *str, int max_len, const char **end) {
 
     const char *p;
 
@@ -623,11 +607,10 @@ int u8_valid (const char  *str,
 
     p = str;
 
-    while ((max_len < 0 || (p - str) < max_len) && *p)
-    {
+    while ((max_len < 0 || (p - str) < max_len) && *p) {
         int i, mask = 0, len;
         int32_t result;
-        unsigned char c = (unsigned char) *p;
+        unsigned char c = (unsigned char)*p;
 
         UTF8_COMPUTE (c, mask, len);
 
@@ -635,8 +618,7 @@ int u8_valid (const char  *str,
             break;
 
         /* check that the expected number of bytes exists in str */
-        if (max_len >= 0 &&
-                ((max_len - (p - str)) < len))
+        if (max_len >= 0 && ((max_len - (p - str)) < len))
             break;
 
         UTF8_GET (result, p, i, mask, len);
@@ -786,7 +768,7 @@ utfcasestr (const char *s1, const char *s2) {
     return NULL;
 }
 
-#define min(x,y) ((x)<(y)?(x):(y))
+#define min(x, y) ((x) < (y) ? (x) : (y))
 // s2 must be lowercase
 const char *
 utfcasestr_fast (const char *s1, const char *s2) {
@@ -800,7 +782,7 @@ utfcasestr_fast (const char *s1, const char *s2) {
             u8_nextchar (p1, &i1);
             u8_nextchar (p2, &i2);
             int l1 = u8_tolower ((const signed char *)p1, i1, lw1);
-            if (memcmp (lw1, p2, min(i2,l1))) {
+            if (memcmp (lw1, p2, min (i2, l1))) {
                 break;
             }
             p1 += i1;
@@ -829,7 +811,7 @@ u8_strcasecmp (const char *a, const char *b) {
         int l2 = u8_tolower ((const signed char *)p2, i2, s2);
         int res = 0;
         if (l1 != l2) {
-            res = l1-l2;
+            res = l1 - l2;
         }
         else {
             res = memcmp (s1, s2, l1);

--- a/src/utf8.h
+++ b/src/utf8.h
@@ -38,90 +38,112 @@
 #include <stdarg.h>
 
 /* is c the start of a utf8 sequence? */
-#define isutf(c) (((c)&0xC0)!=0x80)
+#define isutf(c) (((c) & 0xC0) != 0x80)
 
 /* convert UTF-8 data to wide character */
-int u8_toucs(uint32_t *dest, int32_t sz, const char *src, int32_t srcsz);
+int
+u8_toucs (uint32_t *dest, int32_t sz, const char *src, int32_t srcsz);
 
 /* the opposite conversion */
-int u8_toutf8(char *dest, int32_t sz, const uint32_t *src, int32_t srcsz);
+int
+u8_toutf8 (char *dest, int32_t sz, const uint32_t *src, int32_t srcsz);
 
 /* single character to UTF-8 */
-int u8_wc_toutf8(char *dest, uint32_t ch);
+int
+u8_wc_toutf8 (char *dest, uint32_t ch);
 
 /* character number to byte offset */
-int u8_offset(const char *str, int32_t charnum);
+int
+u8_offset (const char *str, int32_t charnum);
 
 /* byte offset to character number */
-int u8_charnum(const char *s, int32_t offset);
+int
+u8_charnum (const char *s, int32_t offset);
 
 /* return next character, updating an index variable */
-uint32_t u8_nextchar(const char *s, int32_t *i);
+uint32_t
+u8_nextchar (const char *s, int32_t *i);
 
 /* copies num_chars characters from src to dest, return bytes written */
-int u8_strncpy (char *dest, const char* src, int num_chars);
+int
+u8_strncpy (char *dest, const char *src, int num_chars);
 
 /* copy num_bytes maximum bytes from src to dest, but always stop at the last possible utf8 character boundary;
  return number of bytes copied
  */
-int u8_strnbcpy (char *dest, const char* src, int num_bytes);
+int
+u8_strnbcpy (char *dest, const char *src, int num_bytes);
 
 /* copy single utf8 character of up to num_bytes bytes large, only if num_bytes is large enough;
   return number of bytes copied
  */
-int u8_charcpy (char *dest, const char *src, int num_bytes);
+int
+u8_charcpy (char *dest, const char *src, int num_bytes);
 
 /* move to next character */
-void u8_inc(const char *s, int32_t *i);
+void
+u8_inc (const char *s, int32_t *i);
 
 /* move to previous character */
-void u8_dec(const char *s, int32_t *i);
+void
+u8_dec (const char *s, int32_t *i);
 
 /* assuming src points to the character after a backslash, read an
    escape sequence, storing the result in dest and returning the number of
    input characters processed */
-int u8_read_escape_sequence(const char *src, uint32_t *dest);
+int
+u8_read_escape_sequence (const char *src, uint32_t *dest);
 
 /* given a wide character, convert it to an ASCII escape sequence stored in
    buf, where buf is "sz" bytes. returns the number of characters output. */
-int u8_escape_wchar(char *buf, int32_t sz, uint32_t ch);
+int
+u8_escape_wchar (char *buf, int32_t sz, uint32_t ch);
 
 /* convert a string "src" containing escape sequences to UTF-8 */
-int u8_unescape(char *buf, int32_t sz, const char *src);
+int
+u8_unescape (char *buf, int32_t sz, const char *src);
 
 /* convert UTF-8 "src" to ASCII with escape sequences.
    if escape_quotes is nonzero, quote characters will be preceded by
    backslashes as well. */
-int u8_escape(char *buf, int32_t sz, const char *src, int32_t escape_quotes);
+int
+u8_escape (char *buf, int32_t sz, const char *src, int32_t escape_quotes);
 
 /* utility predicates used by the above */
-int octal_digit(char c);
-int hex_digit(char c);
+int
+octal_digit (char c);
+int
+hex_digit (char c);
 
 /* return a pointer to the first occurrence of ch in s, or NULL if not
    found. character index of found character returned in *charn. */
-const char *u8_strchr(const char *s, uint32_t ch, int32_t *charn);
+const char *
+u8_strchr (const char *s, uint32_t ch, int32_t *charn);
 
 /* same as the above, but searches a buffer of a given size instead of
    a NUL-terminated string. */
-const char *u8_memchr(const char *s, uint32_t ch, size_t sz, int32_t *charn);
+const char *
+u8_memchr (const char *s, uint32_t ch, size_t sz, int32_t *charn);
 
 /* count the number of characters in a UTF-8 string */
-int u8_strlen(const char *s);
+int
+u8_strlen (const char *s);
 
-int u8_is_locale_utf8(const char *locale);
+int
+u8_is_locale_utf8 (const char *locale);
 
 /* printf where the format string and arguments may be in UTF-8.
    you can avoid this function and just use ordinary printf() if the current
    locale is UTF-8. */
-int u8_vprintf(const char *fmt, va_list ap);
-int u8_printf(const char *fmt, ...);
+int
+u8_vprintf (const char *fmt, va_list ap);
+int
+u8_printf (const char *fmt, ...);
 
 // validate utf8 string
 // returns 1 if valid, 0 otherwise
-int u8_valid (const char  *str,
-        int max_len,
-        const char **end);
+int
+u8_valid (const char *str, int max_len, const char **end);
 
 int
 u8_tolower (const signed char *c, int l, char *out);

--- a/src/vfs.c
+++ b/src/vfs.c
@@ -30,7 +30,7 @@
 #include "plugins.h"
 
 //#define trace(...) { fprintf(stderr, __VA_ARGS__); }
-#define trace(fmt,...)
+#define trace(fmt, ...)
 
 #if defined(HAVE_XGUI)
 extern int android_use_only_wifi;
@@ -96,7 +96,8 @@ vfs_fopen (const char *fname) {
     return NULL;
 }
 
-void vfs_set_track (DB_FILE *stream, DB_playItem_t *it) {
+void
+vfs_set_track (DB_FILE *stream, DB_playItem_t *it) {
     if (stream->vfs->set_track) {
         stream->vfs->set_track (stream, it);
     }

--- a/src/vfs.h
+++ b/src/vfs.h
@@ -34,18 +34,30 @@
 extern "C" {
 #endif
 
-DB_FILE* vfs_fopen (const char *fname);
-void vfs_set_track (DB_FILE *stream, DB_playItem_t *it);
-void vfs_fclose (DB_FILE *f);
-size_t vfs_fread (void *ptr, size_t size, size_t nmemb, DB_FILE *stream);
-int vfs_fseek (DB_FILE *stream, int64_t offset, int whence);
-int64_t vfs_ftell (DB_FILE *stream);
-void vfs_rewind (DB_FILE *stream);
-int64_t vfs_fgetlength (DB_FILE *stream);
-const char *vfs_get_content_type (DB_FILE *stream);
-void vfs_fabort (DB_FILE *stream);
-uint64_t vfs_get_identifier (DB_FILE *stream);
-void vfs_abort_with_identifier (DB_vfs_t *vfs, uint64_t identifier);
+DB_FILE *
+vfs_fopen (const char *fname);
+void
+vfs_set_track (DB_FILE *stream, DB_playItem_t *it);
+void
+vfs_fclose (DB_FILE *f);
+size_t
+vfs_fread (void *ptr, size_t size, size_t nmemb, DB_FILE *stream);
+int
+vfs_fseek (DB_FILE *stream, int64_t offset, int whence);
+int64_t
+vfs_ftell (DB_FILE *stream);
+void
+vfs_rewind (DB_FILE *stream);
+int64_t
+vfs_fgetlength (DB_FILE *stream);
+const char *
+vfs_get_content_type (DB_FILE *stream);
+void
+vfs_fabort (DB_FILE *stream);
+uint64_t
+vfs_get_identifier (DB_FILE *stream);
+void
+vfs_abort_with_identifier (DB_vfs_t *vfs, uint64_t identifier);
 
 #ifdef __cplusplus
 }

--- a/src/viz.h
+++ b/src/viz.h
@@ -26,7 +26,7 @@
 #include <deadbeef/deadbeef.h>
 
 void
-viz_process (char * restrict bytes, int bytes_size, DB_output_t *output, int fft_size, int wave_size);
+viz_process (char *restrict bytes, int bytes_size, DB_output_t *output, int fft_size, int wave_size);
 
 void
 viz_init (void);
@@ -38,13 +38,13 @@ void
 viz_reset (void);
 
 void
-viz_waveform_listen (void *ctx, void (*callback)(void *ctx, const ddb_audio_data_t *data));
+viz_waveform_listen (void *ctx, void (*callback) (void *ctx, const ddb_audio_data_t *data));
 
 void
 viz_waveform_unlisten (void *ctx);
 
 void
-viz_spectrum_listen (void *ctx, void (*callback)(void *ctx, const ddb_audio_data_t *data));
+viz_spectrum_listen (void *ctx, void (*callback) (void *ctx, const ddb_audio_data_t *data));
 
 void
 viz_spectrum_unlisten (void *ctx);

--- a/src/volume.c
+++ b/src/volume.c
@@ -83,15 +83,15 @@ volume_get_amp (void) {
 
 float
 db_to_amp (float dB) {
-//    return pow (10, dB/20.f);
+    //    return pow (10, dB/20.f);
     // thanks to he for this hack
-    const float ln10=2.3025850929940002f;
-    return (float)exp(ln10*dB/20.f);
+    const float ln10 = 2.3025850929940002f;
+    return (float)exp (ln10 * dB / 20.f);
 }
 
 float
 amp_to_db (float amp) {
-    return (float)(20*log10 (amp));
+    return (float)(20 * log10 (amp));
 }
 
 float


### PR DESCRIPTION
Many files in `src/` and `Tests/` were not formatted consistently according to the `.clang-format` in the repo. Perhaps this is because the `.clang-format` contained a duplicate entry that would cause clang-format to crash. This pull requests simply run
```
clang-format -i src/*.h src/*.c Tests/*.c{pp,} Tests/*.h
```