### PR TITLE
Change padding for Lyrics view on Mac

### DIFF
--- a/plugins/cocoaui/DesignMode/Widgets/Lyrics/LyricsViewController.m
+++ b/plugins/cocoaui/DesignMode/Widgets/Lyrics/LyricsViewController.m
@@ -32,6 +32,7 @@ static NSString * const lyricsNotAvailableString = @"Lyrics Not Available";
 
 - (void)viewDidLoad {
     [super viewDidLoad];
+    self.textView.textContainerInset = NSMakeSize(0, 10);
     self.lyricsCache = [NSCache new];
     [self update];
 }


### PR DESCRIPTION
Currently Lyrics are shown too close to the top and bottom of their frame on Mac:

<img width="1539" height="722" alt="Screenshot 2025-10-26 at 11 09 37 PM" src="https://github.com/user-attachments/assets/98ee7d11-87e7-4176-8178-8e2f8fd5dda7" />

I have changed it to have 10 points of padding at the top and bottom of the text view:
<img width="1539" height="722" alt="Screenshot 2025-10-26 at 11 06 47 PM" src="https://github.com/user-attachments/assets/8c4f0c53-ce92-474c-be03-47f4b2f2503d" />

I think it looks better this way, but feel free to discard this change if you prefer the original padding.