### PR TITLE
fix: test for arm64 architecture properly in MP3DecoderTests

### DIFF
--- a/Tests/MP3DecoderTests.cpp
+++ b/Tests/MP3DecoderTests.cpp
@@ -92,7 +92,7 @@ static void runMp3TwoPieceTestWithBackend(int backend) {
     EXPECT_TRUE(cmp==0);
 }
 
-#if !TARGET_CPU_ARM64
+#if !__aarch64__
 // FIXME: Looks like MPG123 generates bad data in that test. Needs proper debugging on arm64 host.
 TEST_F(MP3DecoderTests, test_DecodeMP3As2PiecesMPG123_SameAs1Piece) {
     runMp3TwoPieceTestWithBackend(0); // mpg123


### PR DESCRIPTION
on arm64/aarch64 libmpg123 generates bad data leading to the test MP3DecoderTests.test_DecodeMP3As2PiecesMPG123_SameAs1Piece failing. this test was excluded by testing for the `TARGET_CPU_ARM64` macro. but this is an Xcode macro defined in `TargetConditionals.h`. thus the test would not be excluded when compiling on a device such as the Raspberry Pi 4 or 5. the portable way to test for arm64 architecture with clang is to check for `__aarch64__`: https://stackoverflow.com/a/41666292