### PR TITLE
cocoaui: Fix extra NSSplitView subviews present in hierarchy

### DIFF
--- a/plugins/cocoaui/SplitViewMainWindow/SidebarSplitViewController.m
+++ b/plugins/cocoaui/SplitViewMainWindow/SidebarSplitViewController.m
@@ -24,19 +24,16 @@
 @dynamic splitView ;
 
 - (void)viewDidLoad {
+    [super viewDidLoad];
     self.splitView.wantsLayer = YES;
 
-    NSSplitViewItem* sidebarItem = [SidebarSplitViewItem splitViewItemWithViewController:self.sidebarViewController];
-    sidebarItem.canCollapse = YES;
-    [self insertSplitViewItem:sidebarItem atIndex:0];
-    sidebarItem.holdingPriority = NSLayoutPriorityDefaultLow+10;
+    NSSplitViewItem* sidebarItem = [NSSplitViewItem sidebarWithViewController:self.sidebarViewController];
+    [self addSplitViewItem:sidebarItem];
 
     self.bodyViewController = [MainContentViewController new];
 
     NSSplitViewItem* bodyItem = [NSSplitViewItem splitViewItemWithViewController:self.bodyViewController];
-    bodyItem.canCollapse = NO;
-    [self insertSplitViewItem:bodyItem atIndex:1];
-    bodyItem.holdingPriority = NSLayoutPriorityDefaultLow;
+    [self addSplitViewItem:bodyItem];
 
 #if 0 // FIXME: broken in Big Sur beta4
 #if defined(__MAC_OS_X_VERSION_MAX_ALLOWED) && __MAC_OS_X_VERSION_MAX_ALLOWED >= 101600
@@ -47,8 +44,6 @@
     }
 #endif
 #endif
-
-    [super viewDidLoad];
 
     self.splitView.autosaveName = @"MainWindowSplitView";
 }


### PR DESCRIPTION
While playing with Liquid Glass adoption I have found several
annoying visual glitches, most prominently two glassy views
were occupying space even when sidebar is collapsed.

While inspecting view hierarchy I have found them to be some
stale views.
They do appear if `[super viewDidLoad]` is called after
`[self insertSplitViewItem:insert:]` and do not appear if
`[super viewDidLoad]` is called before inserting anything.

I assume we must call `[super viewDidLoad]` before adding
any NSSplitViewItems to NSSplitViewController.

Also, migrated manual setup of NSSplitViewItems to [convenient
initializers](https://developer.apple.com/documentation/appkit/nssplitviewitem/init(sidebarwithviewcontroller:)?language=objc). They were added to AppKit with back-compat down to macOS
10.11.

Custom https://github.com/DeaDBeeF-Player/deadbeef/blob/master/plugins/cocoaui/SplitViewMainWindow/SidebarSplitViewItem.m can be removed, but that have not been done here yet.

Before:
<img height="200" alt="Screenshot 2025-10-23 at 00 42 30" src="https://github.com/user-attachments/assets/a780df33-0b25-4d57-99ba-7481175eb2cd" /><img height="200" alt="Screenshot 2025-10-23 at 00 43 03" src="https://github.com/user-attachments/assets/18e3e521-1f3d-4d9c-a1a3-a67d896e11a8" />

After:
<img height="200" alt="Screenshot 2025-10-23 at 00 40 23" src="https://github.com/user-attachments/assets/17ce1695-275d-46ed-897e-adfb6534749e" />

If needed, I can provide Screenshots showing the issue more prominently with Liquid Glass enabled.