### PR TITLE
Windows: update dispatch (fixes #3202)

### DIFF
--- a/travis/build.sh
+++ b/travis/build.sh
@@ -48,7 +48,7 @@ case "$TRAVIS_OS_NAME" in
         cd ../../..
     ;;
     windows)
-        DISPATCH_URL="https://github.com/DeaDBeeF-for-Windows/swift-corelibs-libdispatch/releases/download/release%2F6.0.3/ddb-xdispatch-win-latest.zip"
+        DISPATCH_URL="https://github.com/DeaDBeeF-for-Windows/swift-corelibs-libdispatch/releases/download/release%2F6.1.1/ddb-xdispatch-win-latest.zip"
         PREMAKE_URL="https://github.com/premake/premake-core/releases/download/v5.0.0-beta2/premake-5.0.0-beta2-windows.zip"
         DEPS_URL="https://github.com/kuba160/deadbeef-windows-deps.git"
         echo "Downloading xdispatch_ddb..."


### PR DESCRIPTION
winpthread had ABI breaking change, newest, recompiled version of dispatch should fix it