### PR TITLE
cocoaui: Set Application category to Music

### DIFF
--- a/plugins/cocoaui/deadbeef-Info.plist
+++ b/plugins/cocoaui/deadbeef-Info.plist
@@ -287,6 +287,8 @@
 	<string>????</string>
 	<key>CFBundleVersion</key>
 	<string>1</string>
+	<key>LSApplicationCategoryType</key>
+	<string>public.app-category.music</string>
 	<key>LSEnvironment</key>
 	<dict>
 		<key>PATH</key>


### PR DESCRIPTION
Helps to discover app quickly with Spotlight by selecting
category Music (or more broadly Entertainment).

See: https://developer.apple.com/documentation/bundleresources/information-property-list/lsapplicationcategorytype?language=objc

<img width="783" height="553" alt="image" src="https://github.com/user-attachments/assets/4c104e56-1aec-4ae3-91c8-4bfed4bc4f12" />

