### PR TITLE
gtkui: Implement mouse forward and back buttons

### DIFF
--- a/plugins/gtkui/callbacks.c
+++ b/plugins/gtkui/callbacks.c
@@ -522,6 +522,12 @@ on_mainwin_button_press_event (GtkWidget *widget, GdkEventButton *event, gpointe
         if (event->type == GDK_2BUTTON_PRESS) {
             deadbeef->sendmessage (DB_EV_TRACKFOCUSCURRENT, 0, 0, 0);
         }
+    } else if (event->type == GDK_BUTTON_PRESS){
+        if (event->button == 9 || event->button == 10) {
+            deadbeef->sendmessage (DB_EV_NEXT, 0, 0, 0);
+        } else if (event->button == 8) {
+            deadbeef->sendmessage (DB_EV_PREV, 0, 0, 0);
+        }
     }
 
     return FALSE;

--- a/plugins/gtkui/ddbtabstrip.c
+++ b/plugins/gtkui/ddbtabstrip.c
@@ -1289,6 +1289,7 @@ on_tabstrip_button_press_event (GtkWidget *widget, GdkEventButton *event) {
         ts->dragging = tab_clicked;
         ts->prev_x = event->x;
         tab_moved = 0;
+        return TRUE;
     }
     else if (TEST_RIGHT_CLICK (event)) {
         ddb_playlist_t *plt = deadbeef->plt_get_for_idx (tab_clicked);
@@ -1298,6 +1299,7 @@ on_tabstrip_button_press_event (GtkWidget *widget, GdkEventButton *event) {
         }
         gtk_menu_attach_to_widget (GTK_MENU (menu), GTK_WIDGET (widget), NULL);
         gtk_menu_popup (GTK_MENU (menu), NULL, NULL, NULL, NULL, 0, gtk_get_current_event_time ());
+        return TRUE;
     }
     else if (event->button == 2) {
         if (tab_clicked == -1) {
@@ -1309,16 +1311,15 @@ on_tabstrip_button_press_event (GtkWidget *widget, GdkEventButton *event) {
             return TRUE;
         }
         else if (deadbeef->conf_get_int ("gtkui.mmb_delete_playlist", 1)) {
-            if (tab_clicked != -1) {
-                ddb_playlist_t *plt = deadbeef->plt_get_for_idx (tab_clicked);
-                if (plt != NULL) {
-                    gtkui_remove_playlist (plt);
-                    deadbeef->plt_unref (plt);
-                }
+            ddb_playlist_t *plt = deadbeef->plt_get_for_idx (tab_clicked);
+            if (plt != NULL) {
+                gtkui_remove_playlist (plt);
+                deadbeef->plt_unref (plt);
             }
+            return TRUE;
         }
     }
-    return TRUE;
+    return FALSE;
 }
 
 gboolean

--- a/plugins/gtkui/playlist/ddblistview.c
+++ b/plugins/gtkui/playlist/ddblistview.c
@@ -2995,6 +2995,7 @@ ddb_listview_list_button_press_event (GtkWidget *widget, GdkEventButton *event, 
     DdbListviewPrivate *priv = DDB_LISTVIEW_GET_PRIVATE (listview);
     if (TEST_LEFT_CLICK (event)) {
         ddb_listview_list_mouse1_pressed (listview, event->state, event->x, event->y, event->type);
+        return TRUE;
     }
     else if (TEST_RIGHT_CLICK (event)) {
         // get item under cursor
@@ -3016,8 +3017,9 @@ ddb_listview_list_button_press_event (GtkWidget *widget, GdkEventButton *event, 
             listview->delegate->list_context_menu (playlist, PL_MAIN);
             deadbeef->plt_unref (playlist);
         }
+        return TRUE;
     }
-    return TRUE;
+    return FALSE;
 }
 
 static gboolean

--- a/plugins/gtkui/playlist/ddblistviewheader.c
+++ b/plugins/gtkui/playlist/ddblistviewheader.c
@@ -526,6 +526,7 @@ ddb_listview_header_button_press_event           (GtkWidget       *widget,
             priv->header_sizing = i;
             priv->header_dragpt[0] -= (x + c->width);
         }
+        return TRUE;
     }
     else if (TEST_RIGHT_CLICK (event)) {
         if (priv->header_dragging != -1) {
@@ -536,8 +537,9 @@ ddb_listview_header_button_press_event           (GtkWidget       *widget,
         priv->header_prepare = 0;
         int idx = ddb_listview_header_get_column_idx_for_coord (header, event->x);
         header->delegate->context_menu (header, idx);
+        return TRUE;
     }
-    return TRUE;
+    return FALSE;
 }
 
 static gboolean


### PR DESCRIPTION
Implement use of mouse forward and back buttons to control playback.

* Add handling in `on_mainwin_button_press_event` for buttons 8 and 9/10 (based on [Firefox code](https://github.com/mozilla-firefox/firefox/blob/main/widget/gtk/nsWindow.cpp#L4881-L4893))
* Change playlist's view, header, and tabstrips' button-press events to return `FALSE` in the fallback case, so that events propagate up to `on_mainwin_button_press_event`

I don't have the historical or big-picture context for why the playlist button-press events return `TRUE` in the fallback case, let me know if there's a better way to do this.

I only changed the playlist button-press events because that's the main widget I use, I don't know if I should make the same change for other widgets as well.