### PR TITLE
Install Inno Setup on windows runner

### DIFF
--- a/.github/workflows/windowsbuild.yml
+++ b/.github/workflows/windowsbuild.yml
@@ -9,6 +9,8 @@ jobs:
       uses: actions/checkout@v2
       with:
         submodules: true
+    - name: Install Inno Setup
+      run: choco install -y innosetup
     - name: Install msys2
       uses: msys2/setup-msys2@v2
       with:


### PR DESCRIPTION
needed because `windows-2025` (which will become `windows-latest` next month) does not come with Inno Setup preinstalled