### PR TITLE
Tests: add .gitignore

### DIFF
--- a/Tests/.gitignore
+++ b/Tests/.gitignore
@@ -1,0 +1,1 @@
+PresetManagerData/dspconfig


### PR DESCRIPTION
running the test suite creates the empty file Tests/PresetManagerData/dspconfig, which should be ignored