### PR TITLE
gtkui: Make seekbar respond only to primary mouse button

### DIFF
--- a/plugins/gtkui/ddbseekbar.c
+++ b/plugins/gtkui/ddbseekbar.c
@@ -503,6 +503,9 @@ on_seekbar_motion_notify_event (GtkWidget *widget, GdkEventMotion *event) {
 
 gboolean
 on_seekbar_button_press_event (GtkWidget *widget, GdkEventButton *event) {
+    if (event->button != 1) {
+        return FALSE;
+    }
     DdbSeekbar *self = DDB_SEEKBAR (widget);
     DdbSeekbarPrivate *priv = DDB_SEEKBAR_GET_PRIVATE (self);
     if (deadbeef->get_output ()->state () == DDB_PLAYBACK_STATE_STOPPED) {
@@ -517,11 +520,14 @@ on_seekbar_button_press_event (GtkWidget *widget, GdkEventButton *event) {
     gtk_widget_get_allocation (widget, &a);
     priv->seekbar_move_x = event->x - a.x;
     gtk_widget_queue_draw (widget);
-    return FALSE;
+    return TRUE;
 }
 
 gboolean
 on_seekbar_button_release_event (GtkWidget *widget, GdkEventButton *event) {
+    if (event->button != 1) {
+        return FALSE;
+    }
     DdbSeekbar *self = DDB_SEEKBAR (widget);
     DdbSeekbarPrivate *priv = DDB_SEEKBAR_GET_PRIVATE (self);
     priv->seekbar_moving = 0;
@@ -540,7 +546,7 @@ on_seekbar_button_release_event (GtkWidget *widget, GdkEventButton *event) {
         deadbeef->pl_item_unref (trk);
     }
     gtk_widget_queue_draw (widget);
-    return FALSE;
+    return TRUE;
 }
 
 static gboolean


### PR DESCRIPTION
Without this, seekbar will respond to ANY mouse button (including middle click and forward/back), on both press and release, so you can do weird things like press and hold left and right mouse buttons, release one button and it will seek to position while still being able to drag along the seekbar, then release the other button to seek to another position.