### PR TITLE
fix #3127 (autosort)

### DIFF
--- a/Tests.mk
+++ b/Tests.mk
@@ -36,7 +36,7 @@ CFLAGS=-fblocks -fcommon -O3 -gdwarf $(INCLUDE) \
 	-DXCTEST \
 	-DGOOGLETEST_STATIC
 LIBRARIES=-lmad -lmpg123 -lcurl -ldispatch -lpthread -lBlocksRuntime -lm -ljansson -ldl
-LDFLAGS=-L$(STATIC_ROOT)/lib -L$(STATIC_ROOT)/lib/x86_64-linux-gnu
+LDFLAGS=-L$(STATIC_ROOT)/lib -L$(STATIC_ROOT)/lib/x86_64-linux-gnu -fuse-ld=lld
 
 
 TEST_C_SOURCES=$(wildcard \

--- a/Tests.mk
+++ b/Tests.mk
@@ -23,7 +23,7 @@ INCLUDE=-I external/googletest/googletest \
 	-I plugins/coreaudio \
 	-I$(STATIC_ROOT)/include
 
-CFLAGS=-fblocks -fcommon -O3 $(INCLUDE) \
+CFLAGS=-fblocks -fcommon -O3 -gdwarf $(INCLUDE) \
 	-D_FORTIFY_SOURCE=0 \
 	-D_GNU_SOURCE \
 	-DHAVE_LOG2=1 \

--- a/Tests.mk
+++ b/Tests.mk
@@ -36,7 +36,7 @@ CFLAGS=-fblocks -fcommon -O3 -gdwarf $(INCLUDE) \
 	-DXCTEST \
 	-DGOOGLETEST_STATIC
 LIBRARIES=-lmad -lmpg123 -lcurl -ldispatch -lpthread -lBlocksRuntime -lm -ljansson -ldl
-LDFLAGS=-L$(STATIC_ROOT)/lib -L$(STATIC_ROOT)/lib/x86_64-linux-gnu -fuse-ld=lld
+LDFLAGS=-L$(STATIC_ROOT)/lib -L$(STATIC_ROOT)/lib/x86_64-linux-gnu
 
 
 TEST_C_SOURCES=$(wildcard \

--- a/Tests/PlaylistTests.cpp
+++ b/Tests/PlaylistTests.cpp
@@ -8,8 +8,11 @@
 
 #include <deadbeef/deadbeef.h>
 #include <deadbeef/common.h>
+#include "messagepump.h"
 #include "plmeta.h"
+#include "pltmeta.h"
 #include "plugins.h"
+#include "sort.h"
 #include <gtest/gtest.h>
 #include <gmock/gmock.h>
 
@@ -47,6 +50,54 @@ TEST(PlaylistTests, test_SearchFor2ndValueInMultiValueItems_FindsTheItem) {
 
     pl_item_unref(it);
     plt_unref (plt);
+}
+
+TEST(PlaylistTests, test_PlaylistAutosort) {
+    messagepump_init();
+
+    const char sort_tf[] = "%artist%";
+
+    playlist_t *plt = plt_alloc("test");
+    plt_add_meta(plt, "autosort_enabled", "1");
+    plt_add_meta(plt, "autosort_mode", "tf");
+    plt_add_meta(plt, "autosort_tf", "%artist%");
+    plt_add_meta(plt, "autosort_ascending", "1");
+
+    playItem_t *it_A = pl_item_alloc();
+    playItem_t *it_B = pl_item_alloc();
+    playItem_t *it_C = pl_item_alloc();
+
+    pl_add_meta(it_A, "artist", "A");
+    pl_add_meta(it_B, "artist", "B");
+    pl_add_meta(it_C, "artist", "C");
+
+    playItem_t *tail = plt_insert_item(plt, NULL, it_A);
+
+    playItem_t *tmp = plt_insert_item(plt, tail, it_C);
+    pl_item_unref(tail);
+    tail = tmp;
+
+    tail = plt_insert_item(plt, tail, it_B);
+    pl_item_unref(tail);
+
+    plt_autosort(plt);
+
+    EXPECT_STREQ(plt_find_meta(plt, "autosort_tf"), sort_tf);
+
+    playItem_t *head = plt_get_head_item(plt, PL_MAIN);
+    ASSERT_STREQ("A", pl_find_meta_raw(head, "artist"));
+    pl_item_unref(head);
+
+    tail = plt_get_tail_item(plt, PL_MAIN);
+    ASSERT_STREQ("C", pl_find_meta_raw(tail, "artist"));
+
+    pl_item_unref(tail);
+
+    pl_item_unref(it_A);
+    pl_item_unref(it_B);
+    pl_item_unref(it_C);
+
+    plt_unref(plt);
 }
 
 TEST (PlaylistTests, test_LoadDBPLWithRelativepaths) {

--- a/Tests/PlaylistTests.cpp
+++ b/Tests/PlaylistTests.cpp
@@ -76,11 +76,11 @@ TEST(PlaylistTests, test_PlaylistSort) {
     EXPECT_STREQ(plt_find_meta(plt, "autosort_tf"), sort_tf);
 
     playItem_t *head = plt_get_head_item(plt, PL_MAIN);
-    ASSERT_STREQ("A", pl_find_meta_raw(head, "artist"));
+    EXPECT_STREQ("A", pl_find_meta_raw(head, "artist"));
     pl_item_unref(head);
 
     tail = plt_get_tail_item(plt, PL_MAIN);
-    ASSERT_STREQ("C", pl_find_meta_raw(tail, "artist"));
+    EXPECT_STREQ("C", pl_find_meta_raw(tail, "artist"));
 
     pl_item_unref(tail);
 
@@ -119,11 +119,11 @@ TEST(PlaylistTests, test_PlaylistAutosort) {
     EXPECT_STREQ(plt_find_meta(plt, "autosort_tf"), sort_tf);
 
     playItem_t *head = plt_get_head_item(plt, PL_MAIN);
-    ASSERT_STREQ("A", pl_find_meta_raw(head, "artist"));
+    EXPECT_STREQ("A", pl_find_meta_raw(head, "artist"));
     pl_item_unref(head);
 
     tail = plt_get_tail_item(plt, PL_MAIN);
-    ASSERT_STREQ("C", pl_find_meta_raw(tail, "artist"));
+    EXPECT_STREQ("C", pl_find_meta_raw(tail, "artist"));
 
     pl_item_unref(tail);
 

--- a/Tests/PlaylistTests.cpp
+++ b/Tests/PlaylistTests.cpp
@@ -52,6 +52,45 @@ TEST(PlaylistTests, test_SearchFor2ndValueInMultiValueItems_FindsTheItem) {
     plt_unref (plt);
 }
 
+TEST(PlaylistTests, test_PlaylistSort) {
+    messagepump_init();
+
+    const char sort_tf[] = "%artist%";
+
+    playlist_t *plt = plt_alloc("test");
+
+    playItem_t *it_A = pl_item_alloc();
+    playItem_t *it_B = pl_item_alloc();
+    playItem_t *it_C = pl_item_alloc();
+
+    pl_add_meta(it_A, "artist", "A");
+    pl_add_meta(it_B, "artist", "B");
+    pl_add_meta(it_C, "artist", "C");
+
+    playItem_t *tail = plt_insert_item(plt, NULL, it_A);
+    tail = plt_insert_item(plt, tail, it_C);
+    tail = plt_insert_item(plt, tail, it_B);
+
+    plt_sort_v2(plt, PL_MAIN, -1, sort_tf, DDB_SORT_ASCENDING);
+
+    EXPECT_STREQ(plt_find_meta(plt, "autosort_tf"), sort_tf);
+
+    playItem_t *head = plt_get_head_item(plt, PL_MAIN);
+    ASSERT_STREQ("A", pl_find_meta_raw(head, "artist"));
+    pl_item_unref(head);
+
+    tail = plt_get_tail_item(plt, PL_MAIN);
+    ASSERT_STREQ("C", pl_find_meta_raw(tail, "artist"));
+
+    pl_item_unref(tail);
+
+    pl_item_unref(it_A);
+    pl_item_unref(it_B);
+    pl_item_unref(it_C);
+
+    plt_unref(plt);
+}
+
 TEST(PlaylistTests, test_PlaylistAutosort) {
     messagepump_init();
 
@@ -72,13 +111,8 @@ TEST(PlaylistTests, test_PlaylistAutosort) {
     pl_add_meta(it_C, "artist", "C");
 
     playItem_t *tail = plt_insert_item(plt, NULL, it_A);
-
-    playItem_t *tmp = plt_insert_item(plt, tail, it_C);
-    pl_item_unref(tail);
-    tail = tmp;
-
+    tail = plt_insert_item(plt, tail, it_C);
     tail = plt_insert_item(plt, tail, it_B);
-    pl_item_unref(tail);
 
     plt_autosort(plt);
 

--- a/src/pltmeta.h
+++ b/src/pltmeta.h
@@ -27,6 +27,10 @@
 #ifndef __PLMETA_H
 #define __PLMETA_H
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 void
 plt_add_meta (playlist_t *it, const char *key, const char *value);
 
@@ -62,5 +66,9 @@ plt_delete_metadata (playlist_t *it, DB_metaInfo_t *meta);
 
 void
 plt_delete_all_meta (playlist_t *it);
+
+#ifdef __cplusplus
+}
+#endif
 
 #endif

--- a/src/sort.h
+++ b/src/sort.h
@@ -24,6 +24,10 @@
 #ifndef __deadbeef__sort__
 #define __deadbeef__sort__
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 #include "playlist.h"
 
 void
@@ -34,5 +38,9 @@ sort_track_array (playlist_t *playlist, playItem_t **tracks, int num_tracks, con
 
 void
 plt_autosort (playlist_t *plt);
+
+#ifdef __cplusplus
+}
+#endif
 
 #endif /* defined(__deadbeef__sort__) */


### PR DESCRIPTION
This PR is a draft to resolve #3127. It adds tests for sorting playlists directly and with autosort, plus some tweaks to the test suite (build with debuginfo, link with lld for better error messages).