### PR TITLE
Add threshold config options for prev_or_restart action

### DIFF
--- a/src/actionhandlers.c
+++ b/src/actionhandlers.c
@@ -774,7 +774,8 @@ action_prev_or_restart_cb (struct DB_plugin_action_s *action, ddb_action_context
         deadbeef->pl_item_unref (it);
         if (dur > 0) {
             float pos = deadbeef->streamer_get_playpos ();
-            if (pos > 3) {
+            float threshold = deadbeef->conf_get_float ("playback.prev_restart_threshold", 3);
+            if (pos > threshold) {
                 deadbeef->sendmessage (DB_EV_SEEK, 0, 0, 0);
                 return 0;
             }


### PR DESCRIPTION
The restart-vs-go-to-previous threshold in action_prev_or_restart_cb was hardcoded to 3 seconds. This makes it configurable via playback.prev_restart_threshold (float, in seconds), defaulting to 3 to preserve existing behavior.

Increasing this value is useful when triggering the action via "smart shortcuts" or "touch controls" on Bluetooth headsets, as some of these input schemes require multiple or long key presses that take longer to complete.