### PR TITLE
fix: test script doesn't fail if output directory already exists

### DIFF
--- a/Tests.mk
+++ b/Tests.mk
@@ -99,7 +99,7 @@ $(BUILD)/runtests: $(TEST_C_OBJS) $(GOOGLE_TEST_OBJS) $(TEST_CPP_OBJS)
 	$(CXX) $(LDFLAGS) $(TEST_C_OBJS) $(GOOGLE_TEST_OBJS) $(TEST_CPP_OBJS) $(LIBRARIES) -o $@
 
 runtests: $(BUILD)/runtests
-	mkdir $(BUILD)/Tests
+	mkdir -p $(BUILD)/Tests
 	cp -r Tests/TestData $(BUILD)/Tests/
 	cp -r Tests/PresetManagerData $(BUILD)/Tests/
 	cd $(BUILD) ; ./runtests


### PR DESCRIPTION
b2f8c9905a changed tests to run in a temporary folder to avoid creating output files that would have to be `.gitignore`d (#3119). if this directory already exists, however, the test script fails. passing `-p` to `mkdir` fixes this.