### PR TITLE
cocoaui: let playlist key events fall back to menu shortcuts

### DIFF
--- a/plugins/cocoaui/Playlist/PlaylistContentView.m
+++ b/plugins/cocoaui/Playlist/PlaylistContentView.m
@@ -1037,6 +1037,9 @@ static int grouptitleheight = 22;
             [self scrollPoint:NSMakePoint(vis.origin.x, (self.frame.size.height - sv.contentSize.height))];
             break;
         default:
+            if ([NSApp.mainMenu performKeyEquivalent:theEvent]) {
+                return;
+            }
             [super keyDown:theEvent];
             return;
         }
@@ -1477,4 +1480,3 @@ static int grouptitleheight = 22;
 }
 
 @end
-


### PR DESCRIPTION
After updating to macOS 26.5 and a master DeaDBeeF build, I started seeing the Cocoa UI playback hotkeys behave inconsistently. Shortcuts like `b` for Next and `n` for Play Random would work for a while after launch, then stop working until I restarted the player or reset/re-applied the shortcuts in settings.

The issue seemed tied to playlist focus. After clicking in the playlist or using navigation keys like arrows/Home/End, the playlist view becomes first responder. It handles those navigation keys itself, but for other keys it was just falling through to `[super keyDown:]`.

That seems a bit fragile for DeaDBeeF's plain letter shortcuts, because those shortcuts are Cocoa menu key equivalents. If the playlist does not handle a key, the main menu should still get a chance to handle it.

This change makes the playlist view try:

```
[NSApp.mainMenu performKeyEquivalent:theEvent]
```

before falling back to `[super keyDown:]`.

This keeps the existing playlist navigation behavior, but makes menu-backed shortcuts work even when the playlist is focused. I don't know whether macOS 26.5 changed the AppKit behavior here, or whether it only made an existing edge case easier to hit, but this makes the routing explicit instead of relying on the responder chain to recover later.

Verified with:

```
xcodebuild -project osx/deadbeef.xcodeproj -target DeaDBeeF -configuration Release
```

And during runtime, after making this change I did not had another issue with 'b' or 'n' not working. Before it was happening at random but pretty frequently.