### PR TITLE
Fix ReplayGain fallback behaviour #3323

### DIFF
--- a/src/replaygain.c
+++ b/src/replaygain.c
@@ -93,26 +93,23 @@ replaygain_init_settings (ddb_replaygain_settings_t *settings, playItem_t *it) {
     const char *albumpeak = pl_find_meta (it, ":REPLAYGAIN_ALBUMPEAK");
     const char *trackpeak = pl_find_meta (it, ":REPLAYGAIN_TRACKPEAK");
 
-    if (albumgain) {
-        settings->has_album_gain = 1;
-    }
-    if (trackgain) {
-        settings->has_track_gain = 1;
-    }
-
     if (settings->processing_flags & DDB_RG_PROCESSING_GAIN) {
         if (albumgain) {
             settings->albumgain = db_to_amp((float)atof (albumgain));
+            settings->has_album_gain = 1;
         }
         else if (trackgain) {
             settings->albumgain = db_to_amp((float)atof (trackgain));
+            settings->has_album_gain = 1;
         }
 
         if (trackgain) {
             settings->trackgain = db_to_amp((float)atof (trackgain));
+            settings->has_track_gain = 1;
         }
         else if (albumgain) {
             settings->trackgain = db_to_amp((float)atof (albumgain));
+            settings->has_track_gain = 1;
         }
     }
 


### PR DESCRIPTION
This is to fix #3323 describing a bug with ReplayGain. This reverts only the `src/replaygain.c` edits from 2c6fa6f.