### PR TITLE
UI improvements

### DIFF
--- a/plugins/cocoaui/AppDelegate.m
+++ b/plugins/cocoaui/AppDelegate.m
@@ -622,8 +622,16 @@ main_cleanup_and_quit (void);
 }
 
 - (IBAction)addLocationAction:(id)sender {
+    CGFloat fontSize = [NSFont menuFontOfSize:0].pointSize;
+
+    // Same size as the menus, but with proper text-field metrics.
+    _addLocationTextField.controlSize = NSControlSizeRegular;
+    _addLocationTextField.font = [NSFont systemFontOfSize:fontSize];
+
     _addLocationTextField.stringValue = @"";
-    [_mainWindow.window beginSheet:_addLocationPanel completionHandler:^(NSModalResponse returnCode) {
+
+    [_mainWindow.window beginSheet:_addLocationPanel
+                completionHandler:^(NSModalResponse returnCode) {
         if (returnCode == NSModalResponseOK) {
             NSString *text = [self.addLocationTextField.stringValue stringByTrimmingCharactersInSet:[NSCharacterSet whitespaceAndNewlineCharacterSet]];
 

--- a/plugins/cocoaui/MainWindowController.m
+++ b/plugins/cocoaui/MainWindowController.m
@@ -113,6 +113,11 @@ extern DB_functions_t *deadbeef;
 
 - (void)windowDidLoad {
     [super windowDidLoad];
+    
+    
+    // Match the standard macOS menu font size.
+    self.statusBar.font = [NSFont menuFontOfSize:0];
+    [self.statusBar invalidateIntrinsicContentSize];
 
     // This doesn't work reliably when set in XIB
 #if defined(__MAC_OS_X_VERSION_MAX_ALLOWED) && __MAC_OS_X_VERSION_MAX_ALLOWED >= 101600

--- a/plugins/cocoaui/Playlist/PlaylistHeaderView.m
+++ b/plugins/cocoaui/Playlist/PlaylistHeaderView.m
@@ -70,8 +70,18 @@
     textStyle.alignment = NSTextAlignmentLeft;
     textStyle.lineBreakMode = NSLineBreakByTruncatingTail;
 
+    NSFont *menuFont = [NSFont menuFontOfSize:0];
+    NSFont *boldMenuFont =
+        [[NSFontManager sharedFontManager]
+            convertFont:menuFont
+            toHaveTrait:NSBoldFontMask];
+    
+    if (boldMenuFont == nil) {
+        boldMenuFont = [NSFont boldSystemFontOfSize:menuFont.pointSize];
+    }
+
     self.titleAttributesCurrent = @{
-        NSFontAttributeName:[NSFont controlContentFontOfSize:NSFont.smallSystemFontSize],
+        NSFontAttributeName: boldMenuFont,
         NSBaselineOffsetAttributeName: @0,
         NSForegroundColorAttributeName: self.headerTextColor,
         NSParagraphStyleAttributeName: textStyle

--- a/plugins/cocoaui/Playlist/PlaylistViewController.m
+++ b/plugins/cocoaui/Playlist/PlaylistViewController.m
@@ -427,22 +427,39 @@ artwork_listener (ddb_artwork_listener_event_t event, void *user_data, int64_t p
     textStyle.lineBreakMode = NSLineBreakByTruncatingTail;
 
 
-    int rowheight = 18;
+    int rowheight = 32;
 
     self.groupTextAttrsDictionary = @{NSFontAttributeName: [NSFont boldSystemFontOfSize:[NSFont systemFontSizeForControlSize:rowheight]]
                                  , NSBaselineOffsetAttributeName: @0.0f
                                  , NSForegroundColorAttributeName: NSColor.controlTextColor
                                  , NSParagraphStyleAttributeName: textStyle};
 
-    self.cellTextAttrsDictionary = @{NSFontAttributeName: [NSFont controlContentFontOfSize:[NSFont systemFontSizeForControlSize:rowheight]]
-                                , NSBaselineOffsetAttributeName: @0.0f
-                                , NSForegroundColorAttributeName: NSColor.controlTextColor
-                                , NSParagraphStyleAttributeName: textStyle};
+//    self.cellTextAttrsDictionary = @{NSFontAttributeName: [NSFont controlContentFontOfSize:[NSFont systemFontSizeForControlSize:rowheight]]
+//                                , NSBaselineOffsetAttributeName: @0.0f
+//                                , NSForegroundColorAttributeName: NSColor.controlTextColor
+//                                , NSParagraphStyleAttributeName: textStyle};
+//
+//    self.cellSelectedTextAttrsDictionary = @{NSFontAttributeName: [NSFont controlContentFontOfSize:[NSFont systemFontSizeForControlSize:rowheight]]
+//                                        , NSBaselineOffsetAttributeName: @0.0f
+//                                        , NSForegroundColorAttributeName: NSColor.alternateSelectedControlTextColor
+//                                        , NSParagraphStyleAttributeName: textStyle};
+    
+    NSFont *playlistFont = [NSFont systemFontOfSize:0];
 
-    self.cellSelectedTextAttrsDictionary = @{NSFontAttributeName: [NSFont controlContentFontOfSize:[NSFont systemFontSizeForControlSize:rowheight]]
-                                        , NSBaselineOffsetAttributeName: @0.0f
-                                        , NSForegroundColorAttributeName: NSColor.alternateSelectedControlTextColor
-                                        , NSParagraphStyleAttributeName: textStyle};
+    self.cellTextAttrsDictionary = @{
+        NSFontAttributeName: playlistFont,
+        NSBaselineOffsetAttributeName: @0.0f,
+        NSForegroundColorAttributeName: NSColor.controlTextColor,
+        NSParagraphStyleAttributeName: textStyle
+    };
+
+    self.cellSelectedTextAttrsDictionary = @{
+        NSFontAttributeName: playlistFont,
+        NSBaselineOffsetAttributeName: @0.0f,
+        NSForegroundColorAttributeName:
+            NSColor.alternateSelectedControlTextColor,
+        NSParagraphStyleAttributeName: textStyle
+    };
 
 
     // initialize group by str

--- a/plugins/cocoaui/Utility/TrackContextMenu.m
+++ b/plugins/cocoaui/Utility/TrackContextMenu.m
@@ -65,7 +65,8 @@ extern DB_functions_t *deadbeef;
 - (instancetype)initWithView:(NSView *)view {
     self = [super initWithTitle:@""];
     self.view = view;
-    self.font = [NSFont systemFontOfSize:NSFont.smallSystemFontSize];
+//    self.font = [NSFont systemFontOfSize:NSFont.smallSystemFontSize];
+    self.font = [NSFont menuFontOfSize:0];
 
     // A bit of a hack: we can't control view/menu lifecycle,
     // but here we hold references to some low level objects which we'd like to cleanup before quitting.
@@ -132,7 +133,8 @@ extern DB_functions_t *deadbeef;
     self.reloadMetadataItem.target = self;
 
     NSMenu *rgMenu = [[NSMenu alloc] initWithTitle:@"ReplayGain"];
-    rgMenu.font = [NSFont systemFontOfSize:NSFont.smallSystemFontSize];
+//    rgMenu.font = [NSFont systemFontOfSize:NSFont.smallSystemFontSize];
+    rgMenu.font = [NSFont menuFontOfSize:0];
 
     rgMenu.autoenablesItems = NO;
 
@@ -161,7 +163,12 @@ extern DB_functions_t *deadbeef;
         self.removeFromQueueItem = [self addItemWithTitle:@"Remove from Playback Queue" action:@selector(removeFromPlaybackQueue) keyEquivalent:@""];
         self.removeFromQueueItem.target = self;
 
-        self.removeFromPlaylistItem = [self addItemWithTitle:@"Delete" action:@selector(delete:) keyEquivalent:@"\b"];
+//        self.removeFromPlaylistItem = [self addItemWithTitle:@"Delete" action:@selector(delete:) keyEquivalent:@"\b"];
+        
+        self.removeFromPlaylistItem =
+            [self addItemWithTitle:@"Delete"
+                            action:@selector(removeFromPlaylist:)
+                     keyEquivalent:@"\b"];
         self.removeFromPlaylistItem.target = self;
         self.removeFromPlaylistItem.keyEquivalentModifierMask = 0;
     }
@@ -637,12 +644,26 @@ _deleteCompleted (ddbDeleteFromDiskController_t ctl, int cancelled) {
     [((id<TrackContextMenuDelegate>)self.delegate) trackContextMenuShowTrackProperties:self];
 }
 
-- (void)delete:(id)sender {
+//- (void)delete:(id)sender {
+//    [self forEachTrack:^BOOL(DB_playItem_t *it) {
+//        deadbeef->plt_remove_item(self.playlist, it);
+//        return YES;
+//    }];
+//    deadbeef->sendmessage(DB_EV_PLAYLISTCHANGED, 0, DDB_PLAYLIST_CHANGE_CONTENT, 0);
+//}
+
+- (void)removeFromPlaylist:(id)sender {
     [self forEachTrack:^BOOL(DB_playItem_t *it) {
         deadbeef->plt_remove_item(self.playlist, it);
         return YES;
     }];
-    deadbeef->sendmessage(DB_EV_PLAYLISTCHANGED, 0, DDB_PLAYLIST_CHANGE_CONTENT, 0);
+
+    deadbeef->sendmessage(
+        DB_EV_PLAYLISTCHANGED,
+        0,
+        DDB_PLAYLIST_CHANGE_CONTENT,
+        0
+    );
 }
 
 @end

--- a/plugins/cocoaui/XIB/MainMenu.xib
+++ b/plugins/cocoaui/XIB/MainMenu.xib
@@ -1,8 +1,8 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.Cocoa.XIB" version="3.0" toolsVersion="24412" targetRuntime="MacOSX.Cocoa" propertyAccessControl="none" useAutolayout="YES">
+<document type="com.apple.InterfaceBuilder3.Cocoa.XIB" version="3.0" toolsVersion="24765" targetRuntime="MacOSX.Cocoa" propertyAccessControl="none" useAutolayout="YES">
     <dependencies>
         <deployment identifier="macosx"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.CocoaPlugin" version="24412"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.CocoaPlugin" version="24765"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
     <objects>
@@ -729,20 +729,11 @@ CA
             <windowStyleMask key="styleMask" titled="YES" closable="YES" miniaturizable="YES" resizable="YES" utility="YES"/>
             <windowPositionMask key="initialPositionMask" leftStrut="YES" rightStrut="YES" topStrut="YES" bottomStrut="YES"/>
             <rect key="contentRect" x="167" y="107" width="364" height="93"/>
-            <rect key="screenRect" x="0.0" y="0.0" width="2048" height="1121"/>
+            <rect key="screenRect" x="0.0" y="0.0" width="1512" height="948"/>
             <view key="contentView" id="KVu-0k-T7v">
                 <rect key="frame" x="0.0" y="0.0" width="364" height="93"/>
                 <autoresizingMask key="autoresizingMask"/>
                 <subviews>
-                    <textField focusRingType="none" verticalHuggingPriority="750" fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="zwG-eG-LI0">
-                        <rect key="frame" x="80" y="54" width="264" height="19"/>
-                        <autoresizingMask key="autoresizingMask" widthSizable="YES" flexibleMinY="YES"/>
-                        <textFieldCell key="cell" scrollable="YES" lineBreakMode="clipping" selectable="YES" editable="YES" sendsActionOnEndEditing="YES" state="on" borderStyle="bezel" placeholderString="Type URL here" drawsBackground="YES" id="Kzo-Mq-Xge">
-                            <font key="font" metaFont="controlContent" size="11"/>
-                            <color key="textColor" name="controlTextColor" catalog="System" colorSpace="catalog"/>
-                            <color key="backgroundColor" name="textBackgroundColor" catalog="System" colorSpace="catalog"/>
-                        </textFieldCell>
-                    </textField>
                     <button verticalHuggingPriority="750" fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="tbg-Xz-zrg">
                         <rect key="frame" x="285" y="13" width="65" height="32"/>
                         <autoresizingMask key="autoresizingMask" flexibleMinX="YES" flexibleMaxY="YES"/>
@@ -780,6 +771,15 @@ Gw
                             <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
                         </textFieldCell>
                     </textField>
+                    <textField focusRingType="none" verticalHuggingPriority="750" fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="zwG-eG-LI0">
+                        <rect key="frame" x="80" y="55" width="264" height="22"/>
+                        <autoresizingMask key="autoresizingMask" widthSizable="YES" flexibleMinY="YES"/>
+                        <textFieldCell key="cell" scrollable="YES" lineBreakMode="clipping" selectable="YES" editable="YES" sendsActionOnEndEditing="YES" state="on" borderStyle="bezel" placeholderString="Type URL here" drawsBackground="YES" id="Kzo-Mq-Xge">
+                            <font key="font" metaFont="system"/>
+                            <color key="textColor" name="controlTextColor" catalog="System" colorSpace="catalog"/>
+                            <color key="backgroundColor" name="textBackgroundColor" catalog="System" colorSpace="catalog"/>
+                        </textFieldCell>
+                    </textField>
                 </subviews>
             </view>
             <point key="canvasLocation" x="-137" y="304.5"/>
@@ -788,7 +788,7 @@ Gw
             <windowStyleMask key="styleMask" titled="YES" miniaturizable="YES"/>
             <windowPositionMask key="initialPositionMask" leftStrut="YES" rightStrut="YES" topStrut="YES" bottomStrut="YES"/>
             <rect key="contentRect" x="163" y="199" width="368" height="68"/>
-            <rect key="screenRect" x="0.0" y="0.0" width="2048" height="1121"/>
+            <rect key="screenRect" x="0.0" y="0.0" width="1512" height="948"/>
             <view key="contentView" id="UsQ-WG-CU4">
                 <rect key="frame" x="0.0" y="0.0" width="368" height="68"/>
                 <autoresizingMask key="autoresizingMask"/>
@@ -824,7 +824,7 @@ Gw
             <windowStyleMask key="styleMask" titled="YES" closable="YES" miniaturizable="YES" resizable="YES" utility="YES"/>
             <windowPositionMask key="initialPositionMask" leftStrut="YES" rightStrut="YES" topStrut="YES" bottomStrut="YES"/>
             <rect key="contentRect" x="167" y="107" width="327" height="120"/>
-            <rect key="screenRect" x="0.0" y="0.0" width="2048" height="1121"/>
+            <rect key="screenRect" x="0.0" y="0.0" width="1512" height="948"/>
             <value key="minSize" type="size" width="327" height="120"/>
             <view key="contentView" id="30A-nz-a9e">
                 <rect key="frame" x="0.0" y="0.0" width="327" height="120"/>

--- a/src/dsp.c
+++ b/src/dsp.c
@@ -337,21 +337,12 @@ streamer_dsp_init (void) {
     char fname[PATH_MAX];
     snprintf (fname, sizeof (fname), "%s/dspconfig", plug_get_config_dir ());
     _current_dsp_chain = streamer_dsp_chain_load (fname);
-    if (!_current_dsp_chain) {
-        // first run, let's add resampler
-        DB_dsp_t *src = (DB_dsp_t *)plug_get_for_id ("SRC");
-        if (src) {
-            ddb_dsp_context_t *inst = src->open ();
-            inst->enabled = 1;
-            src->set_param (inst, 0, "48000"); // samplerate
-            src->set_param (inst, 1, "2"); // quality=SINC_FASTEST
-            src->set_param (inst, 2, "1"); // auto
-            inst->next = _current_dsp_chain;
-            _current_dsp_chain = inst;
-        }
-    }
+    
+    // Do NOT auto-add the first-run SRC/resampler DSP.
+    // Do NOT bind SuperEQ as the special EQ backend, otherwise
+    // streamer_dsp_postinit() will auto-create a disabled SuperEQ node.
 
-    _eqplug = (DB_dsp_t *)plug_get_for_id ("supereq");
+    // _eqplug = (DB_dsp_t *)plug_get_for_id ("supereq");
     streamer_dsp_postinit ();
 
     // load legacy eq settings from pre-0.5


### PR DESCRIPTION
## Summary

This updates several parts of the macOS Cocoa UI to use the standard system-defined font size instead of explicitly using smaller control fonts.

The goal is to improve readability and make DeaDBeeF better match the native macOS interface, while continuing to rely on AppKit-provided fonts rather than hard-coded point sizes.

It also changes DSP initialization so that no DSP plugin, such as SuperEQ, is automatically added to the DSP chain. The DSP list remains empty until the user explicitly adds an effect.

## Changes

* Use the default macOS menu font size for the playlist-item context menu.
* Use the same default system font size for playlist rows.
* Use a bold version of the default menu font for playlist column headings.
* Increase the bottom status-bar font to the default system font size.
* Increase the font size of the URL field in **File → Add Location**.
* Adjust the Add Location dialog layout so that the URL field remains vertically aligned with the “Location” label.
* Rename the playlist deletion action from the standard `delete:` selector to a DeaDBeeF-specific selector.

  * This prevents AppKit from automatically adding a Delete icon.
  * It also avoids reserving an otherwise empty icon column for the other context-menu items.

### DSP defaults
Do not automatically insert DSP plugins into the DSP chain.
In particular, SuperEQ is no longer added by default.
Users can still add DSP plugins manually when needed.

This gives users a clean, unmodified signal path by default and avoids enabling audio processing without an explicit user choice.

## Rationale

Several Cocoa UI elements explicitly used `smallSystemFontSize` or a small control-content font. On current macOS versions, this makes playlist content, menus and supporting UI noticeably smaller than equivalent native controls.

Using AppKit’s system font APIs with their default size:

* follows the user’s macOS appearance and accessibility settings;
* avoids hard-coded font sizes;
* improves consistency between DeaDBeeF and other macOS applications;
* keeps the UI adaptable across macOS versions.

The playlist column headings remain bold to preserve their visual hierarchy.

The DSP change follows the principle that audio processing should be opt-in. A newly initialized DSP chain should not contain effects that the user did not explicitly select.

## Scope

These changes affect only the macOS Cocoa UI. Other platform frontends are unchanged.

## Testing

Tested in a local macOS build:

* playlist rows render correctly at the updated font size;
* selected and unselected rows use consistent sizing;
* playlist column headings remain vertically centred and are not clipped;
* the playlist context menu and its submenus use the standard menu font size;
* context-menu items no longer have an unnecessary empty icon column;
* the Delete action and Delete-key shortcut continue to work;
* the status bar remains correctly positioned;
* the Add Location URL field accepts and displays text correctly;
* the URL text is vertically aligned with the “Location” label;
* the Add Location dialog buttons and sheet layout remain unaffected.
* the DSP list is not automatically populated with SuperEQ or another DSP plugin;
* DSP plugins can still be added manually.
