### PR TITLE
gtkui: Build fix

### DIFF
--- a/plugins/gtkui/trkproperties.c
+++ b/plugins/gtkui/trkproperties.c
@@ -909,7 +909,7 @@ _semicolon_separated_string_for_meta(DB_metaInfo_t *meta) {
 static void
 _iterate_semicolon_separated_substrings(const char *svalue, void (^completion_block)(const char *item)) {
     while (*svalue) {
-        char *semicolon = strchr(svalue, ';');
+        const char *semicolon = strchr(svalue, ';');
 
         size_t len;
         if (semicolon == NULL) {


### PR DESCRIPTION
No idea why it started happening but I started getting this error trying to build on Linux:

```
trkproperties.c:912:15: error: initializing 'char *' with an expression of type 'const char *' discards qualifiers [-Werror,-Wincompatible-pointer-types-discards-qualifiers]
  912 |         char *semicolon = strchr(svalue, ';');
      |               ^           ~~~~~~~~~~~~~~~~~~~
```

Fixing this makes the build succeed.