### PR TITLE
Error and continue loading other plugins for #3241

### DIFF
--- a/src/plugins.c
+++ b/src/plugins.c
@@ -1264,34 +1264,39 @@ plug_load_all (void) {
         if (plug->plugin->type == DB_PLUGIN_DECODER) {
 //            trace ("found decoder plugin %s\n", plug->plugin->name);
             if (numdecoders >= MAX_DECODER_PLUGINS) {
-                break;
+                trace_err ("too many decoder plugins. plugin %s will not function correctly.\n", plug->plugin->name);
+                continue;
             }
             g_decoder_plugins[numdecoders++] = (DB_decoder_t *)plug->plugin;
         }
         else if (plug->plugin->type == DB_PLUGIN_VFS) {
 //            trace ("found vfs plugin %s\n", plug->plugin->name);
             if (numvfs >= MAX_VFS_PLUGINS) {
-                break;
+                trace_err ("too many vfs plugins. plugin %s will not function correctly.\n", plug->plugin->name);
+                continue;
             }
             g_vfs_plugins[numvfs++] = (DB_vfs_t *)plug->plugin;
         }
         else if (plug->plugin->type == DB_PLUGIN_OUTPUT) {
 //            trace ("found output plugin %s\n", plug->plugin->name);
             if (numoutput >= MAX_OUTPUT_PLUGINS) {
-                break;
+                trace_err ("too many output plugins. plugin %s will not function correctly.\n", plug->plugin->name);
+                continue;
             }
             g_output_plugins[numoutput++] = (DB_output_t *)plug->plugin;
         }
         else if (plug->plugin->type == DB_PLUGIN_DSP) {
 //            trace ("found dsp plugin %s\n", plug->plugin->name);
             if (numdsp >= MAX_DSP_PLUGINS) {
-                break;
+                trace_err ("too many dsp plugins. plugin %s will not function correctly.\n", plug->plugin->name);
+                continue;
             }
             g_dsp_plugins[numdsp++] = (DB_dsp_t *)plug->plugin;
         }
         else if (plug->plugin->type == DB_PLUGIN_PLAYLIST) {
             if (numplaylist >= MAX_PLAYLIST_PLUGINS) {
-                break;
+                trace_err ("too many playlist plugins. plugin %s will not function correctly.\n", plug->plugin->name);
+                continue;
             }
             g_playlist_plugins[numplaylist++] = (DB_playlist_t *)plug->plugin;
         }


### PR DESCRIPTION
Adds error messages when there are too many plugins of a certain type.

Also, the specific problem in #3241 probably happened because other plugins did not load properly after hitting the max dsp limit, so other types of plugins should continue loading (not breaking the loop when some type is filled).

(Potential problem later on: line 1263 `g_plugins[numplugins++] = plug->plugin;` always adds the plugin. Should this also be done when the plugin cannot be categorised due to hitting a max limit?)