### PR TITLE
gtkui: fix auto-naming playlists regression (#3195)

### DIFF
--- a/src/playlist.c
+++ b/src/playlist.c
@@ -672,15 +672,13 @@ plt_get_idx_of (playlist_t *plt) {
 int
 plt_get_title (playlist_t *p, char *buffer, int bufsize) {
     LOCK;
-    if (!buffer) {
-        int l = (int)strlen (p->title);
-        UNLOCK;
-        return l;
+    int l = (int)strlen (p->title);
+    if (buffer) {
+        strncpy (buffer, p->title, bufsize);
+        buffer[bufsize - 1] = 0;
     }
-    strncpy (buffer, p->title, bufsize);
-    buffer[bufsize - 1] = 0;
     UNLOCK;
-    return 0;
+    return l;
 }
 
 int


### PR DESCRIPTION
`plt_get_title` always returns 0 if called with a non-`NULL` buffer for the title; otherwise it returns the length of the title. This causes #3195, and is unintuitive. We can fix #3195 by always returning the length of the title. The only other place in the codebase that uses the return value from this function is https://github.com/DeaDBeeF-Player/deadbeef/blob/5c5d44afb13a0d0008e859305848dda7686b2a0f/plugins/cocoaui/Utility/PlaylistContextMenu.m#L106 where it is called with a `NULL` buffer.  So this change should be safe.