### PR TITLE
gtkui: prevent total playtime from being cast to int (fixes #3270)

### DIFF
--- a/plugins/gtkui/gtkui.c
+++ b/plugins/gtkui/gtkui.c
@@ -164,10 +164,10 @@ gtkui_dispatch_on_main (void (^block) (void)) {
 static void
 format_timestr (char *buf, int sz, float time) {
     time = roundf (time);
-    int daystotal = (int)time / (3600 * 24);
-    int hourtotal = ((int)time / 3600) % 24;
-    int mintotal = ((int)time / 60) % 60;
-    int sectotal = ((int)time) % 60;
+    int daystotal = (int64_t)time / (3600 * 24);
+    int hourtotal = ((int64_t)time / 3600) % 24;
+    int mintotal = ((int64_t)time / 60) % 60;
+    int sectotal = ((int64_t)time) % 60;
 
     if (daystotal == 0) {
         snprintf (buf, sz, "%d:%02d:%02d", hourtotal, mintotal, sectotal);


### PR DESCRIPTION
For people that need playlists with total playtime longer than 68 years. New limit would land at 5.8 million years.
