### PR TITLE
fix plt_load_from_buffer

### DIFF
--- a/src/playlist.c
+++ b/src/playlist.c
@@ -2445,8 +2445,8 @@ _plt_load_from_file (playlist_t *plt, const char *fname, ddb_file_handle_t *fp, 
         goto load_fail;
     }
 
-    char *slash = strrchr (fname, '/');
-    if (slash && fname) {
+    char *slash = fname ? strrchr (fname, '/') : NULL;
+    if (slash) {
         dname = strndup (fname, slash - fname);
     }
 


### PR DESCRIPTION
plt_load_from_buffer calls _plt_load_from_file with fname=NULL, which basically just unconditionally crashes.

Anyway, drag-and-drop from the sidebar into a playlist was broken on macOS beacause of this. Seems to be fine with this fix.